### PR TITLE
Remove ASCII qualifier from case_insensitive descriptions

### DIFF
--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -110,7 +110,7 @@ export class PrefixQuery extends QueryBase {
    */
   value: string
   /**
-   * Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`.
+   * Allows case insensitive matching of the value with the indexed field values when set to `true`.
    * Default is `false` which means the case sensitivity of matching depends on the underlying field’s mapping.
    * @server_default false
    * @availability stack since=7.10.0
@@ -244,7 +244,7 @@ export class TermQuery extends QueryBase {
    */
   value: FieldValue
   /**
-   * Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`.
+   * Allows case insensitive matching of the value with the indexed field values when set to `true`.
    * When `false`, the case sensitivity of matching depends on the underlying field’s mapping.
    * @availability stack since=7.10.0
    * @availability serverless


### PR DESCRIPTION
## Summary

Updates `PrefixQuery` and `TermQuery` `case_insensitive` parameter descriptions to remove the "ASCII" qualifier. As of elastic/elasticsearch#153513, `case_insensitive` queries use Unicode simple case folding (via Lucene 10.5's `CaseFolding.expand()`), not just ASCII.

This aligns these descriptions with `WildcardQuery` and `RegexpQuery` which already just say "case insensitive" without an ASCII qualifier.

## References

- elastic/elasticsearch#153513
- Closes elastic/elasticsearch#95120 (spec side)