### PR TITLE
[Backport 8.19] Updating custom service task settings to indicate overriding secret parameters is forbidden

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -1148,6 +1148,9 @@ export class CustomTaskSettings {
    *   }
    * }
    * ```
+   *
+   * > warn
+   * > The `task_settings.parameters` cannot contain the same keys as `secret_parameters`. If they do, an error will be returned. This applies to PUT requests and POST requests.
    */
   parameters?: UserDefinedValue
 }


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch-specification/pull/6425

Made with [Cursor](https://cursor.com)