### PR TITLE
ci: declare workflow-level `contents: read` on 6 lint/build workflows

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -2,6 +2,9 @@ name: Code style
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/compiler-rs.yml
+++ b/.github/workflows/compiler-rs.yml
@@ -6,6 +6,9 @@ on:
 env: 
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
     name: compiler-rs

--- a/.github/workflows/compiler.test.yml
+++ b/.github/workflows/compiler.test.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'compiler/**'
 
+permissions:
+  contents: read
+
 jobs:
   compiler-test:
     name: build

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -2,6 +2,9 @@ name: License headers
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,6 +2,9 @@ name: Linter
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/metamodel-sync.yml
+++ b/.github/workflows/metamodel-sync.yml
@@ -6,6 +6,9 @@ on:
       - 'compiler/**'
       - 'typescript-generator/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 6 workflows in `.github/workflows/` that don't actually need any write scope:

- `code-format.yml`: prettier / clang-format check.
- `compiler-rs.yml`: rust compiler build.
- `compiler.test.yml`: spec compiler test matrix.
- `license.yml`: license header check.
- `linter.yml`: spec linter.
- `metamodel-sync.yml`: copies the compiler metamodel to typescript-generator and checks they're in sync with `git status --porcelain`. No GitHub API beyond the initial checkout.

Left implicit on purpose:

- `backport.yml` is on `pull_request_target` with a backport action that needs write scope.
- `generate.yml` does a `git push`.
- `update-rest-api-json.yml` uses `peter-evans/create-pull-request`.
- `labeler.yml` needs `pull-requests: write`.

Those four are best declared by a maintainer who owns the relevant flows.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.