### PR TITLE
Add GeoPoint shape type for geo_shape query

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2629,6 +2629,11 @@ export interface GeoLine {
 
 export type GeoLocation = LatLonGeoLocation | GeoHashLocation | double[] | string
 
+export interface GeoPoint {
+  type: string
+  coordinates: double[]
+}
+
 export type GeoShape = any
 
 export type GeoShapeRelation = 'intersects' | 'disjoint' | 'within' | 'contains'
@@ -6748,7 +6753,7 @@ export type QueryDslGeoPolygonQuery = QueryDslGeoPolygonQueryKeys
   & { [property: string]: QueryDslGeoPolygonPoints | QueryDslGeoValidationMethod | boolean | float | string }
 
 export interface QueryDslGeoShapeFieldQuery {
-  shape?: GeoShape
+  shape?: GeoShape | GeoPoint
   indexed_shape?: QueryDslFieldLookup
   relation?: GeoShapeRelation
 }

--- a/specification/_types/Geo.ts
+++ b/specification/_types/Geo.ts
@@ -61,6 +61,14 @@ export class GeoLine {
   coordinates: Array<Array<double>>
 }
 
+/** A GeoJson GeoPoint. */
+export class GeoPoint {
+  /** Always `"Point"` */
+  type: string
+  /** `[lon, lat]` coordinates */
+  coordinates: Array<double>
+}
+
 export enum GeoShapeRelation {
   /**
    * Return all documents whose `geo_shape` or `geo_point` field intersects the query geometry.

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -25,6 +25,7 @@ import {
   GeoHash,
   GeoHexCell,
   GeoLocation,
+  GeoPoint,
   GeoShape,
   GeoShapeRelation,
   GeoTile
@@ -125,7 +126,8 @@ export enum GeoFormat {
 }
 
 export class GeoShapeFieldQuery {
-  shape?: GeoShape
+  // eslint-disable-next-line es-spec-validator/no-inline-unions -- TODO: create named alias
+  shape?: GeoShape | GeoPoint
   /**
    * Query using an indexed shape retrieved from the the specified document and path.
    */

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -126,6 +126,8 @@ export enum GeoFormat {
 }
 
 export class GeoShapeFieldQuery {
+  // Hackfix: typed shortcut for Point shapes, without modeling the full
+  // GeoJSON variant union (would be breaking). See elastic/elasticsearch-java#501 for context.
   // eslint-disable-next-line es-spec-validator/no-inline-unions -- TODO: create named alias
   shape?: GeoShape | GeoPoint
   /**


### PR DESCRIPTION
Closes elastic/elasticsearch-java#501

Adds a `GeoPoint` type in `_types/Geo.ts`, following the same shape as the existing `GeoLine`, and references it from `GeoShapeFieldQuery.shape` as `GeoShape | GeoPoint`.

Tried adding `GeoPoint` standalone first (like `GeoLine`), but it gets dropped as a dangling type since nothing points to it (`GeoLine` only survives through the aggregation reference). Referencing `GeoPoint` from `shape` fixes that without changing `GeoShape` itself, so this isn't a breaking change: raw JSON shapes still work exactly as before, `GeoPoint` is just an additional typed option.

Tested against a live 8.15.0 cluster: querying a geo_shape field with `{"type": "point", "coordinates": [...]}` as the shape returns the expected results.