### PR TITLE
[DOCS] Uncomment method_request in data stream setting example

### DIFF
--- a/specification/indices/put_data_stream_settings/examples/request/IndicesPutDataStreamSettingsRequestExample1.yaml
+++ b/specification/indices/put_data_stream_settings/examples/request/IndicesPutDataStreamSettingsRequestExample1.yaml
@@ -1,5 +1,5 @@
 summary: Change a data stream setting
-# method_request: PUT /_data_stream/my-data-stream/_settings
+method_request: PUT /_data_stream/my-data-stream/_settings
 description: >
   This is a request to change two settings on a data stream.
 # type: request


### PR DESCRIPTION
This PR fixes the following error that was returned by `make transform-to-openapi-for-docs`:

```
specification/indices/put_data_stream_settings/examples/request/IndicesPutDataStreamSettingsRequestExample1.yaml: Error: Invalid request method
669 examples processed, 1 errors.
```