### PR TITLE
Add new esql datasource and dataset crud api

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -241,6 +241,12 @@ esql-list-queries,https://www.elastic.co/docs/api/doc/elasticsearch/operation/op
 esql-get-view,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
 esql-put-view,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
 esql-delete-view,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
+esql-put-data-source,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
+esql-get-data-source,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
+esql-delete-data-source,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
+esql-put-dataset,https://www.elastic.co/docs/api/doc/elasticsearch/operation#TODO,[use-doc-url],,About Elasticsearch API
+esql-get-dataset,https://www.elastic.co/docs/api/doc/elasticsearch/operation#TODO,[use-doc-url],,About Elasticsearch API
+esql-delete-dataset,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
 evaluate-dfanalytics,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-evaluate-data-frame,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-ml-evaluate-data-frame,https://www.elastic.co/guide/en/elasticsearch/reference/8.19/evaluate-dfanalytics.html,About evaluating data frame
 execute-enrich-policy-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-execute-policy,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-enrich-execute-policy,https://www.elastic.co/guide/en/elasticsearch/reference/8.19/execute-enrich-policy-api.html,About running an enrich policy
 execute-watch,https://www.elastic.co/docs/explore-analyze/alerts-cases/watcher/execute-watch,[use-doc-url],https://www.elastic.co/guide/en/elasticsearch/reference/8.19/watcher-api-execute-watch.html,More about executing a watch

--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-import { FieldValue } from '@_types/common'
-import { SingleKeyDictionary } from '@spec_utils/Dictionary'
+import { FieldValue, Name } from '@_types/common'
+import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @codegen_names value, named
@@ -37,4 +38,37 @@ export class ESQLView {
   name: string
   /** The ES|QL query */
   query: string
+}
+
+/**
+ * Represents a data source definition stored in cluster state. A data source holds
+ * connection settings (credentials, endpoints, auth) for an external data provider.
+ */
+export class ESQLDataSource {
+  /** The data source name. */
+  name: Name
+  /** The data source type. */
+  type: string
+  /** A free-text description. */
+  description?: string
+  /** Type-specific settings. */
+  settings?: Dictionary<string, UserDefinedValue>
+}
+
+/**
+ * Represents a dataset definition stored in cluster state. A dataset is a named reference
+ * to external data that participates in the index namespace alongside indices, aliases, and views.
+ * Datasets inherit credentials from their parent data source at query time.
+ */
+export class ESQLDataset {
+  /** The dataset name. */
+  name: Name
+  /** The name of the parent data source. */
+  data_source: Name
+  /** The data source-specific resource path */
+  resource: string
+  /** A free-text description. */
+  description?: string
+  /** Type-specific settings. */
+  settings?: Dictionary<string, UserDefinedValue>
 }

--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -52,7 +52,7 @@ export class ESQLDataSource {
   /** A free-text description. */
   description?: string
   /** Type-specific settings. */
-  settings?: Dictionary<string, UserDefinedValue>
+  settings: Dictionary<string, UserDefinedValue>
 }
 
 /**

--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -58,17 +58,23 @@ export class ESQLDataSource {
 /**
  * Represents a dataset definition stored in cluster state. A dataset is a named reference
  * to external data that participates in the index namespace alongside indices, aliases, and views.
- * Datasets inherit credentials from their parent data source at query time.
+ * Datasets inherit credentials from their referenced data source at query time.
  */
 export class ESQLDataset {
   /** The dataset name. */
   name: Name
-  /** The name of the parent data source. */
+  /** The name of the referenced data source. */
   data_source: Name
-  /** The data source-specific resource path */
+  /**
+   * The URI that identifies the data to read, resolved against the referenced data source, rather than only a path.
+   * For S3, it can include glob patterns, for example a recursive `/**` matching `*.parquet` files under a prefix such as `s3://bucket/logs`.
+   */
   resource: string
   /** A free-text description. */
   description?: string
-  /** Type-specific settings. */
+  /**
+   * Format- and parsing-specific settings that configure how the resource is read.
+   * The accepted keys depend on the format reader; compression can be inferred from the resource URI.
+   */
   settings?: Dictionary<string, UserDefinedValue>
 }

