### PR TITLE
ci: regenerate output/ instead of AI-merging it in backport resolver

### DIFF
--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -10,5 +10,10 @@ jobs:
       comment_body: ${{ github.event.comment.body }}
       comment_user: ${{ github.event.comment.user.login }}
       pr_number: ${{ github.event.issue.number }}
+      # output/ is generated build output (e.g. output/schema/schema.json) - too large
+      # to hand-merge. Skip AI-merge for it and regenerate from the resolved sources.
+      node_version: "24"
+      generated_paths: "output/"
+      regenerate_command: "make setup && make compile && make generate && make transform-to-openapi && make filter-for-serverless"
     secrets:
       LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}


### PR DESCRIPTION
## Summary

Backport conflicts in this repo are dominated by the generated `output/` tree (e.g. `output/schema/schema.json`), which is too large for the AI resolver to merge — it failed on #6335 with `jq: Argument list too long` / empty Claude response.

This passes the new resolver inputs (added in elastic/clients-team-automations#32) so `output/` is **skipped** by Claude and instead **regenerated** from the resolved sources via the standard pipeline:

```
make setup && make compile && make generate && make transform-to-openapi && make filter-for-serverless
```

## Order

Depends on elastic/clients-team-automations#32 (the reusable workflow is referenced `@main`). Merge that first.

## Test plan
- [ ] After both merge, re-apply a backport label on a merged PR touching `output/` and confirm the resolver opens backport PRs with regenerated output.