### PR TITLE
fix(backport): regenerate output files after conflict resolution

### DIFF
--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -10,5 +10,8 @@ jobs:
       comment_body: ${{ github.event.comment.body }}
       comment_user: ${{ github.event.comment.user.login }}
       pr_number: ${{ github.event.issue.number }}
+      node_version: "24"
+      generated_paths: "output/"
+      regenerate_command: "make setup && make compile && make generate && make transform-to-openapi"
     secrets:
       LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}


### PR DESCRIPTION
## Problem

The AI Backport Resolver was failing with:

```
ERROR: files still unmerged after resolution/regeneration:
output/openapi/elasticsearch-openapi.json
output/schema/schema.json
output/typescript/types.ts
```

Claude resolved all source-level conflicts (11 files resolved, 3 failed), but the 3 failures were all generated output files. Since `regenerate_command` wasn't set, the resolver couldn't rebuild them and correctly refused to commit conflict markers.

Example failing run: https://github.com/elastic/elasticsearch-specification/actions/runs/27656646868/job/81792160507

## Fix

Pass the three inputs added in `elastic/clients-team-automations#32` so the resolver:

1. Skips sending `output/` files to Claude (they're in `generated_paths`)
2. Runs `make setup && make compile && make generate && make transform-to-openapi` to rebuild them from the resolved sources
3. Stages the rebuilt outputs and continues the cherry-pick

## Testing

Re-trigger the resolver on a PR that has output/ conflicts — the regenerate step should now succeed instead of bailing out.