### PR TITLE
ci: use ephemeral PAT for backport so failure comments trigger AI resolver

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -20,7 +20,17 @@ jobs:
           && contains(github.event.label.name, 'backport')
         )
       )
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
     steps:
+      - name: Fetch ephemeral GitHub token
+        id: fetch-token
+        uses: elastic/ci-gh-actions/fetch-github-token@8a7604dfdd4e7fe21f969bfe9ff96e17635ea577 # v1.0.0
+        with:
+          vault-instance: "ci-prod"
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.fetch-token.outputs.token }}


### PR DESCRIPTION
## Problem

The `resolve-conflicts.yml` workflow triggers on `issue_comment: created`, but it never fired when the backport bot posted a failure comment on PRs. The reason is a GitHub limitation:

> Comments posted using `GITHUB_TOKEN` do not trigger `issue_comment` workflows.

The backport workflow was using `${{ secrets.GITHUB_TOKEN }}`, so its failure comments were posted with `GITHUB_TOKEN` → blocked from cascading into other workflows.

## Fix

Switch to an ephemeral PAT from Vault (same pattern used in `elasticsearch-js`). Comments posted with a real token DO trigger `issue_comment` workflows, so `resolve-conflicts.yml` will now fire automatically when the backport fails.

## Reference

- AI resolver: `.github/workflows/resolve-conflicts.yml`
- Same pattern already in use: `elastic/elasticsearch-js` backport workflow