### PR TITLE
Add new stats field to count req, fix same in search req

### DIFF
--- a/specification/_global/count/CountRequest.ts
+++ b/specification/_global/count/CountRequest.ts
@@ -144,6 +144,10 @@ export interface Request extends RequestBase {
      */
     routing?: Routing
     /**
+     * Specific `tag` of the request for logging and statistical purposes.
+     */
+    stats?: string[] | string
+    /**
      * The maximum number of documents to collect for each shard.
      * If a query reaches this limit, Elasticsearch terminates the query early.
      * Elasticsearch collects documents before sorting.

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -254,7 +254,7 @@ export interface Request extends RequestBase {
     /**
      * Specific `tag` of the request for logging and statistical purposes.
      */
-    stats?: string[]
+    stats?: string[] | string
     /**
      * A comma-separated list of stored fields to return as part of a hit.
      * If no fields are specified, no stored fields are included in the response.


### PR DESCRIPTION
Introduced in https://github.com/elastic/elasticsearch/pull/140143, code is the same in SearchRequest, so needs to be updated there to support single value. 
