### PR TITLE
ci: recompile kibana-type-check lock file after frontmatter change

### DIFF
--- a/.github/workflows/kibana-type-check-analysis.lock.yml
+++ b/.github/workflows/kibana-type-check-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e9b1c6e26e52b1ed352268914b34a3ddec2831afe50d1ac8844d25cb4387daa7","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"80e2e5de462e01c0dbf5d62ac8b52b3638b3297d45d7b340d80becea0e8aff8f","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["BUILDKITE_API_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LITELLM_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"elastic/ci-gh-actions/fetch-github-token","sha":"622f9dc1eecdd4af2e81dfb38028aacb1dae03e8","version":"622f9dc1eecdd4af2e81dfb38028aacb1dae03e8"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -192,23 +192,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_4cc0c6ae0a3ce4a5_EOF'
+          cat << 'GH_AW_PROMPT_0948f262245e71a6_EOF'
           <system>
-          GH_AW_PROMPT_4cc0c6ae0a3ce4a5_EOF
+          GH_AW_PROMPT_0948f262245e71a6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4cc0c6ae0a3ce4a5_EOF'
+          cat << 'GH_AW_PROMPT_0948f262245e71a6_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_4cc0c6ae0a3ce4a5_EOF
+          GH_AW_PROMPT_0948f262245e71a6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_4cc0c6ae0a3ce4a5_EOF'
+          cat << 'GH_AW_PROMPT_0948f262245e71a6_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_4cc0c6ae0a3ce4a5_EOF
+          GH_AW_PROMPT_0948f262245e71a6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_4cc0c6ae0a3ce4a5_EOF'
+          cat << 'GH_AW_PROMPT_0948f262245e71a6_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -237,12 +237,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_4cc0c6ae0a3ce4a5_EOF
+          GH_AW_PROMPT_0948f262245e71a6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4cc0c6ae0a3ce4a5_EOF'
+          cat << 'GH_AW_PROMPT_0948f262245e71a6_EOF'
           </system>
           {{#runtime-import .github/workflows/kibana-type-check-analysis.md}}
-          GH_AW_PROMPT_4cc0c6ae0a3ce4a5_EOF
+          GH_AW_PROMPT_0948f262245e71a6_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -383,7 +383,7 @@ jobs:
           BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
           GH_TOKEN: ${{ steps.fetch-token.outputs.token }}
         name: Fetch Buildkite errors
-        run: "mkdir -p /tmp/gh-aw/agent\n\nBUILD=$(curl -sf \\\n  \"https://api.buildkite.com/v2/organizations/elastic/pipelines/kibana-type-checks/builds?per_page=1&branch=${BRANCH}\" \\\n  -H \"Authorization: Bearer $BUILDKITE_API_TOKEN\")\n\nSTATE=$(echo \"$BUILD\" | jq -r '.[0].state')\nBUILD_NUMBER=$(echo \"$BUILD\" | jq -r '.[0].number')\nBUILD_URL=$(echo \"$BUILD\" | jq -r '.[0].web_url')\n\necho \"$STATE\" > /tmp/gh-aw/agent/build-state.txt\necho \"$BUILD_URL\" > /tmp/gh-aw/agent/build-url.txt\n\nif [ \"$STATE\" != \"failed\" ]; then\n  echo \"Build passed or not finished, nothing to do.\"\n  exit 0\nfi\n\nJOB_ID=$(echo \"$BUILD\" | jq -r '.[0].jobs[] | select(.state == \"failed\") | .id' | head -1)\n\ncurl -sf \\\n  \"https://api.buildkite.com/v2/organizations/elastic/pipelines/kibana-type-checks/builds/$BUILD_NUMBER/jobs/$JOB_ID/log\" \\\n  -H \"Authorization: Bearer $BUILDKITE_API_TOKEN\" \\\n  | jq -r '.content' \\\n  | sed 's/\\x1b\\[[0-9;]*m//g' \\\n  | grep -E \"error TS[0-9]+\" | head -100 > /tmp/gh-aw/agent/tsc-errors.txt || true\n\ncurl -sf \\\n  \"https://api.github.com/repos/elastic/elasticsearch-specification/issues?labels=kibana-spec-check&state=open&per_page=10\" \\\n  -H \"Authorization: Bearer $GH_TOKEN\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  | jq '[.[] | {number, title, html_url}]' \\\n  > /tmp/gh-aw/agent/open-spec-issues.json || echo \"[]\" > /tmp/gh-aw/agent/open-spec-issues.json\n\ncurl -sf \\\n  \"https://api.github.com/repos/elastic/elastic-client-generator-js/issues?labels=kibana-spec-check&state=open&per_page=10\" \\\n  -H \"Authorization: Bearer $GH_TOKEN\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  | jq '[.[] | {number, title, html_url}]' \\\n  > /tmp/gh-aw/agent/open-generator-issues.json || echo \"[]\" > /tmp/gh-aw/agent/open-generator-issues.json\n"
+        run: "mkdir -p /tmp/gh-aw/agent\n\nBK_RESPONSE=$(curl -s -w \"\\n__HTTP_STATUS__%{http_code}\" \\\n  \"https://api.buildkite.com/v2/organizations/elastic/pipelines/kibana-type-checks/builds?per_page=1&branch=${BRANCH}\" \\\n  -H \"Authorization: Bearer $BUILDKITE_API_TOKEN\")\n\nHTTP_STATUS=$(echo \"$BK_RESPONSE\" | tail -1 | sed 's/__HTTP_STATUS__//')\nBUILD=$(echo \"$BK_RESPONSE\" | sed '$d')\n\nif [ \"$HTTP_STATUS\" -ge 400 ]; then\n  echo \"Buildkite API error (HTTP $HTTP_STATUS): $BUILD\"\n  exit 1\nfi\n\nSTATE=$(echo \"$BUILD\" | jq -r '.[0].state')\nBUILD_NUMBER=$(echo \"$BUILD\" | jq -r '.[0].number')\nBUILD_URL=$(echo \"$BUILD\" | jq -r '.[0].web_url')\n\necho \"$STATE\" > /tmp/gh-aw/agent/build-state.txt\necho \"$BUILD_URL\" > /tmp/gh-aw/agent/build-url.txt\n\nif [ \"$STATE\" != \"failed\" ]; then\n  echo \"Build passed or not finished, nothing to do.\"\n  exit 0\nfi\n\nJOB_ID=$(echo \"$BUILD\" | jq -r '.[0].jobs[] | select(.state == \"failed\") | .id' | head -1)\n\ncurl -sf \\\n  \"https://api.buildkite.com/v2/organizations/elastic/pipelines/kibana-type-checks/builds/$BUILD_NUMBER/jobs/$JOB_ID/log\" \\\n  -H \"Authorization: Bearer $BUILDKITE_API_TOKEN\" \\\n  | jq -r '.content' \\\n  | sed 's/\\x1b\\[[0-9;]*m//g' \\\n  | grep -E \"error TS[0-9]+\" | head -100 > /tmp/gh-aw/agent/tsc-errors.txt || true\n\ncurl -sf \\\n  \"https://api.github.com/repos/elastic/elasticsearch-specification/issues?labels=kibana-spec-check&state=open&per_page=10\" \\\n  -H \"Authorization: Bearer $GH_TOKEN\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  | jq '[.[] | {number, title, html_url}]' \\\n  > /tmp/gh-aw/agent/open-spec-issues.json || echo \"[]\" > /tmp/gh-aw/agent/open-spec-issues.json\n\ncurl -sf \\\n  \"https://api.github.com/repos/elastic/elastic-client-generator-js/issues?labels=kibana-spec-check&state=open&per_page=10\" \\\n  -H \"Authorization: Bearer $GH_TOKEN\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  | jq '[.[] | {number, title, html_url}]' \\\n  > /tmp/gh-aw/agent/open-generator-issues.json || echo \"[]\" > /tmp/gh-aw/agent/open-generator-issues.json\n"
 
       - name: Configure Git credentials
         env:
@@ -434,9 +434,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9043bd07e16c6676_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0b5a81d9cac90a4d_EOF'
           {"create_issue":{"labels":["kibana-type-check-analysis"],"max":1,"title_prefix":"[kibana-type-check-analysis]"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_9043bd07e16c6676_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_0b5a81d9cac90a4d_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -643,7 +643,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_df6cc81ee700a2ee_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_328e9d85b59c053f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -683,7 +683,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_df6cc81ee700a2ee_EOF
+          GH_AW_MCP_CONFIG_328e9d85b59c053f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true


### PR DESCRIPTION
## Problem

PR #6325 edited the `Fetch Buildkite errors` step in `kibana-type-check-analysis.md` but did not regenerate the compiled `.lock.yml`. The gh-aw `activation` job validates the lock file against the source frontmatter hash and was failing with:

> ERR_CONFIG: Lock file is outdated! ... Run 'gh aw compile' to regenerate the lock file.

This blocked the workflow before it could even reach the Buildkite step.

## Fix

Ran `gh aw compile` to regenerate `kibana-type-check-analysis.lock.yml`. Verified on this branch via `workflow_dispatch`: the `activation` job now passes.

## Bonus: root cause of the original Buildkite failure found

With the lock fixed, the workflow reached the Buildkite step and the new debug logging (from #6325) revealed the real error:

```
Buildkite API error (HTTP 401): {"message":"Authentication required. Please supply a valid API Access Token"}
```

The `BUILDKITE_API_TOKEN` repo secret (last updated 2026-05-20) has expired/been revoked and needs to be rotated. That's a separate follow-up from this PR.