### PR TITLE
Add DataSourcePrivileges to RBAC Spec

### DIFF
--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -417,6 +417,11 @@ export enum IndexPrivilege {
 
 export class GlobalPrivilege {
   application: ApplicationGlobalUserPrivileges
+  /**
+   * A list of data source privilege entries, used to grant access to ES|QL data sources.
+   * @availability stack since=9.5.0
+   */
+  data_source?: DataSourcePrivileges[]
 }
 
 export class ApplicationGlobalUserPrivileges {
@@ -425,6 +430,41 @@ export class ApplicationGlobalUserPrivileges {
 
 export class ManageUserPrivileges {
   applications: string[]
+}
+
+export class DataSourcePrivileges {
+  /**
+   * A list of data source names or wildcard patterns to which the permissions in this entry apply.
+   */
+  names: string[]
+  /**
+   * The data source privileges that owners of the role have for the specified data sources.
+   */
+  privileges: DataSourcePrivilege[]
+}
+
+/** @non_exhaustive */
+export enum DataSourcePrivilege {
+  /**
+   * Grants privilege to create a data source with a matching name.
+   */
+  create,
+  /**
+   * Grants privilege to delete a data source with a matching name.
+   */
+  delete,
+  /**
+   * Grants privilege to read a data source's metadata.
+   */
+  read_metadata,
+  /**
+   * Grants privilege to attach a dataset to a data source with a matching name.
+   */
+  read,
+  /**
+   * Grants all data source privileges, including `create`, `delete`, `read`, and `read_metadata`.
+   */
+  manage
 }
 
 export class ReplicationAccess {

--- a/specification/security/_types/RoleDescriptor.ts
+++ b/specification/security/_types/RoleDescriptor.ts
@@ -52,7 +52,7 @@ export class RoleDescriptor {
    */
   remote_cluster?: RemoteClusterPrivileges[]
   /**
-   * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.
+   * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware.
    * @availability stack
    */
   global?: GlobalPrivilege[] | GlobalPrivilege


### PR DESCRIPTION
Adds the type spec for the new data_source global cluster privilege introduced in elastic/elasticsearch#147782, which lets roles grant ES|QL data source access via role.global.data_source (targeted for 9.5.0).

### Changes
- `Privileges.ts`: Add `GlobalPrivilege.data_source?: DataSourcePrivileges[]`, a new `DataSourcePrivileges` class (names, privileges), and a `DataSourcePrivilege` enum (`create`, `delete`, `read_metadata`, `read`, `manage`) matching the privilege names accepted by `ConfigurableClusterPrivileges.DatasourcePrivileges` in Elasticsearch.
- `RoleDescriptor.ts`: Drop the stale "limited to the management of application privileges" note on global, now that it covers more than application privileges.