### PR TITLE
Add vectordb_document section to _xpack/usage

### DIFF
--- a/specification/xpack/usage/XPackUsageResponse.ts
+++ b/specification/xpack/usage/XPackUsageResponse.ts
@@ -37,6 +37,7 @@ import {
   Slm,
   Sql,
   Vector,
+  VectorDbDocument,
   Watcher
 } from './types'
 
@@ -77,6 +78,10 @@ export class Response {
     sql: Sql
     transform: Base
     vectors?: Vector
+    /**
+     * @availability stack since=9.5.0
+     */
+    vectordb_document?: VectorDbDocument
     voting_only: Base
   }
 }

--- a/specification/xpack/usage/types.ts
+++ b/specification/xpack/usage/types.ts
@@ -496,6 +496,20 @@ export class Vector extends Base {
   sparse_vector_fields_count?: integer
 }
 
+/**
+ * Usage statistics for indices using the `vectordb_document` index mode.
+ */
+export class VectorDbDocument extends Base {
+  /**
+   * The number of indices using the `vectordb_document` index mode.
+   */
+  indices_count: integer
+  /**
+   * The total number of documents held across all `vectordb_document` indices.
+   */
+  num_docs: long
+}
+
 export class Watcher extends Base {
   execution: WatcherActions
   watch: WatcherWatch


### PR DESCRIPTION
Addressing https://github.com/elastic/elasticsearch/pull/152780, relevant code: https://github.com/elastic/elasticsearch/blob/a7e2dbef1097cc159fe3c9ffe5bb5527ce8d4dd8/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/VectorDBDocumentFeatureSetUsage.java#L51
