### PR TITLE
Add delete_backing_index action to modify data stream API

### DIFF
--- a/specification/indices/modify_data_stream/types.ts
+++ b/specification/indices/modify_data_stream/types.ts
@@ -34,6 +34,12 @@ export class Action {
    * A data stream’s write index cannot be removed.
    */
   remove_backing_index?: IndexAndDataStreamAction
+  /**
+   * Deletes a backing index from a data stream.
+   * A data stream’s write index cannot be deleted because it is the write index.
+   * @availability stack since=9.5.0 stability=stable visibility=public
+   */
+  delete_backing_index?: IndexAndDataStreamAction
 }
 
 export class IndexAndDataStreamAction {


### PR DESCRIPTION
Introduced in https://github.com/elastic/elasticsearch/pull/151137, relevant code [here](https://github.com/elastic/elasticsearch/blob/2d67d284377a6243a322572050be339a2d1b746e/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAction.java#L50)
