### PR TITLE
docs: clarify split index shard requirements

### DIFF
--- a/specification/indices/split/IndicesSplitRequest.ts
+++ b/specification/indices/split/IndicesSplitRequest.ts
@@ -57,7 +57,8 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  *
  * * The target index must not exist.
  * * The source index must have fewer primary shards than the target index.
- * * The number of primary shards in the target index must be a multiple of the number of primary shards in the source index and must also be a divisor of the source index's index.number_of_routing_shards.
+ * * The number of primary shards in the target index must be a multiple of the number of primary shards in the source index.
+ * *  The number of primary shards in the target index must be a divisor of the source index's `index.number_of_routing_shards`.
  * * The node handling the split process must have sufficient free disk space to accommodate a second copy of the existing index.
  * @doc_id indices-split-index
  * @rest_spec_name indices.split

--- a/specification/indices/split/IndicesSplitRequest.ts
+++ b/specification/indices/split/IndicesSplitRequest.ts
@@ -57,7 +57,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  *
  * * The target index must not exist.
  * * The source index must have fewer primary shards than the target index.
- * * The number of primary shards in the target index must be a multiple of the number of primary shards in the source index.
+ * * The number of primary shards in the target index must be a multiple of the number of primary shards in the source index and must also be a divisor of the source index's index.number_of_routing_shards.
  * * The node handling the split process must have sufficient free disk space to accommodate a second copy of the existing index.
  * @doc_id indices-split-index
  * @rest_spec_name indices.split

--- a/specification/indices/split/IndicesSplitRequest.ts
+++ b/specification/indices/split/IndicesSplitRequest.ts
@@ -58,7 +58,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * * The target index must not exist.
  * * The source index must have fewer primary shards than the target index.
  * * The number of primary shards in the target index must be a multiple of the number of primary shards in the source index.
- * *  The number of primary shards in the target index must be a divisor of the source index's `index.number_of_routing_shards`.
+ * * The number of primary shards in the target index must be a divisor of the source index's `index.number_of_routing_shards`.
  * * The node handling the split process must have sufficient free disk space to accommodate a second copy of the existing index.
  * @doc_id indices-split-index
  * @rest_spec_name indices.split


### PR DESCRIPTION
The previous description only mentioned that the target shard count must be a multiple of the source shard count. However, the actual validation also requires that index.number_of_routing_shards of the source index is divisible by the target shard count with no remainder. Without this, users can encounter an IllegalStateException even when the multiple condition is satisfied.

Relates to: elastic/elasticsearch#75137

<!-- Hello there! Thank you for opening a pull request. See CONTRIBUTING.md for instructions. -->
