### PR TITLE
Fix ES|QL data federation documentation URLs

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -243,12 +243,12 @@ esql-list-queries,https://www.elastic.co/docs/api/doc/elasticsearch/operation/op
 esql-get-view,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
 esql-put-view,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
 esql-delete-view,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
-esql-put-data-source,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
-esql-get-data-source,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
-esql-delete-data-source,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
-esql-put-dataset,https://www.elastic.co/docs/api/doc/elasticsearch/operation#TODO,[use-doc-url],,About Elasticsearch API
-esql-get-dataset,https://www.elastic.co/docs/api/doc/elasticsearch/operation#TODO,[use-doc-url],,About Elasticsearch API
-esql-delete-dataset,https://www.elastic.co/docs/api/doc/elasticsearch#TODO,[use-doc-url],,About Elasticsearch API
+esql-put-data-source,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-put-data-source,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-esql-put-data-source,,About Elasticsearch API
+esql-get-data-source,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-get-data-source,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-esql-get-data-source,,About Elasticsearch API
+esql-delete-data-source,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-delete-data-source,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-esql-delete-data-source,,About Elasticsearch API
+esql-put-dataset,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-put-dataset,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-esql-put-dataset,,About Elasticsearch API
+esql-get-dataset,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-get-dataset,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-esql-get-dataset,,About Elasticsearch API
+esql-delete-dataset,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-delete-dataset,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-esql-delete-dataset,,About Elasticsearch API
 evaluate-dfanalytics,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-evaluate-data-frame,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-ml-evaluate-data-frame,https://www.elastic.co/guide/en/elasticsearch/reference/8.19/evaluate-dfanalytics.html,About evaluating data frame
 execute-enrich-policy-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-execute-policy,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-enrich-execute-policy,https://www.elastic.co/guide/en/elasticsearch/reference/8.19/execute-enrich-policy-api.html,About running an enrich policy
 execute-watch,https://www.elastic.co/docs/explore-analyze/alerts-cases/watcher/execute-watch,[use-doc-url],https://www.elastic.co/guide/en/elasticsearch/reference/8.19/watcher-api-execute-watch.html,More about executing a watch


### PR DESCRIPTION
Replaces the six placeholder ES|QL data federation documentation URLs with their canonical Stack and Serverless operation URLs. This unblocks the generated Kibana Console definitions in elastic/kibana#279704.

follow-up to https://github.com/elastic/elasticsearch-specification/pull/6497 and https://github.com/elastic/elasticsearch-specification/pull/6366 
