### PR TITLE
Fix validation for get component template

### DIFF
--- a/specification/_types/mapping/complex.ts
+++ b/specification/_types/mapping/complex.ts
@@ -31,10 +31,21 @@ export class FlattenedProperty extends PropertyBase {
   index?: boolean
   index_options?: IndexOptions
   null_value?: string
+  /**
+   * When set to lossy (the default), leaf arrays are sorted, de-nulled, and deduplicated in the returned synthetic source.
+   * When set to exact, leaf arrays preserve order, nulls, and duplicates.
+   * @server_default lossy
+   */
+  preserve_leaf_arrays?: PreserveLeafArrays
   similarity?: string
   split_queries_on_whitespace?: boolean
   time_series_dimensions?: string[]
   type: 'flattened'
+}
+
+export enum PreserveLeafArrays {
+  lossy,
+  exact
 }
 
 export class NestedProperty extends CorePropertyBase {

--- a/specification/_types/mapping/complex.ts
+++ b/specification/_types/mapping/complex.ts
@@ -32,9 +32,9 @@ export class FlattenedProperty extends PropertyBase {
   index_options?: IndexOptions
   null_value?: string
   /**
-   * When set to lossy (the default), leaf arrays are sorted, de-nulled, and deduplicated in the returned synthetic source.
-   * When set to exact, leaf arrays preserve order, nulls, and duplicates.
-   * @server_default lossy
+   * How leaf arrays are represented in synthetic source.
+   * When set to `lossy`, leaf arrays are sorted, de-nulled, and deduplicated in the returned synthetic source.
+   * When set to `exact`, leaf arrays preserve order, nulls, and duplicates.
    */
   preserve_leaf_arrays?: PreserveLeafArrays
   similarity?: string

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -23,7 +23,7 @@ import { Normalizer } from '@_types/analysis/normalizers'
 import { TokenFilter } from '@_types/analysis/token_filters'
 import { Tokenizer } from '@_types/analysis/tokenizers'
 import {
-  ByteSize,
+  ByteSize, Field,
   Name,
   PipelineName,
   Uuid,
@@ -375,6 +375,14 @@ export class IndexSettingsAnalysis {
 export class IndexSettingsTimeSeries {
   end_time?: DateTime
   start_time?: DateTime
+  /**
+   * The name of the field that stores the temporality of a metric.
+   * The referenced field must be a `keyword` dimension field; if the setting is unset or the
+   * field is missing or invalid, the metric temporality resolves to null.
+   * @availability stack since=9.4.0 visibility=feature_flag feature_flag=time_series_temporality
+   * @availability serverless visibility=feature_flag feature_flag=time_series_temporality
+   */
+  temporality_field?: Field
 }
 
 export class Merge {

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -380,8 +380,8 @@ export class IndexSettingsTimeSeries {
    * The name of the field that stores the temporality of a metric.
    * The referenced field must be a `keyword` dimension field; if the setting is unset or the
    * field is missing or invalid, the metric temporality resolves to null.
-   * @availability stack since=9.4.0 visibility=feature_flag feature_flag=time_series_temporality
-   * @availability serverless visibility=feature_flag feature_flag=time_series_temporality
+   * @availability stack since=9.4.0
+   * @availability serverless
    */
   temporality_field?: Field
 }

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -23,7 +23,8 @@ import { Normalizer } from '@_types/analysis/normalizers'
 import { TokenFilter } from '@_types/analysis/token_filters'
 import { Tokenizer } from '@_types/analysis/tokenizers'
 import {
-  ByteSize, Field,
+  ByteSize,
+  Field,
   Name,
   PipelineName,
   Uuid,


### PR DESCRIPTION
Addressing https://github.com/elastic/elasticsearch/pull/145376 and https://github.com/elastic/elasticsearch/pull/144912.
Relevant code: 

- temporality_field: [IndexSettings](https://github.com/elastic/elasticsearch/blob/ce5a29cf2d3401213b41dd05793e3bc0e604c164/server/src/main/java/org/elasticsearch/index/IndexSettings.java#L648)
- preserve_leaf_arrays: [FlattenedFieldMapper](https://github.com/elastic/elasticsearch/blob/030dbbbf5fc27f5b6e735760e7cf3318fbde840b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java#L357)
