### PR TITLE
adds specifications for project_routing for _terms_enum

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2108,6 +2108,7 @@ export interface TermsEnumRequest extends RequestBase {
     index_filter?: QueryDslQueryContainer
     string?: string
     search_after?: string
+    project_routing?: ProjectRouting
   }
 }
 

--- a/specification/_global/terms_enum/TermsEnumRequest.ts
+++ b/specification/_global/terms_enum/TermsEnumRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Field, Indices, MediaType } from '@_types/common'
+import { Field, Indices, MediaType, ProjectRouting } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Duration } from '@_types/Time'
@@ -91,5 +91,17 @@ export interface Request extends RequestBase {
      * It allows for a form of pagination if the last result from one request is passed as the `search_after` parameter for a subsequent request.
      */
     search_after?: string
+    /**
+     * Specifies a subset of projects to target for the search using project
+     * metadata tags in a subset of Lucene query syntax.
+     * Allowed Lucene queries: the _alias tag and a single value (possibly wildcarded).
+     * Examples:
+     *  _alias:my-project
+     *  _alias:_origin
+     *  _alias:*pr*
+     * Supported in serverless only.
+     * @availability serverless stability=stable visibility=feature_flag feature_flag=serverless.cross_project.enabled
+     */
+    project_routing?: ProjectRouting
   }
 }


### PR DESCRIPTION
adds specifications for project_routing in the body of _terms_enum requests

See https://github.com/elastic/elasticsearch/pull/152302