### PR TITLE
6366 followup - add mapping to esql dataset

### DIFF
--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -59,6 +59,65 @@ export class ClassifiedNamedParameter {
 }
 
 /**
+ * A user-declared mapping (the `mappings` block) attached to a dataset.
+ * It is entirely optional: a dataset with no declared mapping relies on inference.
+ */
+export class DatasetMapping {
+  /**
+   * The policy for columns that are not declared in `properties`.
+   * `true` (the default) infers undeclared columns and overlays the declarations; `false` makes the declaration the entire schema, so undeclared columns are not queryable.
+   * @server_default true
+   */
+  dynamic?: Dynamic
+  /**
+   * The per-column declarations, keyed by logical column name.
+   */
+  properties?: Dictionary<string, DatasetFieldMapping>
+  /**
+   * The `_id` meta-field configuration, sourcing the document identity from a column.
+   */
+  _id?: IdPath
+}
+
+/**
+ * The undeclared-column policy for a dataset mapping.
+ * Only the two read-applicable values are supported.
+ */
+export enum Dynamic {
+  true,
+  false
+}
+
+/**
+ * The `_id` meta-field of a dataset mapping.
+ */
+export class IdPath {
+  /**
+   * The name of the column that provides the document identity.
+   */
+  path: string
+}
+
+/**
+ * A per-column declaration inside a dataset mapping's `properties`.
+ */
+export class DatasetFieldMapping {
+  /**
+   * The declared column type.
+   */
+  type: string
+  /**
+   * The underlying file column that this logical column reads from.
+   * This is a read-path rename: the physical column becomes this single logical column.
+   */
+  path?: string
+  /**
+   * The date-parse pattern for a declared `date` column, mirroring the index date-field `format`.
+   */
+  format?: string
+}
+
+/**
  *
  * A non-materialized ES|QL view.
  *
@@ -107,6 +166,10 @@ export class ESQLDataset {
    * The accepted keys depend on the format reader; compression can be inferred from the resource URI.
    */
   settings?: Dictionary<string, UserDefinedValue>
+  /**
+   * The user-declared mapping on the dataset definition.
+   */
+  mappings?: DatasetMapping
 }
 
 /**

--- a/specification/esql/put_dataset/PutDatasetRequest.ts
+++ b/specification/esql/put_dataset/PutDatasetRequest.ts
@@ -22,6 +22,7 @@ import { MediaType, Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { DatasetMapping } from '@esql/_types/types'
 
 /**
  * Create or replace an ES|QL dataset.
@@ -71,6 +72,8 @@ export interface Request extends RequestBase {
     resource: string
     /** A free-text description of the dataset. */
     description?: string
+    /** User-declared mapping on the dataset definition */
+    mappings?: DatasetMapping
     /**
      * Format and parsing-specific settings that configure how the resource is read.
      * The accepted keys depend on the format reader; compression can be inferred from the resource URI.

--- a/specification/esql/put_dataset/PutDatasetRequest.ts
+++ b/specification/esql/put_dataset/PutDatasetRequest.ts
@@ -20,9 +20,9 @@
 import { RequestBase } from '@_types/Base'
 import { MediaType, Name } from '@_types/common'
 import { Duration } from '@_types/Time'
+import { DatasetMapping } from '@esql/_types/types'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { DatasetMapping } from '@esql/_types/types'
 
 /**
  * Create or replace an ES|QL dataset.


### PR DESCRIPTION
To be merged after #6366, [this](https://github.com/elastic/elasticsearch-specification/pull/6472/changes/d27cea96e2e00a0ea067ee854957d535a601146d) is the relevant commit. Addresses https://github.com/elastic/elasticsearch/pull/152473, but also https://github.com/elastic/elasticsearch/pull/153379 (it's easier just to check the current 9.5 code).
Relevant code:

- [DatasetMapping](https://github.com/elastic/elasticsearch/blob/95b9e5c1fc6e3d61be3976830511d00860dd760c/server/src/main/java/org/elasticsearch/cluster/metadata/DatasetMapping.java#L184) 
- In [PutDataset](https://github.com/elastic/elasticsearch/blob/60d0b143ebb7098c906f47a6391d80c79be67a80/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/PutDatasetAction.java#L56)
- In [GetDataset](https://github.com/elastic/elasticsearch/blob/95b9e5c1fc6e3d61be3976830511d00860dd760c/server/src/main/java/org/elasticsearch/cluster/metadata/Dataset.java#L54) 
