### PR TITLE
ci: auto-apply kibana-spec-check and auto-pr labels via safe-outputs config

### DIFF
--- a/.github/workflows/kibana-type-check-analysis.lock.yml
+++ b/.github/workflows/kibana-type-check-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"80e2e5de462e01c0dbf5d62ac8b52b3638b3297d45d7b340d80becea0e8aff8f","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5ba7572e421a616619ec3b8991d616cbbf4327ffa5362982e26b60738756183c","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["BUILDKITE_API_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LITELLM_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"elastic/ci-gh-actions/fetch-github-token","sha":"622f9dc1eecdd4af2e81dfb38028aacb1dae03e8","version":"622f9dc1eecdd4af2e81dfb38028aacb1dae03e8"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -192,23 +192,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_0948f262245e71a6_EOF'
+          cat << 'GH_AW_PROMPT_c05992601b74115f_EOF'
           <system>
-          GH_AW_PROMPT_0948f262245e71a6_EOF
+          GH_AW_PROMPT_c05992601b74115f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0948f262245e71a6_EOF'
+          cat << 'GH_AW_PROMPT_c05992601b74115f_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_0948f262245e71a6_EOF
-          cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_0948f262245e71a6_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_0948f262245e71a6_EOF
+          GH_AW_PROMPT_c05992601b74115f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_0948f262245e71a6_EOF'
+          cat << 'GH_AW_PROMPT_c05992601b74115f_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -237,12 +234,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0948f262245e71a6_EOF
+          GH_AW_PROMPT_c05992601b74115f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0948f262245e71a6_EOF'
+          cat << 'GH_AW_PROMPT_c05992601b74115f_EOF'
           </system>
           {{#runtime-import .github/workflows/kibana-type-check-analysis.md}}
-          GH_AW_PROMPT_0948f262245e71a6_EOF
+          GH_AW_PROMPT_c05992601b74115f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -434,15 +431,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0b5a81d9cac90a4d_EOF'
-          {"create_issue":{"labels":["kibana-type-check-analysis"],"max":1,"title_prefix":"[kibana-type-check-analysis]"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0b5a81d9cac90a4d_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_47a8b3fbfba0a59e_EOF'
+          {"create_issue":{"labels":["kibana-spec-check","auto-pr: kibana type check"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_47a8b3fbfba0a59e_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[kibana-type-check-analysis]\". Labels [\"kibana-type-check-analysis\"] will be automatically added."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Labels [\"kibana-spec-check\" \"auto-pr: kibana type check\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -643,7 +640,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_328e9d85b59c053f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_4db48edd84e32ab1_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -683,7 +680,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_328e9d85b59c053f_EOF
+          GH_AW_MCP_CONFIG_4db48edd84e32ab1_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1403,7 +1400,7 @@ jobs:
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_TOKEN: ${{ steps.fetch-token.outputs.token }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"kibana-type-check-analysis\"],\"max\":1,\"title_prefix\":\"[kibana-type-check-analysis]\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"kibana-spec-check\",\"auto-pr: kibana type check\"],\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/kibana-type-check-analysis.lock.yml
+++ b/.github/workflows/kibana-type-check-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5ba7572e421a616619ec3b8991d616cbbf4327ffa5362982e26b60738756183c","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"aa41e22a70872d28246aa71d3f2a694a84cdeae9493b4a0dd82b4a04fed2d1e1","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["BUILDKITE_API_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LITELLM_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"elastic/ci-gh-actions/fetch-github-token","sha":"622f9dc1eecdd4af2e81dfb38028aacb1dae03e8","version":"622f9dc1eecdd4af2e81dfb38028aacb1dae03e8"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -192,20 +192,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_c05992601b74115f_EOF'
+          cat << 'GH_AW_PROMPT_543754b74bcc1347_EOF'
           <system>
-          GH_AW_PROMPT_c05992601b74115f_EOF
+          GH_AW_PROMPT_543754b74bcc1347_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c05992601b74115f_EOF'
+          cat << 'GH_AW_PROMPT_543754b74bcc1347_EOF'
           <safe-output-tools>
-          Tools: create_issue, missing_tool, missing_data, noop
+          Tools: add_comment(max:2), create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_c05992601b74115f_EOF
+          GH_AW_PROMPT_543754b74bcc1347_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_c05992601b74115f_EOF'
+          cat << 'GH_AW_PROMPT_543754b74bcc1347_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -234,12 +234,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c05992601b74115f_EOF
+          GH_AW_PROMPT_543754b74bcc1347_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c05992601b74115f_EOF'
+          cat << 'GH_AW_PROMPT_543754b74bcc1347_EOF'
           </system>
           {{#runtime-import .github/workflows/kibana-type-check-analysis.md}}
-          GH_AW_PROMPT_c05992601b74115f_EOF
+          GH_AW_PROMPT_543754b74bcc1347_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -431,14 +431,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_47a8b3fbfba0a59e_EOF'
-          {"create_issue":{"labels":["kibana-spec-check","auto-pr: kibana type check"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_47a8b3fbfba0a59e_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f28aab3415558bc8_EOF'
+          {"add_comment":{"max":2,"target":"*"},"create_issue":{"labels":["kibana-spec-check","auto-pr: kibana type check"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_f28aab3415558bc8_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
+                "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
                 "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Labels [\"kibana-spec-check\" \"auto-pr: kibana type check\"] will be automatically added."
               },
               "repo_params": {},
@@ -446,6 +447,28 @@ jobs:
             }
           GH_AW_VALIDATION_JSON: |
             {
+              "add_comment": {
+                "defaultMax": 1,
+                "fields": {
+                  "body": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 65000
+                  },
+                  "item_number": {
+                    "issueOrPRNumber": true
+                  },
+                  "reply_to_id": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
+                  }
+                }
+              },
               "create_issue": {
                 "defaultMax": 1,
                 "fields": {
@@ -640,7 +663,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_4db48edd84e32ab1_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_1a5430c03cd2961e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -680,7 +703,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_4db48edd84e32ab1_EOF
+          GH_AW_MCP_CONFIG_1a5430c03cd2961e_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -977,7 +1000,9 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
+      discussions: write
       issues: write
+      pull-requests: write
     concurrency:
       group: "gh-aw-conclusion-kibana-type-check-analysis"
       cancel-in-progress: false
@@ -1333,7 +1358,9 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
+      discussions: write
       issues: write
+      pull-requests: write
     timeout-minutes: 15
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/kibana-type-check-analysis"
@@ -1347,6 +1374,8 @@ jobs:
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
+      comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
+      comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
       created_issue_number: ${{ steps.process_safe_outputs.outputs.created_issue_number }}
@@ -1400,7 +1429,7 @@ jobs:
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_TOKEN: ${{ steps.fetch-token.outputs.token }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"kibana-spec-check\",\"auto-pr: kibana type check\"],\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":2,\"target\":\"*\"},\"create_issue\":{\"labels\":[\"kibana-spec-check\",\"auto-pr: kibana type check\"],\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/kibana-type-check-analysis.md
+++ b/.github/workflows/kibana-type-check-analysis.md
@@ -79,6 +79,10 @@ steps:
         | jq '[.[] | {number, title, html_url}]' \
         > /tmp/gh-aw/agent/open-generator-issues.json || echo "[]" > /tmp/gh-aw/agent/open-generator-issues.json
 safe-outputs:
+  create-issue:
+    labels:
+      - kibana-spec-check
+      - "auto-pr: kibana type check"
   env:
     GITHUB_TOKEN: ${{ steps.fetch-token.outputs.token }}
 network:
@@ -106,16 +110,16 @@ Group errors by classification. For each group, provide a concrete description o
 
 **If there are SPEC errors:**
 - Read `/tmp/gh-aw/agent/open-spec-issues.json`. If there is already an open issue (array is non-empty), add a comment to the existing issue (use the first one's `number`) with the new Buildkite build URL and the updated analysis. Do **not** open a new issue.
-- If there are no open issues, ensure the labels `kibana-spec-check` (color `0075ca`) and `auto-pr: kibana type check` (color `e4e669`) exist in `elastic/elasticsearch-specification` (create them if not), then use `safe-outputs.create-issue` to open one issue with:
-  - Labels: `kibana-spec-check`, `auto-pr: kibana type check`
+- If there are no open issues, use `safe-outputs.create-issue` to open one issue with:
   - Title: `Kibana type check: spec fixes needed`
   - Body: the Buildkite build URL (from `/tmp/gh-aw/agent/build-url.txt`) followed by the full analysis of all SPEC errors
+  - Do not set labels yourself; the `kibana-spec-check` and `auto-pr: kibana type check` labels are applied automatically.
 
 **If there are GENERATOR errors:**
 - Read `/tmp/gh-aw/agent/open-generator-issues.json`. If there is already an open issue, add a comment to it with the new build URL and updated analysis. Do **not** open a new issue.
-- If there are no open issues, ensure the label `kibana-spec-check` (color `0075ca`) exists in `elastic/elastic-client-generator-js` (create it if not), then use `safe-outputs.create-issue` to open one issue with:
-  - Label: `kibana-spec-check`
+- If there are no open issues, use `safe-outputs.create-issue` to open one issue with:
   - Title: `Kibana type check: generator fixes needed`
   - Body: the Buildkite build URL (from `/tmp/gh-aw/agent/build-url.txt`) followed by the full analysis of all GENERATOR errors
+  - Do not set labels yourself; they are applied automatically.
 
 **If there are no SPEC or GENERATOR errors** (only KIBANA or UNKNOWN), call `noop` with a brief explanation.

--- a/.github/workflows/kibana-type-check-analysis.md
+++ b/.github/workflows/kibana-type-check-analysis.md
@@ -83,6 +83,9 @@ safe-outputs:
     labels:
       - kibana-spec-check
       - "auto-pr: kibana type check"
+  add-comment:
+    target: "*"
+    max: 2
   env:
     GITHUB_TOKEN: ${{ steps.fetch-token.outputs.token }}
 network:
@@ -109,14 +112,14 @@ Classify each error as one of:
 Group errors by classification. For each group, provide a concrete description of the root cause and the required fix.
 
 **If there are SPEC errors:**
-- Read `/tmp/gh-aw/agent/open-spec-issues.json`. If there is already an open issue (array is non-empty), add a comment to the existing issue (use the first one's `number`) with the new Buildkite build URL and the updated analysis. Do **not** open a new issue.
+- Read `/tmp/gh-aw/agent/open-spec-issues.json`. If there is already an open issue (array is non-empty), use `safe-outputs.add-comment` with that issue's `number` (the first one) as the target to post the new Buildkite build URL and the updated analysis. Do **not** open a new issue.
 - If there are no open issues, use `safe-outputs.create-issue` to open one issue with:
   - Title: `Kibana type check: spec fixes needed`
   - Body: the Buildkite build URL (from `/tmp/gh-aw/agent/build-url.txt`) followed by the full analysis of all SPEC errors
   - Do not set labels yourself; the `kibana-spec-check` and `auto-pr: kibana type check` labels are applied automatically.
 
 **If there are GENERATOR errors:**
-- Read `/tmp/gh-aw/agent/open-generator-issues.json`. If there is already an open issue, add a comment to it with the new build URL and updated analysis. Do **not** open a new issue.
+- Read `/tmp/gh-aw/agent/open-generator-issues.json`. If there is already an open issue, use `safe-outputs.add-comment` with that issue's `number` as the target to post the new build URL and updated analysis. Do **not** open a new issue.
 - If there are no open issues, use `safe-outputs.create-issue` to open one issue with:
   - Title: `Kibana type check: generator fixes needed`
   - Body: the Buildkite build URL (from `/tmp/gh-aw/agent/build-url.txt`) followed by the full analysis of all GENERATOR errors


### PR DESCRIPTION
## Problem

When the Kibana type check analysis created issue #6330, it got `kibana-spec-check` but **not** `auto-pr: kibana type check` — so the downstream auto-PR workflow (`kibana-spec-fix.yml`) never fired.

Root cause, confirmed from the run logs:

- The agent calls `mcp__github__get_label` for each label before attaching it. The GitHub MCP is in read-only/lockdown mode (no label-create tool).
- `kibana-spec-check` already existed → agent attached it.
- `auto-pr: kibana type check` returned `not found` → agent dropped it and created the issue with only `labels: ["kibana-spec-check"]`.

Note this is different from `kibana-type-check-analysis`, which **did** get created automatically because it lives in the gh-aw **safe-outputs config** — that label is applied by the privileged `safe_outputs` job (using `GITHUB_TOKEN`), which auto-creates missing labels. Agent-supplied labels don't get that treatment.

## Fix

Move both labels into the safe-outputs `create-issue.labels` config so gh-aw auto-creates and applies them on every run, exactly like `kibana-type-check-analysis`:

```yaml
safe-outputs:
  create-issue:
    labels:
      - kibana-spec-check
      - "auto-pr: kibana type check"
```

The prompt is also simplified to stop asking the agent to manage labels (it can't create them anyway). Lock file recompiled with `gh aw compile`.

## Result

Future analysis issues will automatically carry `auto-pr: kibana type check`, which triggers `kibana-spec-fix.yml` → opens a fix PR. (Issue #6330 was manually labeled to unblock the current cycle.)