### PR TITLE
[Inference API] Adding 9.5 version number to the embedding docs to clarify support

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -530,6 +530,7 @@ export class RequestEmbedding {
    * Either a string, an array of strings, a `content` object, or an array of `content` objects.
    * `content` objects may contain a single item or an array of items. Models that support multiple items per `content`
    * object will return a single embedding for each `content` object, regardless of how many items it contains.
+   * Support for multiple items in a single `content` object is available in Elasticsearch 9.5.0 and later.
    *
    * string example:
    * ```
@@ -568,7 +569,7 @@ export class RequestEmbedding {
    *   }
    * ]
    * ```
-   * Multiple items in one `content` object example:
+   * Multiple items in one `content` object example (available in Elasticsearch 9.5.0 and later):
    * ```
    * "input": [
    *   {
@@ -639,6 +640,7 @@ export class EmbeddingContentObject {
 
 /**
  * Allows specifying one or multiple items for the `embedding` task, which should result in a single embedding vector.
+ * Support for multiple items is available in Elasticsearch 9.5.0 and later.
  */
 type EmbeddingContentObjectGroup =
   | EmbeddingContentObjectItem
@@ -650,6 +652,7 @@ type EmbeddingContentObjectGroup =
 export class EmbeddingContentObjectItem {
   /**
    * The type of input to embed. Not all models support all input types.
+   * The `audio`, `video`, and `pdf` types are available in Elasticsearch 9.5.0 and later.
    */
   type: EmbeddingContentType
   /**
@@ -665,6 +668,7 @@ export class EmbeddingContentObjectItem {
 
 /**
  * The type of input to embed.
+ * The `audio`, `video`, and `pdf` types are available in Elasticsearch 9.5.0 and later.
  */
 export enum EmbeddingContentType {
   text,

--- a/specification/inference/embedding/examples/request/EmbeddingRequestExample3.yaml
+++ b/specification/inference/embedding/examples/request/EmbeddingRequestExample3.yaml
@@ -1,5 +1,5 @@
 summary: Embedding task using multiple items grouped under a single content object
-description: Run `POST _inference/embedding/my-multimodal-endpoint` to generate a single embedding from the example text and image
+description: Run `POST _inference/embedding/my-multimodal-endpoint` to generate a single embedding from the example text and image. Multiple items in a single `content` object are available in Elasticsearch 9.5.0 and later.
 method_request: 'POST _inference/embedding/my-multimodal-endpoint'
 value: |-
   {


### PR DESCRIPTION
Adding 9.5 version clarification to the embedding types for when they were added.

The reason I'm doing this is because the generated docs only distinguish between 8.x, 9.x, and main. So there's no way to tell in what versions of elasticsearch these features are available. I looked to see if we could add version directive somewhere but that only works for APIs.