### PR TITLE
max_chars and min_chars not mandatory

### DIFF
--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -327,8 +327,8 @@ export enum IndexOptions {
 }
 
 export class TextIndexPrefixes {
-  max_chars: integer
-  min_chars: integer
+  max_chars?: integer
+  min_chars?: integer
 }
 
 export class TextProperty extends CorePropertyBase {


### PR DESCRIPTION
TextIndexPrefixes has 2 fields (max_chars and min_chars) which should not be mandatory: the server sets default values ([server code](https://github.com/elastic/elasticsearch/blob/ff5d660dc115639a2dca278ab0e151401c7fe50b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java#L198), [documentation](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/index-prefixes)).
