### PR TITLE
Adding compile to contrib target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ lint-docs-stateful: ## Lint only the elasticsearch-openapi-docs-final.json file
 lint-docs-serverless: ## Lint only the serverless OpenAPI document after overlays
 	@npx @redocly/cli lint "output/openapi/elasticsearch-serverless-openapi-docs-final.json" --config "docs/linters/redocly.yaml" --format stylish --max-problems 500
 
-contrib: | lint generate license-check spec-format-fix transform-to-openapi filter-for-serverless lint-docs ## Pre contribution target
+contrib: | lint generate compile license-check spec-format-fix transform-to-openapi filter-for-serverless lint-docs ## Pre contribution target
 
 help:  ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
After chatting with @l-trotta here: https://github.com/elastic/elasticsearch-specification/pull/6429#issuecomment-4956088669 the recommended command execution is `make generate && make compile && make spec-format-fix && make contrib`

`make contrib` has most of that already except the `compile` target. So I'm opening this PR to see if there's any reason not to have `contrib` handle that too? Then all we need to do is `make contrib`.
