### PR TITLE
Add missing nodes.stats response fields and fix stats types

### DIFF
--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -150,6 +150,8 @@ export class FlushStats {
   total: long
   total_time?: Duration
   total_time_in_millis: DurationValue<UnitMillis>
+  total_time_excluding_waiting?: Duration
+  total_time_excluding_waiting_on_lock_in_millis?: DurationValue<UnitMillis>
 }
 
 export class GetStats {
@@ -160,7 +162,7 @@ export class GetStats {
   missing_time?: Duration
   missing_time_in_millis: DurationValue<UnitMillis>
   missing_total: long
-  time?: Duration
+  getTime?: Duration
   time_in_millis: DurationValue<UnitMillis>
   total: long
 }
@@ -179,6 +181,7 @@ export class IndexingStats {
   index_time_in_millis: DurationValue<UnitMillis>
   index_total: long
   index_failed: long
+  index_failed_due_to_version_conflict?: long
   types?: Dictionary<string, IndexingStats>
   write_load?: double
   recent_write_load?: double
@@ -254,14 +257,19 @@ export class QueryCacheStats {
 
 export class RecoveryStats {
   current_as_source: long
+  current_as_source_queued?: long
   current_as_target: long
+  current_as_target_queued?: long
+  current_from_store?: long
+  current_from_store_queued?: long
   throttle_time?: Duration
   throttle_time_in_millis: DurationValue<UnitMillis>
 }
 
 export class RefreshStats {
   external_total: long
-  external_total_time_in_millis: DurationValue<UnitMillis>
+  external_total_time?: Duration
+  external_total_time_in_millis?: DurationValue<UnitMillis>
   listeners: long
   total: long
   total_time?: Duration
@@ -281,11 +289,13 @@ export class SearchStats {
   fetch_time?: Duration
   fetch_time_in_millis: DurationValue<UnitMillis>
   fetch_total: long
+  fetch_failure: long
   open_contexts?: long
   query_current: long
   query_time?: Duration
   query_time_in_millis: DurationValue<UnitMillis>
   query_total: long
+  query_failure: long
   scroll_current: long
   scroll_time?: Duration
   scroll_time_in_millis: DurationValue<UnitMillis>

--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -151,7 +151,7 @@ export class FlushStats {
   total_time?: Duration
   total_time_in_millis: DurationValue<UnitMillis>
   total_time_excluding_waiting?: Duration
-  total_time_excluding_waiting_on_lock_in_millis?: DurationValue<UnitMillis>
+  total_time_excluding_waiting_on_lock_in_millis: DurationValue<UnitMillis>
 }
 
 export class GetStats {
@@ -181,7 +181,7 @@ export class IndexingStats {
   index_time_in_millis: DurationValue<UnitMillis>
   index_total: long
   index_failed: long
-  index_failed_due_to_version_conflict?: long
+  index_failed_due_to_version_conflict: long
   types?: Dictionary<string, IndexingStats>
   write_load?: double
   recent_write_load?: double
@@ -257,10 +257,22 @@ export class QueryCacheStats {
 
 export class RecoveryStats {
   current_as_source: long
+  /**
+   * @availability stack since=9.5.0
+   */
   current_as_source_queued?: long
   current_as_target: long
+  /**
+   * @availability stack since=9.5.0
+   */
   current_as_target_queued?: long
+  /**
+   * @availability stack since=9.5.0
+   */
   current_from_store?: long
+  /**
+   * @availability stack since=9.5.0
+   */
   current_from_store_queued?: long
   throttle_time?: Duration
   throttle_time_in_millis: DurationValue<UnitMillis>
@@ -269,7 +281,7 @@ export class RecoveryStats {
 export class RefreshStats {
   external_total: long
   external_total_time?: Duration
-  external_total_time_in_millis?: DurationValue<UnitMillis>
+  external_total_time_in_millis: DurationValue<UnitMillis>
   listeners: long
   total: long
   total_time?: Duration

--- a/specification/cluster/stats/types.ts
+++ b/specification/cluster/stats/types.ts
@@ -201,8 +201,8 @@ export class DenseVectorOffHeapStats {
   total_veq_size?: ByteSize
   total_vex_size_bytes: long
   total_vex_size?: ByteSize
-  total_cenif_size_bytes: long
-  total_cenif_size?: ByteSize
+  total_cenivf_size_bytes: long
+  total_cenivf_size?: ByteSize
   total_clivf_size_bytes: long
   total_clivf_size?: ByteSize
   fielddata?: Dictionary<string, Dictionary<string, long>>

--- a/specification/indices/stats/types.ts
+++ b/specification/indices/stats/types.ts
@@ -46,6 +46,7 @@ import {
   TranslogStats,
   WarmerStats
 } from '@_types/Stats'
+import { DenseVectorStats, SparseVectorStats } from '@cluster/stats/types'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
@@ -148,7 +149,8 @@ export class ShardQueryCache {
   cache_size: long
   evictions: long
   hit_count: long
-  memory_size_in_bytes: long
+  memory_size?: ByteSize
+  memory_size_in_bytes?: long
   miss_count: long
   total_count: long
 }
@@ -187,11 +189,15 @@ export class MappingStats {
   total_count: long
   total_estimated_overhead?: ByteSize
   total_estimated_overhead_in_bytes: long
+  total_segments?: long
+  total_segment_fields?: long
+  average_fields_per_segment?: long
 }
 
 export class ShardStats {
   commit?: ShardCommit
   completion?: CompletionStats
+  dense_vector?: DenseVectorStats
   docs?: DocStats
   fielddata?: FielddataStats
   flush?: FlushStats
@@ -209,6 +215,7 @@ export class ShardStats {
   search?: SearchStats
   segments?: SegmentsStats
   seq_no?: ShardSequenceNumber
+  sparse_vector?: SparseVectorStats
   store?: StoreStats
   translog?: TranslogStats
   warmer?: WarmerStats
@@ -219,7 +226,7 @@ export class ShardStats {
    */
   shards?: Dictionary<IndexName, UserDefinedValue>
   shard_stats?: ShardsTotalStats
-  indices?: IndicesStats
+  indices?: Dictionary<IndexName, ShardStats>
 }
 
 export enum IndexMetadataState {

--- a/specification/indices/stats/types.ts
+++ b/specification/indices/stats/types.ts
@@ -150,7 +150,7 @@ export class ShardQueryCache {
   evictions: long
   hit_count: long
   memory_size?: ByteSize
-  memory_size_in_bytes?: long
+  memory_size_in_bytes: long
   miss_count: long
   total_count: long
 }
@@ -189,9 +189,9 @@ export class MappingStats {
   total_count: long
   total_estimated_overhead?: ByteSize
   total_estimated_overhead_in_bytes: long
-  total_segments?: long
-  total_segment_fields?: long
-  average_fields_per_segment?: long
+  total_segments: long
+  total_segment_fields: long
+  average_fields_per_segment: long
 }
 
 export class ShardStats {

--- a/specification/nodes/_types/Stats.ts
+++ b/specification/nodes/_types/Stats.ts
@@ -161,7 +161,7 @@ export class RepositorySnapshotStats {
   /**
    * The cumulative size, in bytes, of the blobs uploaded to this repository.
    */
-  uploaded_size_in_bytes?: long
+  uploaded_size_in_bytes: long
   /**
    * The cumulative time spent uploading blobs to this repository.
    */
@@ -169,7 +169,7 @@ export class RepositorySnapshotStats {
   /**
    * The cumulative time, in milliseconds, spent uploading blobs to this repository.
    */
-  total_upload_time_in_millis?: DurationValue<UnitMillis>
+  total_upload_time_in_millis: DurationValue<UnitMillis>
   /**
    * The cumulative time spent reading blobs while uploading to this repository.
    */
@@ -177,7 +177,7 @@ export class RepositorySnapshotStats {
   /**
    * The cumulative time, in milliseconds, spent reading blobs while uploading to this repository.
    */
-  total_read_time_in_millis?: DurationValue<UnitMillis>
+  total_read_time_in_millis: DurationValue<UnitMillis>
 }
 
 export class Allocations {
@@ -477,27 +477,24 @@ export class IngestStats {
   /**
    * Total time, in milliseconds, spent preprocessing ingest documents during the lifetime of this node.
    */
-  time_in_millis?: DurationValue<UnitMillis>
+  time_in_millis: DurationValue<UnitMillis>
   /**
    * Total size of all documents ingested by the pipeline.
-   * This field is only present on pipelines which are the first to process a document.
-   * Thus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.
+   * The value counts documents for which this pipeline was the first to process them; for pipelines that are not the first to process a document (for example, a final pipeline after a default pipeline, a pipeline run after a reroute processor, or a pipeline invoked by a pipeline processor), the value is `0`.
    * @availability stack since=8.15.0 stability=stable
    * @availability serverless
    */
   ingested_as_first_pipeline?: ByteSize
   /**
    * Total number of bytes of all documents ingested by the pipeline.
-   * This field is only present on pipelines which are the first to process a document.
-   * Thus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.
+   * The value counts documents for which this pipeline was the first to process them; for pipelines that are not the first to process a document, the value is `0`.
    * @availability stack since=8.15.0 stability=stable
    * @availability serverless
    */
-  ingested_as_first_pipeline_in_bytes?: long
+  ingested_as_first_pipeline_in_bytes: long
   /**
    * Total size of all documents produced by the pipeline.
-   * This field is only present on pipelines which are the first to process a document.
-   * Thus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.
+   * The value counts documents for which this pipeline was the first to process them; for pipelines that are not the first to process a document, the value is `0`.
    * In situations where there are subsequent pipelines, the value represents the size of the document after all pipelines have run.
    * @availability stack since=8.15.0 stability=stable
    * @availability serverless
@@ -505,13 +502,12 @@ export class IngestStats {
   produced_as_first_pipeline?: ByteSize
   /**
    * Total number of bytes of all documents produced by the pipeline.
-   * This field is only present on pipelines which are the first to process a document.
-   * Thus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.
+   * The value counts documents for which this pipeline was the first to process them; for pipelines that are not the first to process a document, the value is `0`.
    * In situations where there are subsequent pipelines, the value represents the size of the document after all pipelines have run.
    * @availability stack since=8.15.0 stability=stable
    * @availability serverless
    */
-  produced_as_first_pipeline_in_bytes?: long
+  produced_as_first_pipeline_in_bytes: long
 }
 
 export class IngestTotal {
@@ -534,7 +530,7 @@ export class IngestTotal {
   /**
    * Total time, in milliseconds, spent preprocessing ingest documents during the lifetime of this node.
    */
-  time_in_millis?: DurationValue<UnitMillis>
+  time_in_millis: DurationValue<UnitMillis>
 }
 
 export class KeyedProcessor {
@@ -877,14 +873,14 @@ export class HttpRoute {
 export class HttpRouteRequests {
   count: long
   total_size?: ByteSize
-  total_size_in_bytes?: long
+  total_size_in_bytes: long
   size_histogram: SizeHttpHistogram[]
 }
 
 export class HttpRouteResponses {
   count: long
   total_size?: ByteSize
-  total_size_in_bytes?: long
+  total_size_in_bytes: long
   handling_time_histogram: TimeHttpHistogram[]
   size_histogram: SizeHttpHistogram[]
 }
@@ -1425,7 +1421,7 @@ export class TransportActionMessageStats {
   /**
    * The cumulative size, in bytes, of the messages of this kind that the node has handled for this action.
    */
-  total_size_in_bytes?: long
+  total_size_in_bytes: long
   /**
    * The distribution of the sizes of the messages of this kind that the node has handled for this action, represented as a histogram.
    */

--- a/specification/nodes/_types/Stats.ts
+++ b/specification/nodes/_types/Stats.ts
@@ -115,6 +115,69 @@ export class Stats {
    * Indices stats about size, document count, indexing and deletion times, search times, field cache size, merges and flushes.
    */
   indices?: ShardStats
+  /**
+   * Statistics about snapshot activity for the node's registered repositories, keyed by repository name.
+   */
+  repositories?: Dictionary<string, RepositorySnapshotStats>
+}
+
+export class RepositorySnapshotStats {
+  /**
+   * The cumulative time spent throttling read operations for this repository.
+   */
+  total_read_throttled_time?: Duration
+  /**
+   * The cumulative time spent throttling write operations for this repository.
+   */
+  total_write_throttled_time?: Duration
+  /**
+   * The cumulative time, in nanoseconds, spent throttling read operations for this repository.
+   */
+  total_read_throttled_time_nanos: DurationValue<UnitNanos>
+  /**
+   * The cumulative time, in nanoseconds, spent throttling write operations for this repository.
+   */
+  total_write_throttled_time_nanos: DurationValue<UnitNanos>
+  /**
+   * The number of shard snapshots started for this repository.
+   */
+  shard_snapshots_started: long
+  /**
+   * The number of shard snapshots completed for this repository.
+   */
+  shard_snapshots_completed: long
+  /**
+   * The number of shard snapshots currently in progress for this repository.
+   */
+  shard_snapshots_in_progress: long
+  /**
+   * The number of blobs uploaded to this repository.
+   */
+  uploaded_blobs: long
+  /**
+   * The cumulative size of the blobs uploaded to this repository.
+   */
+  uploaded_size?: ByteSize
+  /**
+   * The cumulative size, in bytes, of the blobs uploaded to this repository.
+   */
+  uploaded_size_in_bytes?: long
+  /**
+   * The cumulative time spent uploading blobs to this repository.
+   */
+  total_upload_time?: Duration
+  /**
+   * The cumulative time, in milliseconds, spent uploading blobs to this repository.
+   */
+  total_upload_time_in_millis?: DurationValue<UnitMillis>
+  /**
+   * The cumulative time spent reading blobs while uploading to this repository.
+   */
+  total_read_time?: Duration
+  /**
+   * The cumulative time, in milliseconds, spent reading blobs while uploading to this repository.
+   */
+  total_read_time_in_millis?: DurationValue<UnitMillis>
 }
 
 export class Allocations {
@@ -131,9 +194,17 @@ export class Allocations {
    */
   forecasted_ingest_load?: double
   /**
+   * Forecasted disk usage for the node.
+   */
+  forecasted_disk_usage?: string
+  /**
    * Forecasted disk usage, in bytes, for the node.
    */
   forecasted_disk_usage_in_bytes?: long
+  /**
+   * Current disk usage for the node.
+   */
+  current_disk_usage?: string
   /**
    * Current disk usage, in bytes, for the node.
    */
@@ -400,9 +471,21 @@ export class IngestStats {
    */
   processors: Dictionary<string, KeyedProcessor>[]
   /**
+   * Total time spent preprocessing ingest documents during the lifetime of this node.
+   */
+  time?: Duration
+  /**
    * Total time, in milliseconds, spent preprocessing ingest documents during the lifetime of this node.
    */
-  time_in_millis: DurationValue<UnitMillis>
+  time_in_millis?: DurationValue<UnitMillis>
+  /**
+   * Total size of all documents ingested by the pipeline.
+   * This field is only present on pipelines which are the first to process a document.
+   * Thus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.
+   * @availability stack since=8.15.0 stability=stable
+   * @availability serverless
+   */
+  ingested_as_first_pipeline?: ByteSize
   /**
    * Total number of bytes of all documents ingested by the pipeline.
    * This field is only present on pipelines which are the first to process a document.
@@ -410,7 +493,16 @@ export class IngestStats {
    * @availability stack since=8.15.0 stability=stable
    * @availability serverless
    */
-  ingested_as_first_pipeline_in_bytes: long
+  ingested_as_first_pipeline_in_bytes?: long
+  /**
+   * Total size of all documents produced by the pipeline.
+   * This field is only present on pipelines which are the first to process a document.
+   * Thus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.
+   * In situations where there are subsequent pipelines, the value represents the size of the document after all pipelines have run.
+   * @availability stack since=8.15.0 stability=stable
+   * @availability serverless
+   */
+  produced_as_first_pipeline?: ByteSize
   /**
    * Total number of bytes of all documents produced by the pipeline.
    * This field is only present on pipelines which are the first to process a document.
@@ -419,7 +511,7 @@ export class IngestStats {
    * @availability stack since=8.15.0 stability=stable
    * @availability serverless
    */
-  produced_as_first_pipeline_in_bytes: long
+  produced_as_first_pipeline_in_bytes?: long
 }
 
 export class IngestTotal {
@@ -436,9 +528,13 @@ export class IngestTotal {
    */
   failed: long
   /**
+   * Total time spent preprocessing ingest documents during the lifetime of this node.
+   */
+  time?: Duration
+  /**
    * Total time, in milliseconds, spent preprocessing ingest documents during the lifetime of this node.
    */
-  time_in_millis: DurationValue<UnitMillis>
+  time_in_millis?: DurationValue<UnitMillis>
 }
 
 export class KeyedProcessor {
@@ -459,6 +555,10 @@ export class Processor {
    * Number of failed operations for the processor.
    */
   failed?: long
+  /**
+   * Time spent by the processor transforming documents.
+   */
+  time?: Duration
   /**
    * Time, in milliseconds, spent by the processor transforming documents.
    */
@@ -602,6 +702,10 @@ export class CgroupMemory {
 }
 
 export class Cpu {
+  /**
+   * The number of processors available to the Java virtual machine.
+   */
+  available_processors?: integer
   percent?: integer
   sys?: Duration
   sys_in_millis?: DurationValue<UnitMillis>
@@ -637,6 +741,38 @@ export class DataPathStats {
    */
   free_in_bytes?: long
   /**
+   * The amount of free disk space that, once reached, triggers the low disk watermark.
+   */
+  low_watermark_free_space?: string
+  /**
+   * The amount of free disk space, in bytes, that, once reached, triggers the low disk watermark.
+   */
+  low_watermark_free_space_in_bytes?: long
+  /**
+   * The amount of free disk space that, once reached, triggers the high disk watermark.
+   */
+  high_watermark_free_space?: string
+  /**
+   * The amount of free disk space, in bytes, that, once reached, triggers the high disk watermark.
+   */
+  high_watermark_free_space_in_bytes?: long
+  /**
+   * The amount of free disk space that, once reached, triggers the flood stage disk watermark.
+   */
+  flood_stage_free_space?: string
+  /**
+   * The amount of free disk space, in bytes, that, once reached, triggers the flood stage disk watermark.
+   */
+  flood_stage_free_space_in_bytes?: long
+  /**
+   * The amount of free disk space that, once reached, triggers the frozen flood stage disk watermark.
+   */
+  frozen_flood_stage_free_space?: string
+  /**
+   * The amount of free disk space, in bytes, that, once reached, triggers the frozen flood stage disk watermark.
+   */
+  frozen_flood_stage_free_space_in_bytes?: long
+  /**
    * Mount point of the file store (for example: `/dev/sda2`).
    */
   mount?: string
@@ -660,6 +796,11 @@ export class DataPathStats {
 
 export class MemoryStats {
   /**
+   * If the amount of physical memory has been overridden using the `es`.`total_memory_bytes` system property then this reports the overridden value.
+   * Otherwise it reports the same value as `total`.
+   */
+  adjusted_total?: string
+  /**
    * If the amount of physical memory has been overridden using the `es`.`total_memory_bytes` system property then this reports the overridden value in bytes.
    * Otherwise it reports the same value as `total_in_bytes`.
    */
@@ -671,13 +812,25 @@ export class MemoryStats {
   total_virtual?: string
   total_virtual_in_bytes?: long
   /**
+   * Total amount of physical memory.
+   */
+  total?: string
+  /**
    * Total amount of physical memory in bytes.
    */
   total_in_bytes?: long
   /**
+   * Amount of free physical memory.
+   */
+  free?: string
+  /**
    * Amount of free physical memory in bytes.
    */
   free_in_bytes?: long
+  /**
+   * Amount of used physical memory.
+   */
+  used?: string
   /**
    * Amount of used physical memory in bytes.
    */
@@ -723,26 +876,32 @@ export class HttpRoute {
 
 export class HttpRouteRequests {
   count: long
-  total_size_in_bytes: long
+  total_size?: ByteSize
+  total_size_in_bytes?: long
   size_histogram: SizeHttpHistogram[]
 }
 
 export class HttpRouteResponses {
   count: long
-  total_size_in_bytes: long
+  total_size?: ByteSize
+  total_size_in_bytes?: long
   handling_time_histogram: TimeHttpHistogram[]
   size_histogram: SizeHttpHistogram[]
 }
 
 export class TimeHttpHistogram {
   count: long
+  ge?: Duration
   ge_millis?: long
+  lt?: Duration
   lt_millis?: long
 }
 
 export class SizeHttpHistogram {
   count: long
+  ge?: ByteSize
   ge_bytes?: long
+  lt?: ByteSize
   lt_bytes?: long
 }
 
@@ -771,11 +930,23 @@ export class Client {
   /**
    * Time at which the client opened the connection.
    */
+  opened_time?: string
+  /**
+   * Time at which the client opened the connection.
+   */
   opened_time_millis?: long
   /**
    * Time at which the client closed the connection if the connection is closed.
    */
+  closed_time?: string
+  /**
+   * Time at which the client closed the connection if the connection is closed.
+   */
   closed_time_millis?: long
+  /**
+   * Time of the most recent request from this client.
+   */
+  last_request_time?: string
   /**
    * Time of the most recent request from this client.
    */
@@ -946,6 +1117,10 @@ export class Jvm {
 
 export class JvmMemoryStats {
   /**
+   * Memory currently in use by the heap.
+   */
+  heap_used?: ByteSize
+  /**
    * Memory, in bytes, currently in use by the heap.
    */
   heap_used_in_bytes?: long
@@ -953,6 +1128,10 @@ export class JvmMemoryStats {
    * Percentage of memory currently in use by the heap.
    */
   heap_used_percent?: long
+  /**
+   * Amount of memory available for use by the heap.
+   */
+  heap_committed?: ByteSize
   /**
    * Amount of memory, in bytes, available for use by the heap.
    */
@@ -967,9 +1146,17 @@ export class JvmMemoryStats {
   heap_max?: ByteSize
 
   /**
+   * Non-heap memory used.
+   */
+  non_heap_used?: ByteSize
+  /**
    * Non-heap memory used, in bytes.
    */
   non_heap_used_in_bytes?: long
+  /**
+   * Amount of non-heap memory available.
+   */
+  non_heap_committed?: ByteSize
   /**
    * Amount of non-heap memory available, in bytes.
    */
@@ -982,17 +1169,33 @@ export class JvmMemoryStats {
 
 export class Pool {
   /**
+   * Memory used by the heap.
+   */
+  used?: string
+  /**
    * Memory, in bytes, used by the heap.
    */
   used_in_bytes?: long
+  /**
+   * Maximum amount of memory available for use by the heap.
+   */
+  max?: string
   /**
    * Maximum amount of memory, in bytes, available for use by the heap.
    */
   max_in_bytes?: long
   /**
+   * Largest amount of memory historically used by the heap.
+   */
+  peak_used?: string
+  /**
    * Largest amount of memory, in bytes, historically used by the heap.
    */
   peak_used_in_bytes?: long
+  /**
+   * Largest amount of memory historically used by the heap.
+   */
+  peak_max?: string
   /**
    * Largest amount of memory, in bytes, historically used by the heap.
    */
@@ -1193,6 +1396,67 @@ export class Transport {
    * Transport connections are typically long-lived so this statistic should remain constant in a stable cluster.
    */
   total_outbound_connections?: long
+  /**
+   * Statistics about the transport messages sent and received by the node, broken down by action name.
+   */
+  actions?: Dictionary<string, TransportActionStats>
+}
+
+export class TransportActionStats {
+  /**
+   * Statistics about the requests received for this action.
+   */
+  requests: TransportActionMessageStats
+  /**
+   * Statistics about the responses sent for this action.
+   */
+  responses: TransportActionMessageStats
+}
+
+export class TransportActionMessageStats {
+  /**
+   * The number of messages of this kind that the node has handled for this action.
+   */
+  count: long
+  /**
+   * The cumulative size of the messages of this kind that the node has handled for this action.
+   */
+  total_size?: ByteSize
+  /**
+   * The cumulative size, in bytes, of the messages of this kind that the node has handled for this action.
+   */
+  total_size_in_bytes?: long
+  /**
+   * The distribution of the sizes of the messages of this kind that the node has handled for this action, represented as a histogram.
+   */
+  histogram: TransportMessageSizeHistogramBucket[]
+}
+
+export class TransportMessageSizeHistogramBucket {
+  /**
+   * The number of messages with a size that falls within the bounds of this bucket.
+   */
+  count: long
+  /**
+   * The inclusive lower bound of the bucket.
+   * May be omitted on the first bucket if this bucket has no lower bound.
+   */
+  ge?: ByteSize
+  /**
+   * The inclusive lower bound of the bucket in bytes.
+   * May be omitted on the first bucket if this bucket has no lower bound.
+   */
+  ge_bytes?: long
+  /**
+   * The exclusive upper bound of the bucket.
+   * May be omitted on the last bucket if this bucket has no upper bound.
+   */
+  lt?: ByteSize
+  /**
+   * The exclusive upper bound of the bucket in bytes.
+   * May be omitted on the last bucket if this bucket has no upper bound.
+   */
+  lt_bytes?: long
 }
 
 export class TransportHistogram {
@@ -1201,10 +1465,19 @@ export class TransportHistogram {
    */
   count?: long
   /**
+   * The exclusive upper bound of the bucket.
+   * May be omitted on the last bucket if this bucket has no upper bound.
+   */
+  lt?: Duration
+  /**
    * The exclusive upper bound of the bucket in milliseconds.
    * May be omitted on the last bucket if this bucket has no upper bound.
    */
   lt_millis?: long
+  /**
+   * The inclusive lower bound of the bucket. May be omitted on the first bucket if this bucket has no lower bound.
+   */
+  ge?: Duration
   /**
    * The inclusive lower bound of the bucket in milliseconds. May be omitted on the first bucket if this bucket has no lower bound.
    */


### PR DESCRIPTION
Looks like a lot, but it's straightforward to verify: 

- Every class in the specification/_types/Stats.ts files has the same name in the server code.
- DenseVectorOffHeapStats just had typos
- In specification/indices/stats/types.ts: 
    - MappingStats is [NodeMappingStats](https://github.com/elastic/elasticsearch/blob/0cd9c72199e3b665be6e816993647439e962ee21/server/src/main/java/org/elasticsearch/index/mapper/NodeMappingStats.java#L27) 

    - ShardStats is [CommonStats](https://github.com/elastic/elasticsearch/blob/80d6866608449c9e79879fd8fd6efae971420cfc/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java#L121) 
    - Proof that indices in SharedStats is a [map](https://github.com/elastic/elasticsearch/blob/63647a8ed33af0fe7f15f6b553696ba0039c28c8/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java#L276)

    - ShardQueryCache is [QueryCacheStats](https://github.com/elastic/elasticsearch/blob/a59c182f9f7e9d1bf3d6eecbc0e44f24ff91d053/server/src/main/java/org/elasticsearch/index/cache/query/QueryCacheStats.java#L142) 

- In specification/nodes/_types/Stats.ts, `repository` is a map because of [RepositoriesStats](https://github.com/elastic/elasticsearch/blob/b6c748f9c227bc6eaa3af50bd0e87e8c1cdd9452/server/src/main/java/org/elasticsearch/repositories/RepositoriesStats.java#L111), and the fields are mapped [here](https://github.com/elastic/elasticsearch/blob/b6c748f9c227bc6eaa3af50bd0e87e8c1cdd9452/server/src/main/java/org/elasticsearch/repositories/RepositoriesStats.java#L111)