### PR TITLE
Add Reindex tag to OpenAPI overlay

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -246,6 +246,10 @@ actions:
             url: https://www.elastic.co/docs/reference/elasticsearch/rest-apis/searching-with-query-rules
             description: Learn more about searching with query rules.
       # R
+        - name: reindex
+          x-displayName: Reindex
+          description: >
+            The reindex APIs enable you to copy documents from a source to a destination and to manage reindex tasks.
         - name: rollup
           x-displayName: Rollup
           description: >


### PR DESCRIPTION
The reindex management endpoints (`GET /_reindex`, `GET /_reindex/{task_id}`, `POST /_reindex/{task_id}/_cancel`) introduced a new `reindex` tag that had no matching entry in the shared docs overlay. As a result the tag rendered with its raw lowercase name ("reindex") at the bottom of the API docs page, outside the alphabetically-sorted tag list.

This adds a `reindex` tag entry with `x-displayName: Reindex` and a description, placing it in the correct alphabetical position (between Query rules and Rollup).

Affects both Elasticsearch and Elasticsearch Serverless docs (shared overlay).