### PR TITLE
Model classified form of named ES|QL query parameters

### DIFF
--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -19,7 +19,8 @@
 
 import { FieldValue, Name, ProjectRouting } from '@_types/common'
 import { double, integer } from '@_types/Numeric'
-import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
+import { AdditionalProperties } from '@spec_utils/behaviors'
+import { SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { Stringified } from '@spec_utils/Stringified'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
@@ -173,7 +174,7 @@ export class EsqlQuerySettings
    * @availability stack since=9.5.0 stability=experimental
    * @availability serverless stability=experimental
    */
-  column_metadata?: boolean
+  column_metadata?: Stringified<boolean>
   /**
    * Limits the scope of a cross-project search (CPS) to specific projects before query execution, based on a Lucene query expression evaluated against project tags.
    * Excluded projects are not queried, which can reduce cost and latency.

--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -140,3 +140,17 @@ export class EsqlApproximationSettings {
    */
   confidence_level?: double
 }
+
+/**
+ * Per-query settings supplied through the request body.
+ * This is the request-body equivalent of the in-query `SET` command: each key is a
+ * setting name (for example `time_zone`) and its value configures how the query runs.
+ * @behavior_meta AdditionalProperties fieldname=settings description="Additional per-query settings, equivalent to in-query `SET` keys."
+ */
+export class EsqlQuerySettings implements AdditionalProperties<string, UserDefinedValue> {
+  /**
+   * Sets the default timezone of the query.
+   * @doc_id esql-timezones
+   */
+  time_zone?: string
+}

--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -19,10 +19,8 @@
 
 import { FieldValue, Name, ProjectRouting } from '@_types/common'
 import { double, integer } from '@_types/Numeric'
