### PR TITLE
Fix validation for ml info

### DIFF
--- a/specification/ml/info/types.ts
+++ b/specification/ml/info/types.ts
@@ -24,6 +24,16 @@ import { CategorizationAnalyzer } from '@ml/_types/Analysis'
 export class Defaults {
   anomaly_detectors: AnomalyDetectors
   datafeeds: Datafeeds
+  /**
+   * Returns `linux-x86_64` when all ML nodes are x86, or when no ML nodes exist but the cluster is in Elastic Cloud.
+   * Returns `platform_agnostic` otherwise.
+   */
+  model_platform_variant: ModelPlatformVariant
+}
+
+export enum ModelPlatformVariant {
+  linux86 = `linux-x86_64`,
+  platform_agnostic = `platform_agnostic`
 }
 
 export class NativeCode {


### PR DESCRIPTION
Addressing https://github.com/elastic/elasticsearch/pull/147496, specifically https://github.com/elastic/elasticsearch/blob/a6141b9dbec012eb147c8280ccc65f847b2956fa/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java#L107. Not really an enum in the server code, but since it's a string with only 2 values I'm modeling it as such. 
