### PR TITLE
ci: generate and publish schema.json to GH release pages

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -1,0 +1,73 @@
+name: Publish Generated Artifacts
+
+on:
+  push:
+    branches:
+      - main
+      - "7.17"
+      - "8.[0-9]+"
+      - "9.[0-9]+"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: generate-release-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish:
+    name: Publish artifacts to release pages
+    runs-on: ubuntu-latest
+    # Avoid running on forks
+    if: github.repository_owner == 'elastic'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Setup Dependencies
+        run: make setup
+
+      - name: Generate Output
+        run: |
+          make compile
+          make generate
+
+      - name: Resolve branch name
+        id: branch
+        run: echo "name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: generated-${{ steps.branch.outputs.name }}
+          TITLE: "Generated artifacts (${{ steps.branch.outputs.name }})"
+          STEPS_BRANCH_OUTPUTS_NAME: ${{ steps.branch.outputs.name }}
+        run: |
+          # Force-move the tag to current commit
+          git tag -f "$TAG"
+          git push origin "$TAG" --force
+
+          # Create release if it doesn't exist, otherwise ensure it stays as a pre-release
+          if ! gh release view "$TAG" &>/dev/null; then
+            gh release create "$TAG" \
+              --prerelease \
+              --title "$TITLE" \
+              --notes "Auto-generated from branch ${STEPS_BRANCH_OUTPUTS_NAME}. Updated on every merge."
+          fi
+
+          # Upload asset (overwrite if exists)
+          gh release upload "$TAG" output/schema/schema.json --clobber


### PR DESCRIPTION
This is an experiment, to see if it's reasonable to not store `schema.json` in the repository.

The basic idea: instead of using [`generate.yml`](https://github.com/elastic/elasticsearch-specification/blob/main/.github/workflows/generate.yml) to commit generated artifacts to each branch, we pull all such artifacts out of the repo entirely, and publish them on GitHub release pages.

This POC generates `schema.json` on every merge to a matching branch, and upserts a release page/tag (`generated-main`, `generated-9.4`, etc.) with the latest changes. The `generated-*` tags will be mutable, and the downloadable artifacts will always reflect the latest changes to `HEAD` for each branch. 

If the idea has merit, we can expand it to any other files that would otherwise be committed to the repo.