### PR TITLE
fix: print Buildkite API error response for easier debugging

### DIFF
--- a/.github/workflows/kibana-type-check-analysis.md
+++ b/.github/workflows/kibana-type-check-analysis.md
@@ -32,9 +32,17 @@ steps:
     run: |
       mkdir -p /tmp/gh-aw/agent
 
-      BUILD=$(curl -sf \
+      BK_RESPONSE=$(curl -s -w "\n__HTTP_STATUS__%{http_code}" \
         "https://api.buildkite.com/v2/organizations/elastic/pipelines/kibana-type-checks/builds?per_page=1&branch=${BRANCH}" \
         -H "Authorization: Bearer $BUILDKITE_API_TOKEN")
+
+      HTTP_STATUS=$(echo "$BK_RESPONSE" | tail -1 | sed 's/__HTTP_STATUS__//')
+      BUILD=$(echo "$BK_RESPONSE" | sed '$d')
+
+      if [ "$HTTP_STATUS" -ge 400 ]; then
+        echo "Buildkite API error (HTTP $HTTP_STATUS): $BUILD"
+        exit 1
+      fi
 
       STATE=$(echo "$BUILD" | jq -r '.[0].state')
       BUILD_NUMBER=$(echo "$BUILD" | jq -r '.[0].number')


### PR DESCRIPTION
The `Fetch Buildkite errors` step was using `curl -sf` which silently exits with code 22 on any 4xx/5xx from the Buildkite API. Since May 28, the job has been failing with exit code 22 and no explanation.

This change switches to `curl -s -w` to capture the HTTP status code separately, and prints the actual API response body + status when the request fails — so we can see whether it's a 401 (bad token), 404 (wrong pipeline slug), etc.

Trigger a `workflow_dispatch` from this branch to see the actual Buildkite error.