### PR TITLE
[Backport 9.4] Updating custom service task settings to indicate overriding secret parameters is forbidden

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -1450,6 +1450,9 @@ export class CustomTaskSettings {
    *   }
    * }
    * ```
+   *
+   * > warn
+   * > The `task_settings.parameters` cannot contain the same keys as `secret_parameters`. If they do, an error will be returned. This applies to PUT requests and POST requests.
    */
   parameters?: Dictionary<string, CustomTaskParameter>
 }


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch-specification/pull/6425

Made with [Cursor](https://cursor.com)