### PR TITLE
Codegen name for _slice

### DIFF
--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -205,6 +205,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/count/CountRequest.ts
+++ b/specification/_global/count/CountRequest.ts
@@ -153,6 +153,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/delete/DeleteRequest.ts
+++ b/specification/_global/delete/DeleteRequest.ts
@@ -125,6 +125,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -244,6 +244,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -99,6 +99,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -150,6 +150,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/index/IndexRequest.ts
+++ b/specification/_global/index/IndexRequest.ts
@@ -239,6 +239,7 @@ export interface Request<TDocument> extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -99,6 +99,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -167,6 +167,7 @@ export interface Request extends RequestBase {
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * Individual sub-search headers can also specify `_slice` to override the top-level setting.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -72,6 +72,7 @@ export class MultisearchHeader {
    * Use the special value `_all` to query all slices without restricting to a routing value.
    * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
    * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+   * @codegen_name route_slice
    */
   _slice?: string
 }

--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -119,6 +119,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/reindex/types.ts
+++ b/specification/_global/reindex/types.ts
@@ -66,6 +66,7 @@ export class Destination {
    * Use the special value `_all` to target all slices without restricting to a routing value.
    * Required when `index.slice.enabled` is `true` for the destination index; not allowed when `index.slice.enabled` is `false`.
    * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+   * @codegen_name route_slice
    */
   _slice?: string
   /**

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -245,6 +245,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/search_shards/SearchShardsRequest.ts
+++ b/specification/_global/search_shards/SearchShardsRequest.ts
@@ -109,6 +109,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to query all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
   }

--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -157,6 +157,7 @@ export interface Request<TDocument> extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -133,6 +133,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -258,6 +258,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
     /**

--- a/specification/indices/validate_query/IndicesValidateQueryRequest.ts
+++ b/specification/indices/validate_query/IndicesValidateQueryRequest.ts
@@ -133,6 +133,7 @@ export interface Request extends RequestBase {
      * Use the special value `_all` to target all slices without restricting to a routing value.
      * Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
      * @availability stack since=9.5.0 visibility=feature_flag feature_flag=slice_indexing
+     * @codegen_name route_slice
      */
     _slice?: string
   }


### PR DESCRIPTION
Followup of https://github.com/elastic/elasticsearch-specification/pull/6427. The new `_slice` parameter clashes with the old `slice` in 3 classes (SearchRequest, DeleteByQueryRequest, UpdateByQueryRequest) because some of the language clients remove underscores, or convert snake case to camel case. Adding a `@codegen_name` annotation to rename it to `route_slice` in all its occurrences.
