### PR TITLE
ci: file kibana type-check issues per root cause in the correct repo

### DIFF
--- a/.github/workflows/kibana-type-check-analysis.lock.yml
+++ b/.github/workflows/kibana-type-check-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"aa41e22a70872d28246aa71d3f2a694a84cdeae9493b4a0dd82b4a04fed2d1e1","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9d477274dd42bbd9cdf30a9d99475e42bcf04155c825b960814f2e24673021b0","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["BUILDKITE_API_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LITELLM_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"elastic/ci-gh-actions/fetch-github-token","sha":"622f9dc1eecdd4af2e81dfb38028aacb1dae03e8","version":"622f9dc1eecdd4af2e81dfb38028aacb1dae03e8"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -192,20 +192,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_543754b74bcc1347_EOF'
+          cat << 'GH_AW_PROMPT_b8fb6d2d648ccd82_EOF'
           <system>
-          GH_AW_PROMPT_543754b74bcc1347_EOF
+          GH_AW_PROMPT_b8fb6d2d648ccd82_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_543754b74bcc1347_EOF'
+          cat << 'GH_AW_PROMPT_b8fb6d2d648ccd82_EOF'
           <safe-output-tools>
-          Tools: add_comment(max:2), create_issue, missing_tool, missing_data, noop
+          Tools: add_comment(max:15), create_issue(max:15), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_543754b74bcc1347_EOF
+          GH_AW_PROMPT_b8fb6d2d648ccd82_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_543754b74bcc1347_EOF'
+          cat << 'GH_AW_PROMPT_b8fb6d2d648ccd82_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -234,12 +234,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_543754b74bcc1347_EOF
+          GH_AW_PROMPT_b8fb6d2d648ccd82_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_543754b74bcc1347_EOF'
+          cat << 'GH_AW_PROMPT_b8fb6d2d648ccd82_EOF'
           </system>
           {{#runtime-import .github/workflows/kibana-type-check-analysis.md}}
-          GH_AW_PROMPT_543754b74bcc1347_EOF
+          GH_AW_PROMPT_b8fb6d2d648ccd82_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -431,18 +431,27 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f28aab3415558bc8_EOF'
-          {"add_comment":{"max":2,"target":"*"},"create_issue":{"labels":["kibana-spec-check","auto-pr: kibana type check"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f28aab3415558bc8_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_29941f758052a0f7_EOF'
+          {"add_comment":{"allowed_repos":["elastic/elasticsearch-specification","elastic/elastic-client-generator-js"],"max":15,"target":"*","target-repo":"*"},"create_issue":{"allowed_repos":["elastic/elasticsearch-specification","elastic/elastic-client-generator-js"],"labels":["kibana-spec-check","auto-pr: kibana type check"],"max":15,"target-repo":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_29941f758052a0f7_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Labels [\"kibana-spec-check\" \"auto-pr: kibana type check\"] will be automatically added."
+                "add_comment": " CONSTRAINTS: Maximum 15 comment(s) can be added. Target: *. Comments will be added in repository \"*\". Supports reply_to_id for discussion threading.",
+                "create_issue": " CONSTRAINTS: Maximum 15 issue(s) can be created. Labels [\"kibana-spec-check\" \"auto-pr: kibana type check\"] will be automatically added. Issues will be created in repository \"*\"."
               },
-              "repo_params": {},
+              "repo_params": {
+                "add_comment": {
+                  "description": "Target repository for this operation in 'owner/repo' format. Any repository can be targeted.",
+                  "type": "string"
+                },
+                "create_issue": {
+                  "description": "Target repository for this operation in 'owner/repo' format. Any repository can be targeted.",
+                  "type": "string"
+                }
+              },
               "dynamic_tools": []
             }
           GH_AW_VALIDATION_JSON: |
@@ -663,7 +672,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_1a5430c03cd2961e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_5ecc6dd557932311_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -703,7 +712,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_1a5430c03cd2961e_EOF
+          GH_AW_MCP_CONFIG_5ecc6dd557932311_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1429,7 +1438,7 @@ jobs:
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_TOKEN: ${{ steps.fetch-token.outputs.token }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":2,\"target\":\"*\"},\"create_issue\":{\"labels\":[\"kibana-spec-check\",\"auto-pr: kibana type check\"],\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"allowed_repos\":[\"elastic/elasticsearch-specification\",\"elastic/elastic-client-generator-js\"],\"max\":15,\"target\":\"*\",\"target-repo\":\"*\"},\"create_issue\":{\"allowed_repos\":[\"elastic/elasticsearch-specification\",\"elastic/elastic-client-generator-js\"],\"labels\":[\"kibana-spec-check\",\"auto-pr: kibana type check\"],\"max\":15,\"target-repo\":\"*\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/kibana-type-check-analysis.md
+++ b/.github/workflows/kibana-type-check-analysis.md
@@ -80,12 +80,21 @@ steps:
         > /tmp/gh-aw/agent/open-generator-issues.json || echo "[]" > /tmp/gh-aw/agent/open-generator-issues.json
 safe-outputs:
   create-issue:
+    target-repo: "*"
+    allowed-repos:
+      - elastic/elasticsearch-specification
+      - elastic/elastic-client-generator-js
     labels:
       - kibana-spec-check
       - "auto-pr: kibana type check"
+    max: 15
   add-comment:
     target: "*"
-    max: 2
+    target-repo: "*"
+    allowed-repos:
+      - elastic/elasticsearch-specification
+      - elastic/elastic-client-generator-js
+    max: 15
   env:
     GITHUB_TOKEN: ${{ steps.fetch-token.outputs.token }}
 network:
@@ -109,20 +118,17 @@ Classify each error as one of:
 - **KIBANA**: Kibana code needs to be updated to match the improved types (e.g. removing stale `@ts-expect-error` comments)
 - **UNKNOWN**: cannot determine from the error alone
 
-Group errors by classification. For each group, provide a concrete description of the root cause and the required fix.
+Now, **within the GENERATOR and SPEC errors, group them by distinct root cause**. A root cause is a single underlying problem (e.g. "`Duration` is not emitted as a string alias") that may manifest across several files. Errors that share the same fix belong to the same root cause; errors that need different fixes are different root causes.
 
-**If there are SPEC errors:**
-- Read `/tmp/gh-aw/agent/open-spec-issues.json`. If there is already an open issue (array is non-empty), use `safe-outputs.add-comment` with that issue's `number` (the first one) as the target to post the new Buildkite build URL and the updated analysis. Do **not** open a new issue.
-- If there are no open issues, use `safe-outputs.create-issue` to open one issue with:
-  - Title: `Kibana type check: spec fixes needed`
-  - Body: the Buildkite build URL (from `/tmp/gh-aw/agent/build-url.txt`) followed by the full analysis of all SPEC errors
-  - Do not set labels yourself; the `kibana-spec-check` and `auto-pr: kibana type check` labels are applied automatically.
+**Open one issue per distinct root cause — never a single combined issue.** For each GENERATOR or SPEC root cause:
 
-**If there are GENERATOR errors:**
-- Read `/tmp/gh-aw/agent/open-generator-issues.json`. If there is already an open issue, use `safe-outputs.add-comment` with that issue's `number` as the target to post the new build URL and updated analysis. Do **not** open a new issue.
-- If there are no open issues, use `safe-outputs.create-issue` to open one issue with:
-  - Title: `Kibana type check: generator fixes needed`
-  - Body: the Buildkite build URL (from `/tmp/gh-aw/agent/build-url.txt`) followed by the full analysis of all GENERATOR errors
-  - Do not set labels yourself; they are applied automatically.
+1. **Pick the target repository** (you must supply the `repo` argument on every `create-issue`/`add-comment` call):
+   - GENERATOR root cause → `elastic/elastic-client-generator-js`
+   - SPEC root cause → `elastic/elasticsearch-specification`
+2. **Deduplicate.** Read `/tmp/gh-aw/agent/open-generator-issues.json` (for GENERATOR) or `/tmp/gh-aw/agent/open-spec-issues.json` (for SPEC). If an open issue already describes this same root cause (match on the descriptive part of the title), do **not** open a new issue — instead use `safe-outputs.add-comment` (with `repo` set to that issue's repository and `number` set to that issue's number) to post the new Buildkite build URL and the refreshed analysis.
+3. **Otherwise open a new issue** with `safe-outputs.create-issue` (with `repo` set to the target repository):
+   - Title: `Kibana type check: <concise, specific, stable summary of this root cause>` — keep the wording stable across runs so the same problem dedupes. Example: `Kibana type check: Duration not emitted as string alias`.
+   - Body: the Buildkite build URL (from `/tmp/gh-aw/agent/build-url.txt`), then the root-cause description, the affected file locations, and the required fix for **this root cause only**.
+   - Do not set labels yourself; the `kibana-spec-check` and `auto-pr: kibana type check` labels are applied automatically.
 
 **If there are no SPEC or GENERATOR errors** (only KIBANA or UNKNOWN), call `noop` with a brief explanation.


### PR DESCRIPTION
## Problem

Surfaced by elastic/elastic-client-generator-js#204 ("Kibana type check: generator fixes needed"), which has two issues:

1. **Wrong repo.** It contains GENERATOR errors but was opened in `elasticsearch-specification`. gh-aw's `create-issue` files in the current repo unless `target-repo` is set, so GENERATOR errors never reach `elastic-client-generator-js`.
2. **One mega-issue.** `create_issue.max` was 1 and the prompt asked for a single combined issue, so every distinct root cause got crammed into one issue.

## Fix

- **Cross-repo routing:** `create-issue`/`add-comment` now use `target-repo: "*"` + `allowed-repos: [elasticsearch-specification, elastic-client-generator-js]`. The agent supplies `repo` per call — GENERATOR → `elastic-client-generator-js`, SPEC → `elasticsearch-specification`.
- **One issue per root cause:** `max: 15`, and the prompt now groups errors by **distinct root cause** and opens one issue each with a specific, stable title.
- **Dedup preserved:** per root cause, if a matching open issue already exists (in the right repo), it comments with the new build URL instead of opening a duplicate.

The kibana token policy (`token-policy-spec-kibana-type-check`) already grants issue-write to both repos, so no auth change is needed. Lock file recompiled with `gh aw compile`.

## Test plan
- [ ] Trigger the workflow against a failing build and confirm GENERATOR issues open in `elastic-client-generator-js`, SPEC issues in `elasticsearch-specification`, one per root cause.