### PR TITLE
fix: add @codegen_name `timestamp` to `@timestamp` field in watcher.execute_watch

### DIFF
--- a/specification/watcher/execute_watch/types.ts
+++ b/specification/watcher/execute_watch/types.ts
@@ -29,6 +29,7 @@ import { TriggerEventResult } from '@watcher/_types/Trigger'
 import { WatchStatus } from '@watcher/_types/Watch'
 
 export class WatchRecord {
+  /** @codegen_name timestamp */
   '@timestamp': DateTime
   node: string
   state: ExecutionStatus


### PR DESCRIPTION
As titled

<!-- Hello there! Thank you for opening a pull request. See CONTRIBUTING.md for instructions. -->
