### PR TITLE
Adding _slice to multiple APIs

### DIFF
--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -204,6 +204,13 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
      */
     routing?: Routing
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * Indicates whether to return the `_source` field (`true` or `false`) or contains a list of fields to return.
      */
     _source?: SourceConfigParam

--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -200,6 +200,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
     refresh?: Refresh
     /**
      * A custom value that is used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      * @ext_doc_id search-shard-routing
      */
     routing?: Routing

--- a/specification/_global/count/CountRequest.ts
+++ b/specification/_global/count/CountRequest.ts
@@ -141,6 +141,7 @@ export interface Request extends RequestBase {
     preference?: string
     /**
      * A custom value used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      */
     routing?: Routing
     /**

--- a/specification/_global/count/CountRequest.ts
+++ b/specification/_global/count/CountRequest.ts
@@ -148,6 +148,13 @@ export interface Request extends RequestBase {
      */
     stats?: string[] | string
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * The maximum number of documents to collect for each shard.
      * If a query reaches this limit, Elasticsearch terminates the query early.
      * Elasticsearch collects documents before sorting.

--- a/specification/_global/delete/DeleteRequest.ts
+++ b/specification/_global/delete/DeleteRequest.ts
@@ -120,6 +120,13 @@ export interface Request extends RequestBase {
      */
     routing?: Routing
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * The period to wait for active shards.
      *
      * This parameter is useful for situations where the primary shard assigned to perform the delete operation might not be available when the delete operation runs.

--- a/specification/_global/delete/DeleteRequest.ts
+++ b/specification/_global/delete/DeleteRequest.ts
@@ -117,6 +117,7 @@ export interface Request extends RequestBase {
     refresh?: Refresh
     /**
      * A custom value used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      */
     routing?: Routing
     /**

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -236,8 +236,16 @@ export interface Request extends RequestBase {
     requests_per_second?: float
     /**
      * A custom value used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      */
     routing?: Routing
+    /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
     /**
      * A query in the Lucene query string syntax.
      */

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -94,6 +94,13 @@ export interface Request extends RequestBase {
      */
     routing?: Routing
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * `True` or `false` to return the `_source` field or not or a list of fields to return.
      */
     _source?: SourceConfigParam

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -91,6 +91,7 @@ export interface Request extends RequestBase {
     preference?: string
     /**
      * A custom value used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      */
     routing?: Routing
     /**

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -141,6 +141,7 @@ export interface Request extends RequestBase {
     refresh?: boolean
     /**
      * A custom value used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      * @ext_doc_id routing
      */
     routing?: Routing

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -145,6 +145,13 @@ export interface Request extends RequestBase {
      */
     routing?: Routing
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * Indicates whether to return the `_source` field (`true` or `false`) or lists the fields to return.
      */
     _source?: SourceConfigParam

--- a/specification/_global/index/IndexRequest.ts
+++ b/specification/_global/index/IndexRequest.ts
@@ -234,6 +234,13 @@ export interface Request<TDocument> extends RequestBase {
      */
     routing?: Routing
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * The period the request waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
      *
      * This parameter is useful for situations where the primary shard assigned to perform the operation might not be available when the operation runs.

--- a/specification/_global/index/IndexRequest.ts
+++ b/specification/_global/index/IndexRequest.ts
@@ -230,6 +230,7 @@ export interface Request<TDocument> extends RequestBase {
     refresh?: Refresh
     /**
      * A custom value that is used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      * @ext_doc_id search-shard-routing
      */
     routing?: Routing

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -91,6 +91,7 @@ export interface Request extends RequestBase {
     refresh?: boolean
     /**
      * Custom value used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      */
     routing?: Routing
     /**

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -94,6 +94,13 @@ export interface Request extends RequestBase {
      */
     routing?: Routing
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * True or false to return the `_source` field or not, or a list of fields to return.
      */
     _source?: SourceConfigParam

--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -114,6 +114,13 @@ export interface Request extends RequestBase {
      */
     routing?: Routing
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * If true, the response includes term frequency and document frequency.
      * @server_default false
      */

--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -111,6 +111,7 @@ export interface Request extends RequestBase {
     realtime?: boolean
     /**
      * A custom value used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      */
     routing?: Routing
     /**

--- a/specification/_global/reindex/types.ts
+++ b/specification/_global/reindex/types.ts
@@ -57,6 +57,7 @@ export class Destination {
    * If it is `keep`, the routing on the bulk request sent for each match is set to the routing on the match.
    * If it is `discard`, the routing on the bulk request sent for each match is set to `null`.
    * If it is `=value`, the routing on the bulk request sent for each match is set to all value specified after the equals sign (`=`).
+   * Not allowed when `index.slice.enabled` is `true` for the destination index; use `_slice` instead.
    * @server_default keep
    */
   routing?: string

--- a/specification/_global/reindex/types.ts
+++ b/specification/_global/reindex/types.ts
@@ -61,6 +61,13 @@ export class Destination {
    */
   routing?: string
   /**
+   * The slice identifier used to route the reindexed documents to a specific slice of the destination index.
+   * Use the special value `_all` to target all slices without restricting to a routing value.
+   * Required when `index.slice.enabled` is `true` for the destination index; not allowed when `index.slice.enabled` is `false`.
+   * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+   */
+  _slice?: string
+  /**
    *  The versioning to use for the indexing operation.
    */
   version_type?: VersionType

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -236,6 +236,7 @@ export interface Request extends RequestBase {
     request_cache?: boolean
     /**
      * A custom value that is used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      * @ext_doc_id search-shard-routing
      */
     routing?: Routing

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -240,6 +240,13 @@ export interface Request extends RequestBase {
      */
     routing?: Routing
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * The period to retain the search context for scrolling.
      * By default, this value cannot exceed `1d` (24 hours).
      * You can change this limit by using the `search.max_keep_alive` cluster-level setting.

--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -152,6 +152,13 @@ export interface Request<TDocument> extends RequestBase {
      */
     routing?: Routing
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * If `true`, the response includes:
      *
      * * The total term frequency (how often a term occurs in all documents).

--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -148,6 +148,7 @@ export interface Request<TDocument> extends RequestBase {
     realtime?: boolean
     /**
      * A custom value that is used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      * @ext_doc_id search-shard-routing
      */
     routing?: Routing

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -128,6 +128,13 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
      */
     routing?: Routing
     /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
+    /**
      * The period to wait for the following operations: dynamic mapping updates and waiting for active shards.
      * Elasticsearch waits for at least the timeout period before failing.
      * The actual wait time could be longer, particularly when multiple waits occur.

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -125,6 +125,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
     retry_on_conflict?: integer
     /**
      * A custom value used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      */
     routing?: Routing
     /**

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -260,8 +260,16 @@ export interface Request extends RequestBase {
     requests_per_second?: float
     /**
      * A custom value used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
      */
     routing?: Routing
+    /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
     /**
      * The period to retain the search context for scrolling.
      * @server_default 5m

--- a/specification/indices/validate_query/IndicesValidateQueryRequest.ts
+++ b/specification/indices/validate_query/IndicesValidateQueryRequest.ts
@@ -121,6 +121,13 @@ export interface Request extends RequestBase {
      * Query in the Lucene query string syntax.
      */
     q?: string
+    /**
+     * The slice identifier used to route the operation to a specific slice.
+     * Use the special value `_all` to target all slices without restricting to a routing value.
+     * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+     * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     */
+    _slice?: string
   }
   body?: {
     /**

--- a/specification/indices/validate_query/IndicesValidateQueryRequest.ts
+++ b/specification/indices/validate_query/IndicesValidateQueryRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { ExpandWildcards, Indices, MediaType } from '@_types/common'
+import { ExpandWildcards, Indices, MediaType, Routing } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Operator } from '@_types/query_dsl/Operator'
 
@@ -121,6 +121,13 @@ export interface Request extends RequestBase {
      * Query in the Lucene query string syntax.
      */
     q?: string
+    /**
+     * A custom value used to route operations to a specific shard.
+     * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
+     * @availability stack since=9.5.0 stability=stable
+     * @availability serverless stability=stable
+     */
+    routing?: Routing
     /**
      * The slice identifier used to route the operation to a specific slice.
      * Use the special value `_all` to target all slices without restricting to a routing value.


### PR DESCRIPTION
Followup of https://github.com/elastic/elasticsearch-specification/pull/6302, `_slice` was added behind a feature flag to multiple APIs. 

  | ES PR | Title | Spec endpoint(s) |
  |---|---|---|
  | [#147185](https://github.com/elastic/elasticsearch/pull/147185) | [Slice] Introduce initial _slice API changes | `bulk`, `index`, `update` |
  | [#147525](https://github.com/elastic/elasticsearch/pull/147525) | [Slice] Adds GET & DELETE for _slice | `get`, `delete` |
  | [#147943](https://github.com/elastic/elasticsearch/pull/147943) | Slice, adding _slice input to reindex | `reindex` (destination `_slice`) |
  | [#148541](https://github.com/elastic/elasticsearch/pull/148541) | Slice: add _slice support to search | `search` |
  | [#148675](https://github.com/elastic/elasticsearch/pull/148675) | Slice: add _slice support to count | `count` |
  | [#149738](https://github.com/elastic/elasticsearch/pull/149738) | Slice: adding _slice to _explain API | `explain` |
  | [#149880](https://github.com/elastic/elasticsearch/pull/149880) | Slice: Add _slice support to DBQ and UBQ | `delete_by_query`, `update_by_query` |
  | [#150252](https://github.com/elastic/elasticsearch/pull/150252) | Slice: Add _slice to validate query | `validate_query` (+ new `routing`) |
  | [#151643](https://github.com/elastic/elasticsearch/pull/151643) | Slice, _mget support | `mget` |
  | [#152204](https://github.com/elastic/elasticsearch/pull/152204) | Slice: Make term and mterm vectors APIs slice aware | `termvectors`, `mtermvectors` |
