### PR TITLE
Model allocations in nodes.stats response

### DIFF
--- a/specification/nodes/_types/Stats.ts
+++ b/specification/nodes/_types/Stats.ts
@@ -33,6 +33,10 @@ export class Stats {
    */
   adaptive_selection?: Dictionary<string, AdaptiveSelection>
   /**
+   * Statistics about shard allocations on the node.
+   */
+  allocations?: Allocations
+  /**
    * Statistics about the field data circuit breaker.
    */
   breakers?: Dictionary<string, Breaker>
@@ -111,6 +115,29 @@ export class Stats {
    * Indices stats about size, document count, indexing and deletion times, search times, field cache size, merges and flushes.
    */
   indices?: ShardStats
+}
+
+export class Allocations {
+  /**
+   * Number of shards allocated to the node.
+   */
+  shards?: integer
+  /**
+   * Number of shards allocated to the node that are currently undesired.
+   */
+  undesired_shards?: integer
+  /**
+   * Forecasted ingest load for the node.
+   */
+  forecasted_ingest_load?: double
+  /**
+   * Forecasted disk usage, in bytes, for the node.
+   */
+  forecasted_disk_usage_in_bytes?: long
+  /**
+   * Current disk usage, in bytes, for the node.
+   */
+  current_disk_usage_in_bytes?: long
 }
 
 export class IndexingPressure {


### PR DESCRIPTION
## Summary
- add the missing `allocations` response model for `nodes.stats`
- add `allocations` to `specification/nodes/_types/Stats.ts`

## Validation
- `npm run compile:specification --prefix compiler`
- `npm run lint --prefix specification -- specification/nodes/_types/Stats.ts` (fails locally because `eslint` is not installed in `specification/node_modules`)

Relates to: https://github.com/elastic/go-elasticsearch/issues/1526
