### PR TITLE
[ML] Update platforms in MlPutTrainedModelRequest

### DIFF
--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -121,7 +121,7 @@ export interface Request extends RequestBase {
      * only works on one platform, because it is heavily optimized for a particular
      * processor architecture and OS combination, then this field specifies which.
      * The format of the string must match the platform identifiers used by Elasticsearch,
-     * so one of, `linux-x86_64`, `linux-aarch64`, `darwin-x86_64`, `darwin-aarch64`,
+     * so one of, `linux-x86_64`, `linux-aarch64`, `darwin-aarch64`,
      * or `windows-x86_64`. For portable models (those that work independent of processor
      * architecture or OS features), leave this field unset.
      */


### PR DESCRIPTION
`darwin-x86_64` support was dropped in 8.18.0: https://github.com/elastic/elasticsearch/pull/104125