### PR TITLE
ci: use PAT for backport instead of broken Vault token

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,13 +24,9 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
     steps:
-      - name: Fetch ephemeral GitHub token
-        id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@8a7604dfdd4e7fe21f969bfe9ff96e17635ea577 # v1.0.0
-        with:
-          vault-instance: "ci-prod"
+      # Use a real PAT (not GITHUB_TOKEN) so that the failure comment posted on
+      # conflicting backports triggers the issue_comment-based AI Backport Resolver.
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
-          github_token: ${{ steps.fetch-token.outputs.token }}
+          github_token: ${{ secrets.PAT }}


### PR DESCRIPTION
## Problem

The backport workflow has been **failing on every merged PR** since #6326 switched it to fetch an ephemeral GitHub token from Vault. The Vault role for this workflow was never provisioned, so the `fetch-github-token` step fails immediately:

```
##[error]failed to retrieve vault token. code: ERR_NON_2XX_3XX_RESPONSE,
Response code 400 (Bad Request),
vaultResponse: {"errors":["role \"token-policy-c34099963f9d\" could not be found"]}
```

Because the job errors out at the token step, the backport never runs and the bot never posts its "to backport manually..." comment — which is the comment the **AI Backport Resolver** listens for. So both the normal backport *and* the AI resolver are broken.

Example: #6335 (5 backport labels) produced 4 failed Backport runs and zero bot comments.

## Fix

Drop the Vault step and use the repo's existing `secrets.PAT` (already used by `generate.yml` to push). It's a real account token, so:
- backport works again with no Vault provisioning needed, and
- its failure comments still trigger the `issue_comment`-based AI Backport Resolver (the original goal of #6326).

## Test plan
- [ ] Merge, then re-apply a backport label on #6335 to verify the backport runs and (on conflict) posts the manual-backport comment that triggers the AI resolver.