-import { AdditionalProperties } from '@spec_utils/behaviors'
 import { SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { Stringified } from '@spec_utils/Stringified'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @codegen_names value, named
@@ -144,13 +142,11 @@ export class EsqlApproximationSettings {
 
 /**
  * Per-query settings supplied through the request body.
- * This is the request-body equivalent of the in-query `SET` command: each key is a
- * setting name (for example `time_zone`) and its value configures how the query runs.
- * @behavior_meta AdditionalProperties fieldname=settings description="Additional per-query settings, equivalent to in-query `SET` keys."
+ * This is the request-body equivalent of the in-query `SET` command.
+ * Only settings that are exposed as request-body parameters can be set here; other `SET`-only
+ * settings (such as `unmapped_fields`) must be supplied in the query itself.
  */
-export class EsqlQuerySettings
-  implements AdditionalProperties<string, UserDefinedValue>
-{
+export class EsqlQuerySettings {
   /**
    * The default timezone to be used in the query.
    * It defaults to UTC and overrides the `time_zone` request parameter.
@@ -181,13 +177,6 @@ export class EsqlQuerySettings
    * @availability serverless stability=experimental
    */
   project_routing?: ProjectRouting
-  /**
-   * Determines how unmapped fields are treated.
-   * Possible values are `default` (queries fail when referencing unmapped fields), `nullify` (treats unmapped fields as null values), and `load` (loads unmapped fields from the stored `_source` with type `keyword`, or nullifies them if absent from `_source`).
-   * @availability stack since=9.3.0 stability=experimental
-   * @availability serverless stability=experimental
-   */
-  unmapped_fields?: string
 }
 
 /**

--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -26,8 +26,36 @@ import { Stringified } from '@spec_utils/Stringified'
  * @codegen_names value, named
  */
 export type ESQLParams = SingleOrMultiValue[] | NamedValue[]
-export type NamedValue = SingleKeyDictionary<string, SingleOrMultiValue>
+export type NamedValue = SingleKeyDictionary<string, NamedParameterValue>
 export type SingleOrMultiValue = FieldValue | FieldValue[]
+
+/**
+ * The value of a named ES|QL query parameter.
+ * It is either a literal single or multi value, or a single-key object that classifies how
+ * the parameter is interpreted.
+ * @codegen_names literal, classified
+ */
+export type NamedParameterValue = SingleOrMultiValue | ClassifiedNamedParameter
+
+/**
+ * A named ES|QL query parameter supplied in its classified form.
+ * Exactly one of `value`, `identifier`, or `pattern` must be set.
+ * @variants container
+ */
+export class ClassifiedNamedParameter {
+  /**
+   * Interpret the parameter as a literal value.
+   */
+  value?: SingleOrMultiValue
+  /**
+   * Interpret the parameter as an identifier, such as a field or function name.
+   */
+  identifier?: string
+  /**
+   * Interpret the parameter as a pattern, such as an index or field name pattern.
+   */
+  pattern?: string
+}
 
 /**
  *

--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -149,8 +149,61 @@ export class EsqlApproximationSettings {
  */
 export class EsqlQuerySettings implements AdditionalProperties<string, UserDefinedValue> {
   /**
-   * Sets the default timezone of the query.
+   * The default timezone to be used in the query.
+   * It defaults to UTC and overrides the `time_zone` request parameter.
    * @doc_id esql-timezones
+   * @availability stack since=9.4.0 stability=stable
+   * @availability serverless stability=stable
    */
   time_zone?: string
+  /**
+   * Enables query approximation if possible for the query.
+   * `false` (the default) disables query approximation and `true` enables it with default settings.
+   * A map value enables query approximation with custom settings.
+   * @availability stack since=9.5.0 stability=stable
+   * @availability serverless stability=stable
+   */
+  approximation?: EsqlApproximation
+  /**
+   * When enabled, column metadata is added to the query response as additional `_meta` properties.
+   * Currently, only `_meta.bucket` is added for columns corresponding to the `BUCKET` function, containing the bucket interval and unit for queries where it can be determined.
+   * @server_default false
+   * @availability stack since=9.5.0 stability=experimental
+   * @availability serverless stability=experimental
+   */
+  column_metadata?: boolean
+  /**
+   * Limits the scope of a cross-project search (CPS) to specific projects before query execution, based on a Lucene query expression evaluated against project tags.
+   * Excluded projects are not queried, which can reduce cost and latency.
+   * @availability serverless stability=experimental
+   */
+  project_routing?: ProjectRouting
+  /**
+   * Determines how unmapped fields are treated.
+   * Possible values are `default` (queries fail when referencing unmapped fields), `nullify` (treats unmapped fields as null values), and `load` (loads unmapped fields from the stored `_source` with type `keyword`, or nullifies them if absent from `_source`).
+   * @availability stack since=9.3.0 stability=experimental
+   * @availability serverless stability=experimental
+   */
+  unmapped_fields?: string
+}
+
+/**
+ * The `approximation` query setting.
+ * It can be a boolean that toggles query approximation with default settings, or a map that enables it with custom settings.
+ * @codegen_names enabled, settings
+ */
+export type EsqlApproximation = boolean | EsqlApproximationSettings
+
+export class EsqlApproximationSettings {
+  /**
+   * The number of sampled rows used for approximating the query.
+   * It must be at least 10,000. A null value uses the system default.
+   */
+  rows?: integer
+  /**
+   * The confidence level of the computed confidence intervals.
+   * A null value disables computing confidence intervals.
+   * @server_default 0.90
+   */
+  confidence_level?: double
 }

--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -147,7 +147,9 @@ export class EsqlApproximationSettings {
  * setting name (for example `time_zone`) and its value configures how the query runs.
  * @behavior_meta AdditionalProperties fieldname=settings description="Additional per-query settings, equivalent to in-query `SET` keys."
  */
-export class EsqlQuerySettings implements AdditionalProperties<string, UserDefinedValue> {
+export class EsqlQuerySettings
+  implements AdditionalProperties<string, UserDefinedValue>
+{
   /**
    * The default timezone to be used in the query.
    * It defaults to UTC and overrides the `time_zone` request parameter.

--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -19,8 +19,9 @@
 
 import { FieldValue, Name, ProjectRouting } from '@_types/common'
 import { double, integer } from '@_types/Numeric'
-import { SingleKeyDictionary } from '@spec_utils/Dictionary'
+import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { Stringified } from '@spec_utils/Stringified'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @codegen_names value, named
@@ -106,66 +107,6 @@ export class ESQLDataset {
    * The accepted keys depend on the format reader; compression can be inferred from the resource URI.
    */
   settings?: Dictionary<string, UserDefinedValue>
-}
-
-/**
- * Per-query settings supplied through the request body.
- * This is the request-body equivalent of the in-query `SET` command.
- * Only settings that are exposed as request-body parameters can be set here; other `SET`-only
- * settings (such as `unmapped_fields`) must be supplied in the query itself.
- */
-export class EsqlQuerySettings {
-  /**
-   * The default timezone to be used in the query.
-   * It defaults to UTC and overrides the `time_zone` request parameter.
-   * @doc_id esql-timezones
-   * @availability stack since=9.4.0 stability=stable
-   * @availability serverless stability=stable
-   */
-  time_zone?: string
-  /**
-   * Enables query approximation if possible for the query.
-   * `false` (the default) disables query approximation and `true` enables it with default settings.
-   * A map value enables query approximation with custom settings.
-   * @availability stack since=9.5.0 stability=stable
-   * @availability serverless stability=stable
-   */
-  approximation?: EsqlApproximation
-  /**
-   * When enabled, column metadata is added to the query response as additional `_meta` properties.
-   * Currently, only `_meta.bucket` is added for columns corresponding to the `BUCKET` function, containing the bucket interval and unit for queries where it can be determined.
-   * @server_default false
-   * @availability stack since=9.5.0 stability=experimental
-   * @availability serverless stability=experimental
-   */
-  column_metadata?: Stringified<boolean>
-  /**
-   * Limits the scope of a cross-project search (CPS) to specific projects before query execution, based on a Lucene query expression evaluated against project tags.
-   * Excluded projects are not queried, which can reduce cost and latency.
-   * @availability serverless stability=experimental
-   */
-  project_routing?: ProjectRouting
-}
-
-/**
- * The `approximation` query setting.
- * It can be a boolean that toggles query approximation with default settings, or a map that enables it with custom settings.
- * @codegen_names enabled, settings
- */
-export type EsqlApproximation = boolean | EsqlApproximationSettings
-
-export class EsqlApproximationSettings {
-  /**
-   * The number of sampled rows used for approximating the query.
-   * It must be at least 10,000. A null value uses the system default.
-   */
-  rows?: integer
-  /**
-   * The confidence level of the computed confidence intervals.
-   * A null value disables computing confidence intervals.
-   * @server_default 0.90
-   */
-  confidence_level?: double
 }
 
 /**


### PR DESCRIPTION
To be merged after https://github.com/elastic/elasticsearch-specification/pull/6442, this fixes validation for esql query.  Addressing https://github.com/elastic/elasticsearch/pull/121850.
To be honest I didn't really look at the server code to model this, because it's [a lot to read](https://github.com/elastic/elasticsearch/blob/5cf8e8797ab96b2131297050c81f53d0f97dd1f0/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RequestXContent.java#L237), and instead I checked the [recordings](https://github.com/elastic/elasticsearch/blob/8a52778d28dbc5c8750f88b36730d1722da3ab76/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/10_basic.yml#L940-L957). 
