### PR TITLE
Add spec for encryption reset API

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -216,6 +216,7 @@ docvalue-fields,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/re
 dot-expand-processor,https://www.elastic.co/docs/reference/enrich-processor/dot-expand-processor,[use-doc-url],,About the dot expander processor
 drop-processor,https://www.elastic.co/docs/reference/enrich-processor/drop-processor,[use-doc-url],,More about the drop processor
 eland-import,https://www.elastic.co/docs/explore-analyze/machine-learning/nlp/ml-nlp-import-model#ml-nlp-import-script,[use-doc-url],,About importing a trained model
+encryption-reset,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
 enrich-processor,https://www.elastic.co/docs/reference/enrich-processor/enrich-processor,[use-doc-url],,More about the enrich processor
 enrich-stats-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-stats,,https://www.elastic.co/guide/en/elasticsearch/reference/8.19/enrich-stats-api.html,Learn more about enrich stats
 eql-async-search-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-get,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-eql-get,https://www.elastic.co/guide/en/elasticsearch/reference/8.19/get-async-eql-search-api.html,About async EQL search results

--- a/specification/encryption/reset/EncryptionResetRequest.ts
+++ b/specification/encryption/reset/EncryptionResetRequest.ts
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Duration } from '@_types/Time'
+import { MediaType } from '@_types/common'
+
+/**
+ * Reset the project encryption key.
+ *
+ * Destroy the current project encryption key (PEK) and generate a new one.
+ * This is the recovery path for when the on-disk encrypted PEK becomes permanently
+ * inaccessible, for example because the key encryption material protecting it was lost.
+ *
+ * All data that was encrypted under the destroyed key becomes permanently unrecoverable.
+ * Each feature that stores encrypted data decides how to handle its own data during the
+ * reset: some features drop the encrypted values entirely, while others preserve the rest
+ * of the affected data and only clear the values that can no longer be decrypted.
+ *
+ * Because this operation causes permanent data loss, it requires the `accept_data_loss`
+ * query parameter to be set to `true`.
+ * @rest_spec_name encryption.reset
+ * @availability stack since=9.5.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
+ * @doc_id encryption-reset
+ */
+export interface Request extends RequestBase {
+  urls: [
+    {
+      path: '/_encryption/_reset'
+      methods: ['POST']
+    }
+  ]
+  response_media_type: MediaType.Json
+  query_parameters: {
+    /**
+     * Acknowledge that resetting the project encryption key permanently destroys all data
+     * that was encrypted under the current key.
+     * The request fails if this is not set to `true`.
+     */
+    accept_data_loss: boolean
+    /**
+     * The period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    master_timeout?: Duration
+    /**
+     * The period to wait for a response.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    timeout?: Duration
+  }
+}

--- a/specification/encryption/reset/EncryptionResetResponse.ts
+++ b/specification/encryption/reset/EncryptionResetResponse.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  /** @codegen_name result */
+  body: AcknowledgedResponseBase
+}

--- a/specification/encryption/reset/examples/200_response/EncryptionResetResponseExample1.yaml
+++ b/specification/encryption/reset/examples/200_response/EncryptionResetResponseExample1.yaml
@@ -1,0 +1,6 @@
+summary: Reset the project encryption key
+description: >
+  A successful response from `POST /_encryption/_reset?accept_data_loss=true`.
+# type: response
+value:
+  acknowledged: true

--- a/specification/encryption/reset/examples/request/EncryptionResetRequestExample1.yaml
+++ b/specification/encryption/reset/examples/request/EncryptionResetRequestExample1.yaml
@@ -1,0 +1,7 @@
+summary: Reset the project encryption key
+method_request: POST /_encryption/_reset?accept_data_loss=true
+# type: request
+description: >
+  Run `POST /_encryption/_reset?accept_data_loss=true` to destroy the current project
+  encryption key and generate a new one. All data encrypted under the destroyed key is
+  permanently unrecoverable.


### PR DESCRIPTION
Adds the specification for `POST /_encryption/_reset`, which was previously entirely undocumented in this repo.

The endpoint destroys the current project encryption key (PEK) and generates a new one — the recovery path for when the on-disk encrypted PEK becomes permanently inaccessible (disk failure, lost HSM access, etc.). It requires the `accept_data_loss` query parameter to be explicitly set to `true`, since all data encrypted under the destroyed key becomes permanently unrecoverable.

This spec is prompted by elastic/elasticsearch#152181, which changes how the ES|QL datasource `EncryptedDataHandler` behaves during this reset (preserving non-secret datasource config instead of dropping the whole entry), but the REST endpoint itself already existed and had no spec.

### Modeling notes

- New `encryption` namespace/`encryption.reset` rest_spec_name, since `/_encryption` didn't fit any existing namespace.
- `accept_data_loss` is modeled as a required (non-optional) boolean query parameter, matching `EncryptionResetRequest#validate()` in Elasticsearch, which rejects the request unless it's `true`.
- Marked `@availability stack since=9.5.0 stability=experimental` and `serverless ... visibility=private`: the action is restricted to operator users only (see `DefaultOperatorOnlyRegistry` in Elasticsearch), so it's modeled the same way as other operator-scoped endpoints (e.g. `cat.*`, `xpack.usage`) — usable on self-managed stack, hidden from serverless docs/clients.
- Added a placeholder `encryption-reset` entry to `_doc_ids/table.csv` (`#TODO` URL) since there's no published docs page yet, following the same pattern used for other recently-added APIs (e.g. `streams-logs-disable`).