### PR TITLE
[9.4] Correct Jina inference service setting name

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -1925,7 +1925,7 @@ export class JinaAIServiceSettings {
    * Use `float` for the default float embeddings.
    * @server_default float
    */
-  element_type?: JinaAIElementType
+  embedding_type?: JinaAIElementType
   /**
    * For the `embedding` task, whether the model supports multimodal inputs. If true, requests sent to the Jina model
    * will use the multimodal request format (a list of objects). If false, requests sent to the model will use the same


### PR DESCRIPTION
Backports the relevant part of https://github.com/elastic/elasticsearch-specification/pull/6335 to 9.4

The name of the service setting used to specify the embedding element type for the Jina integration is "embedding_type", not "element_type"

(cherry picked from commit 8c628ef4825f8a1573300ebebc66c5273b5c4713)
