### PR TITLE
chore: update fetch-github-token to v1.5.3 in kibana-type-check-analysis workflow

### DIFF
--- a/.github/workflows/kibana-type-check-analysis.md
+++ b/.github/workflows/kibana-type-check-analysis.md
@@ -21,7 +21,7 @@ engine:
 steps:
   - name: Fetch ephemeral GitHub token
     id: fetch-token
-    uses: elastic/ci-gh-actions/fetch-github-token@622f9dc1eecdd4af2e81dfb38028aacb1dae03e8 # v1.5.0
+    uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.3
     with:
       vault-instance: "ci-prod"
   - name: Fetch Buildkite errors


### PR DESCRIPTION
Same change as in https://github.com/elastic/elasticsearch-specification/pull/6376

## Summary

Upgrades `elastic/ci-gh-actions/fetch-github-token` to `v1.5.3` across `kibana-type-check-analysis.md`

## Reason

Version `v1.5.3` includes a fix for a security concern related to new GitHub token formats. Previous pinned versions (including commit SHAs and older semver tags) do not handle the updated token format correctly.

See: https://github.com/elastic/ci-gh-actions/releases/tag/v1.5.3

## Changes

Bumps `fetch-github-token` references from older versions/SHAs to `v1.5.3`.