### PR TITLE
[9.1] Correct Jina inference service setting name

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -1437,7 +1437,7 @@ export class JinaAIServiceSettings {
    * Use `float` for the default float embeddings.
    * @server_default float
    */
-  element_type?: JinaAIElementType
+  embedding_type?: JinaAIElementType
 }
 
 export class JinaAITaskSettings {


### PR DESCRIPTION
Backports the relevant part of https://github.com/elastic/elasticsearch-specification/pull/6335 to 9.1

The name of the service setting used to specify the embedding element type for the Jina integration is "embedding_type", not "element_type"

(cherry picked from commit 8c628ef4825f8a1573300ebebc66c5273b5c4713)