--- a/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
+++ b/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { MediaType, Names } from '@_types/common'
+import { Duration } from '@_types/Time'
+
+/**
+ * Delete one or more ES|QL data sources.
+ *
+ * Fails with `409` if any dataset references one of the named data sources;
+ * delete the dependent datasets first.
+ *
+ * @rest_spec_name esql.delete_data_source
+ * @cluster_privileges manage
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
+ * @doc_id esql-delete-data-source
+ */
+export interface Request extends RequestBase {
+  urls: [
+    {
+      path: '/_query/data_source/{name}'
+      methods: ['DELETE']
+    }
+  ]
+  request_media_type: MediaType.Json
+  response_media_type: MediaType.Json
+  path_parts: {
+    /** A comma-separated list of data source names to delete. */
+    name: Names
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * @server_default 30s
+     */
+    master_timeout?: Duration
+    /**
+     * The time to wait for the request to be completed.
+     * @server_default 30s
+     */
+    timeout?: Duration
+  }
+}

--- a/specification/esql/delete_data_source/DeleteDataSourceResponse.ts
+++ b/specification/esql/delete_data_source/DeleteDataSourceResponse.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  /** @codegen_name result */
+  body: AcknowledgedResponseBase
+}

--- a/specification/esql/delete_dataset/DeleteDatasetRequest.ts
+++ b/specification/esql/delete_dataset/DeleteDatasetRequest.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { MediaType, Names } from '@_types/common'
+import { Duration } from '@_types/Time'
+
+/**
+ * Delete one or more ES|QL datasets.
+ *
+ * @rest_spec_name esql.delete_dataset
+ * @index_privileges manage
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
+ * @doc_id esql-delete-dataset
+ */
+export interface Request extends RequestBase {
+  urls: [
+    {
+      path: '/_query/dataset/{name}'
+      methods: ['DELETE']
+    }
+  ]
+  request_media_type: MediaType.Json
+  response_media_type: MediaType.Json
+  path_parts: {
+    /** A comma-separated list of dataset names to delete. */
+    name: Names
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * @server_default 30s
+     */
+    master_timeout?: Duration
+    /**
+     * The time to wait for the request to be completed.
+     * @server_default 30s
+     */
+    timeout?: Duration
+  }
+}

--- a/specification/esql/delete_dataset/DeleteDatasetResponse.ts
+++ b/specification/esql/delete_dataset/DeleteDatasetResponse.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  /** @codegen_name result */
+  body: AcknowledgedResponseBase
+}

--- a/specification/esql/get_data_source/GetDataSourceRequest.ts
+++ b/specification/esql/get_data_source/GetDataSourceRequest.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { MediaType, Names } from '@_types/common'
+import { Duration } from '@_types/Time'
+
+/**
+ * Get one or more ES|QL data sources.
+ *
+ * Returns the requested data sources. A concrete-name miss returns `404`; a
+ * wildcard pattern or list-all with no match returns `200` with an empty
+ * array.
+ *
+ * @rest_spec_name esql.get_data_source
+ * @cluster_privileges manage
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
+ * @doc_id esql-get-data-source
+ */
+export interface Request extends RequestBase {
+  urls: [
+    {
+      path: '/_query/data_source'
+      methods: ['GET']
+    },
+    {
+      path: '/_query/data_source/{name}'
+      methods: ['GET']
+    }
+  ]
+  request_media_type: MediaType.Json
+  response_media_type: MediaType.Json
+  path_parts: {
+    /** A comma-separated list of data source names or wildcard patterns. Omit to return all data sources. */
+    name?: Names
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * @server_default 30s
+     */
+    master_timeout?: Duration
+  }
+}

