### PR TITLE
[ML] GA the update trained model action

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -23146,7 +23146,7 @@
             }
           }
         },
-        "x-state": "Beta",
+        "x-state": "Generally available",
         "x-metaTags": [
           {
             "content": "Elasticsearch, Machine Learning",

--- a/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
+++ b/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
@@ -27,7 +27,7 @@ import { AdaptiveAllocationsSettings } from '@ml/_types/TrainedModel'
  *
  * @rest_spec_name ml.update_trained_model_deployment
  * @availability stack since=8.6.0 stability=stable
- * @availability serverless stability=beta visibility=public
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml trained model
  * @doc_id update-trained-model-deployment


### PR DESCRIPTION
In discussions about upcoming refinements to the "beta", "technical preview", and "experimental" states, @valeriy42 said it was an oversight that this API is still listed as "beta" in https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-ml-update-trained-model-deployment

This PR updates the availibility to `stable`.

Related:

- https://github.com/elastic/elasticsearch/pull/108868
- https://github.com/elastic/elasticsearch-specification/pull/2564
