### PR TITLE
Fix Serverless create index API examples

### DIFF
--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -54,6 +54,10 @@ actions:
     description: Use a Serverless-compatible create index with mappings example
     update:
       value: "{\n  \"mappings\": {\n    \"properties\": {\n      \"field1\": { \"type\": \"text\" }\n    }\n  }\n}"
+  - target: "$.paths['/{index}'].put.requestBody.content['application/json'].examples.indicesCreateRequestExample3"
+    description: Use a Serverless-compatible create index with aliases example
+    update:
+      value: "{\n  \"aliases\": {\n    \"alias_1\": {},\n    \"alias_2\": {\n      \"filter\": {\n        \"term\": {\n          \"user.id\": \"kimchy\"\n        }\n      }\n    }\n  }\n}"
   - target: "$.paths['/{index}'].put['x-codeSamples']"
     description: Remove stack-only create index code samples before replacing them
     remove: true

--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -45,3 +45,47 @@ actions:
     update:
       security:
         - apiKeyAuth: []
+  - target: "$.paths['/{index}'].put.requestBody.content['application/json'].examples.indicesCreateRequestExample1"
+    description: Use a Serverless-compatible create index example
+    update:
+      description: Create an index with default settings.
+      value: "{}"
+  - target: "$.paths['/{index}'].put.requestBody.content['application/json'].examples.indicesCreateRequestExample2"
+    description: Use a Serverless-compatible create index with mappings example
+    update:
+      value: "{\n  \"mappings\": {\n    \"properties\": {\n      \"field1\": { \"type\": \"text\" }\n    }\n  }\n}"
+  - target: "$.paths['/{index}'].put['x-codeSamples']"
+    description: Use Serverless-compatible code samples for create index
+    update:
+      - lang: Console
+        source: |
+          PUT /my-index-000001
+          {}
+      - lang: Python
+        source: |
+          resp = client.indices.create(
+              index="my-index-000001",
+          )
+      - lang: JavaScript
+        source: |
+          const response = await client.indices.create({
+            index: "my-index-000001",
+          });
+      - lang: Ruby
+        source: |
+          response = client.indices.create(
+            index: "my-index-000001"
+          )
+      - lang: PHP
+        source: |
+          $resp = $client->indices()->create([
+              "index" => "my-index-000001",
+          ]);
+      - lang: curl
+        source: |
+          curl -X PUT -H "Authorization: ApiKey $ELASTIC_API_KEY" "$ELASTICSEARCH_URL/my-index-000001"
+      - lang: Java
+        source: |
+          client.indices().create(c -> c
+              .index("my-index-000001")
+          );

--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -55,37 +55,41 @@ actions:
     update:
       value: "{\n  \"mappings\": {\n    \"properties\": {\n      \"field1\": { \"type\": \"text\" }\n    }\n  }\n}"
   - target: "$.paths['/{index}'].put['x-codeSamples']"
+    description: Remove stack-only create index code samples before replacing them
+    remove: true
+  - target: "$.paths['/{index}'].put"
     description: Use Serverless-compatible code samples for create index
     update:
-      - lang: Console
-        source: |
-          PUT /my-index-000001
-          {}
-      - lang: Python
-        source: |
-          resp = client.indices.create(
-              index="my-index-000001",
-          )
-      - lang: JavaScript
-        source: |
-          const response = await client.indices.create({
-            index: "my-index-000001",
-          });
-      - lang: Ruby
-        source: |
-          response = client.indices.create(
-            index: "my-index-000001"
-          )
-      - lang: PHP
-        source: |
-          $resp = $client->indices()->create([
-              "index" => "my-index-000001",
-          ]);
-      - lang: curl
-        source: |
-          curl -X PUT -H "Authorization: ApiKey $ELASTIC_API_KEY" "$ELASTICSEARCH_URL/my-index-000001"
-      - lang: Java
-        source: |
-          client.indices().create(c -> c
-              .index("my-index-000001")
-          );
+      x-codeSamples:
+        - lang: Console
+          source: |
+            PUT /my-index-000001
+            {}
+        - lang: Python
+          source: |
+            resp = client.indices.create(
+                index="my-index-000001",
+            )
+        - lang: JavaScript
+          source: |
+            const response = await client.indices.create({
+              index: "my-index-000001",
+            });
+        - lang: Ruby
+          source: |
+            response = client.indices.create(
+              index: "my-index-000001"
+            )
+        - lang: PHP
+          source: |
+            $resp = $client->indices()->create([
+                "index" => "my-index-000001",
+            ]);
+        - lang: curl
+          source: |
+            curl -X PUT -H "Authorization: ApiKey $ELASTIC_API_KEY" "$ELASTICSEARCH_URL/my-index-000001"
+        - lang: Java
+          source: |
+            client.indices().create(c -> c
+                .index("my-index-000001")
+            );


### PR DESCRIPTION
## Summary
- Add Serverless-specific OpenAPI overlays for the create index API so examples no longer reference `number_of_shards`, `number_of_replicas` and `routing`.
- Preserve existing Stack examples and language snippets unchanged.
- Override the primary Console and client code samples on Serverless to use a minimal create-index request.

## Test plan
- [x] Run `make overlay-docs` and verify `output/openapi/elasticsearch-serverless-openapi-docs-final.json` no longer includes shard settings in create index examples.
- [x] Confirm Stack OpenAPI docs still show the original shard settings examples.
- [ ] After publish, verify https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-indices-create shows Serverless-compatible examples.


Made with [Cursor](https://cursor.com)