--- a/specification/esql/get_data_source/GetDataSourceResponse.ts
+++ b/specification/esql/get_data_source/GetDataSourceResponse.ts
@@ -21,6 +21,10 @@ import { ESQLDataSource } from '@esql/_types/types'
 
 export class Response {
   body: {
+    /**
+     * The matching data sources.
+     * Credential values in each data source's settings are redacted as `::es_redacted::` in the response.
+     */
     data_sources: ESQLDataSource[]
   }
 }

--- a/specification/esql/get_data_source/GetDataSourceResponse.ts
+++ b/specification/esql/get_data_source/GetDataSourceResponse.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ESQLDataSource } from '@esql/_types/types'
+
+export class Response {
+  body: {
+    data_sources: ESQLDataSource[]
+  }
+}

--- a/specification/esql/get_dataset/GetDatasetRequest.ts
+++ b/specification/esql/get_dataset/GetDatasetRequest.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { MediaType, Names } from '@_types/common'
+import { Duration } from '@_types/Time'
+
+/**
+ * Get one or more ES|QL datasets.
+ *
+ * Returns the requested datasets. A concrete-name miss returns `404`; a
+ * wildcard pattern or list-all with no match returns `200` with an empty
+ * array.
+ *
+ * @rest_spec_name esql.get_dataset
+ * @index_privileges manage
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
+ * @doc_id esql-get-dataset
+ */
+export interface Request extends RequestBase {
+  urls: [
+    {
+      path: '/_query/dataset'
+      methods: ['GET']
+    },
+    {
+      path: '/_query/dataset/{name}'
+      methods: ['GET']
+    }
+  ]
+  request_media_type: MediaType.Json
+  response_media_type: MediaType.Json
+  path_parts: {
+    /** A comma-separated list of dataset names or wildcard patterns. Omit to return all datasets. */
+    name?: Names
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * @server_default 30s
+     */
+    master_timeout?: Duration
+  }
+}

--- a/specification/esql/get_dataset/GetDatasetResponse.ts
+++ b/specification/esql/get_dataset/GetDatasetResponse.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ESQLDataset } from '@esql/_types/types'
+
+export class Response {
+  body: {
+    datasets: ESQLDataset[]
+  }
+}

--- a/specification/esql/put_data_source/PutDataSourceRequest.ts
+++ b/specification/esql/put_data_source/PutDataSourceRequest.ts
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { MediaType, Name } from '@_types/common'
+import { Duration } from '@_types/Time'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+
+/**
+ * Create or update an ES|QL data source.
+ *
+ * Creates or replaces a named, type-specific data source configuration that
+ * datasets reference to access external data. Names must be lowercase and
+ * follow index/alias naming rules.
+ *
+ * @rest_spec_name esql.put_data_source
+ * @cluster_privileges manage
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
+ * @doc_id esql-put-data-source
+ */
+export interface Request extends RequestBase {
+  urls: [
+    {
+      path: '/_query/data_source/{name}'
+      methods: ['PUT']
+    }
+  ]
+  request_media_type: MediaType.Json
+  response_media_type: MediaType.Json
+  path_parts: {
+    /** The data source name to create or update. */
+    name: Name
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * @server_default 30s
+     */
+    master_timeout?: Duration
+    /**
+     * The time to wait for the request to be completed.
+     * @server_default 30s
+     */
+    timeout?: Duration
+  }
+  body: {
+    /** The data source type. Must be lowercase and contain no whitespace. */
+    type: string
+    /** A free-text description of the data source. */
+    description?: string
+    /** Type-specific settings. The accepted keys depend on the data source type's validator. */
+    settings?: Dictionary<string, UserDefinedValue>
+  }
+}

--- a/specification/esql/put_data_source/PutDataSourceResponse.ts
+++ b/specification/esql/put_data_source/PutDataSourceResponse.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  /** @codegen_name result */
+  body: AcknowledgedResponseBase
+}

