### PR TITLE
ci: add AI backport resolver

### DIFF
--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -1,0 +1,14 @@
+name: AI Backport Resolver
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  resolve:
+    uses: elastic/clients-team-automations/.github/workflows/ai-backport-resolver.yml@main
+    with:
+      comment_body: ${{ github.event.comment.body }}
+      comment_user: ${{ github.event.comment.user.login }}
+      pr_number: ${{ github.event.issue.number }}
+    secrets:
+      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}


### PR DESCRIPTION
Adds AI-powered backport conflict resolution using the reusable workflow from `elastic/clients-team-automations`.

When the backport bot posts a failure comment on a merged PR, the workflow:
1. Parses the target branch and commit SHA from the comment
2. Attempts the cherry-pick — if no conflicts, creates the backport PR directly
3. If there are conflicts, calls Claude (via LiteLLM) to resolve them file by file
4. Opens the backport PR and comments on the original PR

**Requires**: `LITELLM_API_KEY` secret in this repo.
**Reusable workflow**: https://github.com/elastic/clients-team-automations/pull/29