### PR TITLE
Add index.unassigned.node_left.delayed_timeout setting to IndexSettings

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12516,6 +12516,7 @@ export interface IndicesIndexSettingsKeys {
   max_terms_count?: integer
   max_regex_length?: integer
   routing?: IndicesIndexRouting
+  unassigned?: IndicesIndexSettingsUnassigned
   gc_deletes?: Duration
   default_pipeline?: PipelineName
   final_pipeline?: PipelineName
@@ -12570,6 +12571,14 @@ export interface IndicesIndexSettingsLifecycleStep {
 export interface IndicesIndexSettingsTimeSeries {
   end_time?: DateTime
   start_time?: DateTime
+}
+
+export interface IndicesIndexSettingsUnassigned {
+  node_left?: IndicesIndexSettingsUnassignedNodeLeft
+}
+
+export interface IndicesIndexSettingsUnassignedNodeLeft {
+  delayed_timeout?: Duration
 }
 
 export interface IndicesIndexState {

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -138,6 +138,7 @@ export class IndexSettings
   /** @server_default 1000 */
   max_regex_length?: integer
   routing?: IndexRouting
+  unassigned?: IndexSettingsUnassigned
   /** @server_default 60s */
   gc_deletes?: Duration
   /** @server_default _none */
@@ -348,6 +349,19 @@ export class IndexSettingsLifecycleStep {
    * See Shard allocation for shrink.
    */
   wait_time_threshold?: Duration
+}
+
+export class IndexSettingsUnassigned {
+  node_left?: IndexSettingsUnassignedNodeLeft
+}
+
+export class IndexSettingsUnassignedNodeLeft {
+  /**
+   * The amount of time to wait for a node that has left before assuming its
+   * shards are permanently missing and starting to allocate replacement replicas.
+   * @server_default 1m
+   */
+  delayed_timeout?: Duration
 }
 
 export class IndexSettingsAnalysis {


### PR DESCRIPTION
Closes elastic/elasticsearch-java#278

Adds `unassigned.node_left.delayed_timeout` to `IndexSettings`, following 
the same nesting pattern as `lifecycle`/`IndexSettingsLifecycle`.

It wasn't modeled in the spec before, so it fell through as an untyped 
setting in the generated clients (see elastic/elasticsearch-java#278 for 
the original report).

Tested against a live 8.15.0 cluster: PUT with the nested form 
(`{"unassigned": {"node_left": {"delayed_timeout": "5m"}}}`) gets accepted 
and persisted correctly as `index.unassigned.node_left.delayed_timeout`.