--- a/specification/esql/put_dataset/PutDatasetRequest.ts
+++ b/specification/esql/put_dataset/PutDatasetRequest.ts
@@ -26,9 +26,9 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 /**
  * Create or replace an ES|QL dataset.
  *
- * Creates or replaces a dataset that references a parent data source. Dataset
+ * Creates or replaces a dataset that references a data source. Dataset
  * names participate in the index namespace and must follow index/alias naming
- * rules. Returns `404` if the parent data source does not exist.
+ * rules. Returns `404` if the referenced data source does not exist.
  *
  * @rest_spec_name esql.put_dataset
  * @index_privileges manage
@@ -62,13 +62,19 @@ export interface Request extends RequestBase {
     timeout?: Duration
   }
   body: {
-    /** The name of the parent data source. The data source must already exist. */
+    /** The name of the referenced data source. The data source must already exist. */
     data_source: Name
-    /** The data source-specific resource path. */
+    /**
+     * The URI that identifies the data to read, resolved against the referenced data source, rather than only a path.
+     * For S3, it can include glob patterns, for example a recursive `/**` matching `*.parquet` files under a prefix such as `s3://bucket/logs`.
+     */
     resource: string
     /** A free-text description of the dataset. */
     description?: string
-    /** Type-specific settings. */
+    /**
+     * Format and parsing-specific settings that configure how the resource is read.
+     * The accepted keys depend on the format reader; compression can be inferred from the resource URI.
+     */
     settings?: Dictionary<string, UserDefinedValue>
   }
 }

--- a/specification/esql/put_dataset/PutDatasetRequest.ts
+++ b/specification/esql/put_dataset/PutDatasetRequest.ts
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { MediaType, Name } from '@_types/common'
+import { Duration } from '@_types/Time'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+
+/**
+ * Create or replace an ES|QL dataset.
+ *
+ * Creates or replaces a dataset that references a parent data source. Dataset
+ * names participate in the index namespace and must follow index/alias naming
+ * rules. Returns `404` if the parent data source does not exist.
+ *
+ * @rest_spec_name esql.put_dataset
+ * @index_privileges manage
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
+ * @doc_id esql-put-dataset
+ */
+export interface Request extends RequestBase {
+  urls: [
+    {
+      path: '/_query/dataset/{name}'
+      methods: ['PUT']
+    }
+  ]
+  request_media_type: MediaType.Json
+  response_media_type: MediaType.Json
+  path_parts: {
+    /** The dataset name to create or update. */
+    name: Name
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * @server_default 30s
+     */
+    master_timeout?: Duration
+    /**
+     * The time to wait for the request to be completed.
+     * @server_default 30s
+     */
+    timeout?: Duration
+  }
+  body: {
+    /** The name of the parent data source. The data source must already exist. */
+    data_source: Name
+    /** The data source-specific resource path. */
+    resource: string
+    /** A free-text description of the dataset. */
+    description?: string
+    /** Type-specific settings. */
+    settings?: Dictionary<string, UserDefinedValue>
+  }
+}

--- a/specification/esql/put_dataset/PutDatasetResponse.ts
+++ b/specification/esql/put_dataset/PutDatasetResponse.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  /** @codegen_name result */
+  body: AcknowledgedResponseBase
+}


### PR DESCRIPTION
Added in https://github.com/elastic/elasticsearch/pull/146600.

This is pretty straightforward, I just have a couple of doubts:

- Is there a requested format for the `resource` field? some examples we could add to the docs?
- `type` is a string (even in the server code) but it could be a non exhaustive enums if we had a list of the values that are currently accepted (similar to how we handle [Repository](https://github.com/elastic/elasticsearch-specification/blob/0af659ccc0171743ba0fe97cba210a94b3b3538f/specification/snapshot/_types/SnapshotRepository.ts#L29))
