### PR TITLE
Fix NodeInfoDiscover.seed_providers type

### DIFF
--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -189,7 +189,7 @@ export class NodeInfoDiscover
 {
   seed_hosts?: string[] | string
   type?: string
-  seed_providers?: string[]
+  seed_providers?: string[] | string
 }
 
 export class NodeInfoAction {


### PR DESCRIPTION
## Summary
- change `NodeInfoDiscover.seed_providers` to accept either `string` or `string[]`
- align the field with observed `nodes.info` server responses
- match the existing union used by `seed_hosts` in the same type

## Testing
- not run (spec-only change)

Relates to: https://github.com/elastic/go-elasticsearch/issues/1524