### PR TITLE
Fix watcher api

### DIFF
--- a/specification/_types/Transform.ts
+++ b/specification/_types/Transform.ts
@@ -34,6 +34,9 @@ export class TransformContainer {
   search?: SearchTransform
 }
 
+/**
+ * @shortcut_property source
+ */
 export class ScriptTransform {
   /**
    * @server_default painless
@@ -46,5 +49,5 @@ export class ScriptTransform {
 
 export class SearchTransform {
   request: SearchInputRequestDefinition
-  timeout: Duration
+  timeout?: Duration
 }

--- a/specification/watcher/_types/Action.ts
+++ b/specification/watcher/_types/Action.ts
@@ -93,11 +93,18 @@ export class SimulatedActions {
   use_all: boolean
 }
 
+/**
+ * The status of an executed action.
+ * It maps to the server-side `Action.Result.Status` enum.
+ */
 export enum ActionStatusOptions {
   success,
   failure,
-  simulated,
-  throttled
+  partial_failure,
+  acknowledged,
+  throttled,
+  condition_failed,
+  simulated
 }
 
 export enum AcknowledgementOptions {

--- a/specification/watcher/_types/Actions.ts
+++ b/specification/watcher/_types/Actions.ts
@@ -289,7 +289,7 @@ export class IndexResultRequestSummary {
   doc_id?: Id
   index: IndexName
   refresh?: Refresh
-  source?: UserDefinedValue
+  source: UserDefinedValue
 }
 
 export class IndexResultSummary {

--- a/specification/watcher/_types/Actions.ts
+++ b/specification/watcher/_types/Actions.ts
@@ -264,6 +264,13 @@ export class IndexAction {
   execution_time_field?: Field
 }
 
+// This is IndexAction.Result and IndexAction.Simulated in the server
+/**
+ * The result of an index action.
+ * It is a container that holds either the `response` of an executed index
+ * operation, or the `request` that would have run when the action is simulated.
+ * @variants container
+ */
 export class IndexResult {
   /**
    * The outcome of the index operation.
@@ -281,6 +288,7 @@ export class IndexResult {
 export class IndexResultRequestSummary {
   doc_id?: Id
   index: IndexName
+  refresh?: Refresh
   source?: UserDefinedValue
 }
 

--- a/specification/watcher/_types/Actions.ts
+++ b/specification/watcher/_types/Actions.ts
@@ -274,8 +274,9 @@ export class IndexAction {
 export class IndexResult {
   /**
    * The outcome of the index operation.
-   * A single summary is returned when a single document is indexed,
-   * or an array when several documents are indexed at once.
+   * A single summary is returned when a single document is indexed, or an array
+   * when several documents are indexed at once. When a bulk operation ends in
+   * `failure` or `partial_failure`, the array includes failed items.
    */
   response?: IndexResultSummary | IndexResultSummary[]
   /**
@@ -292,12 +293,26 @@ export class IndexResultRequestSummary {
   source: UserDefinedValue
 }
 
+/**
+ * A single item of an index action result.
+ * Successful items and failed items expose different fields; only `id` and `index`
+ * are present in both. Failed items appear when a bulk index action ends in
+ * `failure` or `partial_failure`.
+ */
 export class IndexResultSummary {
-  created: boolean
   id: Id
   index: IndexName
-  result: Result
-  version: VersionNumber
+  created?: boolean
+  result?: Result
+  version?: VersionNumber
+  /**
+   * Only present for failed items
+   */
+  failed?: boolean
+  /**
+   * Only present for failed items
+   */
+  message?: string
 }
 
 // Logging ------------------------------ //

--- a/specification/watcher/_types/Actions.ts
+++ b/specification/watcher/_types/Actions.ts
@@ -254,7 +254,7 @@ export class EmailAction extends Email {}
 // Index -------------------------------- //
 
 export class IndexAction {
-  index: IndexName
+  index?: IndexName
   doc_id?: Id
   refresh?: Refresh
   /** @server_default index */
@@ -265,7 +265,23 @@ export class IndexAction {
 }
 
 export class IndexResult {
-  response: IndexResultSummary
+  /**
+   * The outcome of the index operation.
+   * A single summary is returned when a single document is indexed,
+   * or an array when several documents are indexed at once.
+   */
+  response?: IndexResultSummary | IndexResultSummary[]
+  /**
+   * The request that would have been executed.
+   * It is only present when the action is simulated.
+   */
+  request?: IndexResultRequestSummary
+}
+
+export class IndexResultRequestSummary {
+  doc_id?: Id
+  index: IndexName
+  source?: UserDefinedValue
 }
 
 export class IndexResultSummary {

--- a/specification/watcher/_types/Execution.ts
+++ b/specification/watcher/_types/Execution.ts
@@ -156,6 +156,11 @@ export class ExecutionResultSearchInput {
 
 export class ExecutionResultHttpInput {
   request: HttpInputRequestResult
+  /**
+   * The HTTP status code returned by the request.
+   * It is only present when the request was executed.
+   */
+  status_code?: integer
 }
 
 export class ExecutionThreadPool {

--- a/specification/watcher/_types/Execution.ts
+++ b/specification/watcher/_types/Execution.ts
@@ -91,25 +91,9 @@ export class ExecutionResultConditionResolved {
   resolved_values?: Dictionary<string, UserDefinedValue>
 }
 
-export class ExecutionResultAction {
-  email?: EmailResult
-  id: Id
-  index?: IndexResult
-  logging?: LoggingResult
-  pagerduty?: PagerDutyResult
-  reason?: string
-  slack?: SlackResult
-  status: ActionStatusOptions
-  type: ActionType
-  webhook?: WebhookResult
-  error?: ErrorCause
-  condition?: ExecutionResultCondition
-  transform?: ExecutionResultTransform
-  foreach?: ExecutionResultForeachAction[]
-  max_iterations?: integer
-  number_of_actions_executed?: integer
-}
-
+/**
+ * The result of a single action execution.
+ */
 export class ExecutionResultForeachAction {
   email?: EmailResult
   index?: IndexResult
@@ -119,8 +103,17 @@ export class ExecutionResultForeachAction {
   webhook?: WebhookResult
   error?: ErrorCause
   reason?: string
-  status?: ActionStatusOptions
-  type?: ActionType
+}
+
+export class ExecutionResultAction extends ExecutionResultForeachAction {
+  id: Id
+  type: ActionType
+  status: ActionStatusOptions
+  condition?: ExecutionResultCondition
+  transform?: ExecutionResultTransform
+  foreach?: ExecutionResultForeachAction[]
+  max_iterations?: integer
+  number_of_actions_executed?: integer
 }
 
 export class ExecutionResultTransform {

--- a/specification/watcher/_types/Execution.ts
+++ b/specification/watcher/_types/Execution.ts
@@ -19,13 +19,14 @@
 
 import { Id } from '@_types/common'
 import { ErrorCause } from '@_types/Errors'
-import { long } from '@_types/Numeric'
+import { integer, long } from '@_types/Numeric'
 import { DateTime, DurationValue, UnitMillis } from '@_types/Time'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { ActionStatusOptions, ActionType } from './Action'
 import {
   EmailResult,
+  HttpInputRequestResult,
   IndexResult,
   LoggingResult,
   PagerDutyResult,
@@ -33,7 +34,7 @@ import {
   WebhookResult
 } from './Actions'
 import { ConditionType } from './Conditions'
-import { InputType } from './Input'
+import { InputType, SearchInputRequestDefinition } from './Input'
 
 export enum ExecutionStatus {
   awaits_execution,
@@ -57,18 +58,37 @@ export enum ExecutionPhase {
   finished
 }
 
+/**
+ * The status of an input, condition, or transform phase.
+ * These phases can only succeed or fail, so unlike an action they never report
+ * statuses such as `throttled`, `condition_failed`, or `simulated`.
+ * It maps to the server-side `Input.Result.Status`, `Condition.Result.Status`,
+ * and `Transform.Result.Status` enums.
+ */
+export enum ExecutionResultStatus {
+  success,
+  failure
+}
+
 export class ExecutionResult {
   actions: ExecutionResultAction[]
-  condition: ExecutionResultCondition
+  condition?: ExecutionResultCondition
   execution_duration: DurationValue<UnitMillis>
   execution_time: DateTime
   input: ExecutionResultInput
+  transform?: ExecutionResultTransform
 }
 
 export class ExecutionResultCondition {
   met: boolean
-  status: ActionStatusOptions
+  status: ExecutionResultStatus
   type: ConditionType
+  compare?: ExecutionResultConditionResolved
+  array_compare?: ExecutionResultConditionResolved
+}
+
+export class ExecutionResultConditionResolved {
+  resolved_values?: Dictionary<string, UserDefinedValue>
 }
 
 export class ExecutionResultAction {
@@ -83,12 +103,66 @@ export class ExecutionResultAction {
   type: ActionType
   webhook?: WebhookResult
   error?: ErrorCause
+  condition?: ExecutionResultCondition
+  transform?: ExecutionResultTransform
+  foreach?: ExecutionResultForeachAction[]
+  max_iterations?: integer
+  number_of_actions_executed?: integer
+}
+
+export class ExecutionResultForeachAction {
+  email?: EmailResult
+  index?: IndexResult
+  logging?: LoggingResult
+  pagerduty?: PagerDutyResult
+  slack?: SlackResult
+  webhook?: WebhookResult
+  error?: ErrorCause
+  reason?: string
+  status?: ActionStatusOptions
+  type?: ActionType
+}
+
+export class ExecutionResultTransform {
+  payload?: Dictionary<string, UserDefinedValue>
+  status: ExecutionResultStatus
+  type: ExecutionResultTransformType
+  search?: ExecutionResultSearchInput
+  error?: ErrorCause
+  reason?: string
+}
+
+export enum ExecutionResultTransformType {
+  script,
+  search,
+  chain
 }
 
 export class ExecutionResultInput {
-  payload: Dictionary<string, UserDefinedValue>
-  status: ActionStatusOptions
+  payload?: Dictionary<string, UserDefinedValue>
+  status: ExecutionResultStatus
   type: InputType
+  /**
+   * The resolved search request, present when the input is a search input.
+   */
+  search?: ExecutionResultSearchInput
+  /**
+   * The resolved HTTP request, present when the input is an HTTP input.
+   */
+  http?: ExecutionResultHttpInput
+  /**
+   * The result of each named input, present when the input is a chain input.
+   */
+  chain?: Dictionary<string, ExecutionResultInput>
+  error?: ErrorCause
+}
+
+export class ExecutionResultSearchInput {
+  request: SearchInputRequestDefinition
+}
+
+export class ExecutionResultHttpInput {
+  request: HttpInputRequestResult
 }
 
 export class ExecutionThreadPool {

--- a/specification/watcher/_types/Execution.ts
+++ b/specification/watcher/_types/Execution.ts
@@ -75,7 +75,7 @@ export class ExecutionResult {
   condition?: ExecutionResultCondition
   execution_duration: DurationValue<UnitMillis>
   execution_time: DateTime
-  input: ExecutionResultInput
+  input?: ExecutionResultInput
   transform?: ExecutionResultTransform
 }
 

--- a/specification/watcher/_types/Input.ts
+++ b/specification/watcher/_types/Input.ts
@@ -27,11 +27,10 @@ import {
 } from '@_types/common'
 import { Host } from '@_types/Networking'
 import { uint } from '@_types/Numeric'
-import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Duration } from '@_types/Time'
+import { SearchRequestBody } from '@global/search/_types/SearchRequestBody'
 import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import {SearchRequestBody} from "@global/search/_types/SearchRequestBody";
 
 export class ChainInput {
   inputs: Array<SingleKeyDictionary<string, InputContainer>>

--- a/specification/watcher/_types/Input.ts
+++ b/specification/watcher/_types/Input.ts
@@ -31,6 +31,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Duration } from '@_types/Time'
 import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import {SearchRequestBody} from "@global/search/_types/SearchRequestBody";
 
 export class ChainInput {
   inputs: Array<SingleKeyDictionary<string, InputContainer>>
@@ -113,7 +114,7 @@ export class SearchInput {
 }
 
 export class SearchInputRequestDefinition {
-  body?: SearchInputRequestBody
+  body?: SearchRequestBody
   indices?: IndexName[]
   indices_options?: IndicesOptions
   search_type?: SearchType
@@ -139,10 +140,6 @@ export class SearchTemplateRequestBody {
    * parameter is required.
    */
   source?: string
-}
-
-export class SearchInputRequestBody {
-  query: QueryContainer
 }
 
 export class SimpleInput {

--- a/specification/watcher/_types/Input.ts
+++ b/specification/watcher/_types/Input.ts
@@ -19,7 +19,7 @@
 
 import {
   Id,
-  IndexName,
+  Indices,
   IndicesOptions,
   Password,
   SearchType,
@@ -27,7 +27,9 @@ import {
 } from '@_types/common'
 import { Host } from '@_types/Networking'
 import { uint } from '@_types/Numeric'
+import { ScriptLanguage } from '@_types/Scripting'
 import { Duration } from '@_types/Time'
+import { TransformContainer } from '@_types/Transform'
 import { SearchRequestBody } from '@global/search/_types/SearchRequestBody'
 import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
@@ -92,12 +94,15 @@ export class InputContainer {
   http?: HttpInput
   search?: SearchInput
   simple?: Dictionary<string, UserDefinedValue>
+  transform?: TransformContainer
 }
 
 export enum InputType {
+  chain,
   http,
   search,
-  simple
+  simple,
+  transform
 }
 
 export enum ResponseContentType {
@@ -114,7 +119,7 @@ export class SearchInput {
 
 export class SearchInputRequestDefinition {
   body?: SearchRequestBody
-  indices?: IndexName[]
+  indices?: Indices
   indices_options?: IndicesOptions
   search_type?: SearchType
   template?: SearchTemplateRequestBody
@@ -130,6 +135,12 @@ export class SearchTemplateRequestBody {
    * this parameter is required.
    */
   id?: Id
+  /**
+   * The language the template is written in.
+   * It is reported in the resolved search input of a watch record.
+   * @server_default mustache
+   */
+  lang?: ScriptLanguage
   params?: Dictionary<string, UserDefinedValue>
   /** @server_default false */
   profile?: boolean

--- a/specification/watcher/_types/Input.ts
+++ b/specification/watcher/_types/Input.ts
@@ -100,6 +100,7 @@ export class InputContainer {
 export enum InputType {
   chain,
   http,
+  none,
   search,
   simple,
   transform

--- a/specification/watcher/_types/Watch.ts
+++ b/specification/watcher/_types/Watch.ts
@@ -36,7 +36,7 @@ import { TriggerContainer } from './Trigger'
 
 export class Watch {
   actions: Dictionary<IndexName, Action>
-  condition: ConditionContainer
+  condition?: ConditionContainer
   input: InputContainer
   metadata?: Metadata
   status?: WatchStatus

--- a/specification/watcher/execute_watch/types.ts
+++ b/specification/watcher/execute_watch/types.ts
@@ -18,7 +18,10 @@
  */
 
 import { Id, Metadata, Username } from '@_types/common'
+import { ErrorCause } from '@_types/Errors'
 import { DateTime } from '@_types/Time'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { ConditionContainer } from '@watcher/_types/Conditions'
 import { ExecutionResult, ExecutionStatus } from '@watcher/_types/Execution'
 import { InputContainer } from '@watcher/_types/Input'
@@ -27,15 +30,17 @@ import { WatchStatus } from '@watcher/_types/Watch'
 
 export class WatchRecord {
   '@timestamp': DateTime
-  condition: ConditionContainer
-  input: InputContainer
-  messages: string[]
-  metadata?: Metadata
   node: string
-  result: ExecutionResult
   state: ExecutionStatus
   trigger_event: TriggerEventResult
-  user: Username
   watch_id: Id
+  condition?: ConditionContainer
+  input?: InputContainer
+  metadata?: Metadata
+  result?: ExecutionResult
+  user?: Username
   status?: WatchStatus
+  messages?: string[]
+  vars?: Dictionary<string, UserDefinedValue>
+  exception?: ErrorCause
 }

--- a/specification/watcher/execute_watch/types.ts
+++ b/specification/watcher/execute_watch/types.ts
@@ -18,6 +18,7 @@
  */
 
 import { Id, Metadata, Username } from '@_types/common'
+import { DateTime } from '@_types/Time'
 import { ConditionContainer } from '@watcher/_types/Conditions'
 import { ExecutionResult, ExecutionStatus } from '@watcher/_types/Execution'
 import { InputContainer } from '@watcher/_types/Input'
@@ -25,6 +26,7 @@ import { TriggerEventResult } from '@watcher/_types/Trigger'
 import { WatchStatus } from '@watcher/_types/Watch'
 
 export class WatchRecord {
+  '@timestamp': DateTime
   condition: ConditionContainer
   input: InputContainer
   messages: string[]


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-java/issues/455

List of changes: 

  - **Transform.ts**: ScriptTransform has a [shortcut](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/script/ScriptTransform.java#L59),  SearchTransform's timeout is [nullable](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/search/SearchTransform.java#L33).
  - **Action.ts**: the Status enum has [more values](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/Action.java#L25-L37).
  - **Actions.ts**: index is [optional](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/IndexAction.java#L34), IndexResult is a container of  either [response](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/IndexAction.java#L267) or  [request](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/IndexAction.java#L302), response can be a [single object](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java#L128) or an  [array](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java#L206) (single vs bulk indexing).
  - **Input.ts**: search input's indices is an [array](https://github.com/elastic/elasticsearch/blob/fac9bb4795dc3df3e4a7b01884dec9eb154e208b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java#L40), InputType has [more values](https://github.com/elastic/elasticsearch/blob/ee33e2d1eaa39f5646cfd5da3ad1422c47edde92/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java#L415-L425), InputContainer also has [transform](https://github.com/elastic/elasticsearch/blob/20c9f756d28d116f0667e19a1b531aa80c55bde7/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/transform/TransformInput.java#L25),  SearchTemplateRequestBody has [lang](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/server/src/main/java/org/elasticsearch/script/Script.java#L110).
  - **Watch.ts**: condition is [optional](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/watch/WatchParser.java#L178) (defaults to [`always`](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/watch/WatchParser.java#L78)).
  - **Execution.ts**: condition and transform are [nullable](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/WatchExecutionResult.java#L27-L32), the [input](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/input/Input.java#L29-L31)/[condition](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/condition/Condition.java#L30-L32)/[transform](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transform/Transform.java#L32-L34) phases only report success/failure (new `ExecutionResultStatus`), condition can emit [resolved_values](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/condition/Condition.java#L86) as `compare`/`array_compare`, an action result can carry [condition/transform](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/ActionWrapperResult.java#L84-L89) and [foreach/max_iterations/number_of_actions_executed](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/ActionWrapper.java#L238-L246), and a chain input result is a [dict of named results](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/chain/ChainInput.java#L138-L146).
  - **execute_watch/types.ts**: WatchRecord has a [@timestamp](https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/history/WatchRecord.java#L203).