### PR TITLE
Generate C# language examples via the .NET request converter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ overlay-docs: ## Apply overlays to OpenAPI documents
 	rm output/openapi/elasticsearch-openapi-docs.tmp*.json
 
 generate-language-examples:
-	@npm update --prefix docs/examples @elastic/request-converter
+	@npm update --prefix docs/examples @elastic/request-converter @elastic/request-converter-dotnet
 	@node docs/examples/generate-language-examples.js
 	@npm run format:fix-examples --prefix compiler
 

--- a/docs/examples/generate-language-examples.js
+++ b/docs/examples/generate-language-examples.js
@@ -24,7 +24,14 @@ const { convertRequests, loadSchema } = require('@elastic/request-converter');
 const {parseRequest} = require("@elastic/request-converter/dist/parse");
 const {JavaCaller} = require("java-caller");
 
-const LANGUAGES = ['Python', 'JavaScript', 'Ruby', 'PHP', 'curl'];
+const LANGUAGES = ['Python', 'JavaScript', 'Ruby', 'PHP', 'curl', 'C#'];
+
+// The C# converter runs out of process in a .NET WASM bundle and has known
+// endpoint-coverage gaps; a failed conversion skips that language for the
+// example instead of aborting the whole run.
+const BEST_EFFORT_LANGUAGES = new Set(['C#']);
+const conversionFailures = [];
+
 const EXAMPLES_JSON = 'docs/examples/languageExamples.json';
 let languageExamples = {};
 
@@ -46,10 +53,17 @@ async function generateLanguages(example) {
   }
   let alternatives = [];
   for (const lang of LANGUAGES) {
-    alternatives.push({
-      language: lang,
-      code: (await convertRequests(request, lang, {})).trim(),
-    });
+    try {
+      alternatives.push({
+        language: lang,
+        code: (await convertRequests(request, lang, {})).trim(),
+      });
+    } catch (err) {
+      if (!BEST_EFFORT_LANGUAGES.has(lang)) {
+        throw err;
+      }
+      conversionFailures.push({ example, lang, message: err.message });
+    }
   }
   alternatives = alternatives.concat((languageExamples[example] ?? []).filter(pair => !LANGUAGES.includes(pair.language)));
 
@@ -149,6 +163,12 @@ async function main() {
   }
   await fs.promises.writeFile(EXAMPLES_JSON, JSON.stringify(languageExamples, null, 2));
   console.log(`${count} examples processed, ${errors} errors.`);
+  if (conversionFailures.length > 0) {
+    console.log(`\n${conversionFailures.length} best-effort conversions skipped:`);
+    for (const failure of conversionFailures) {
+      console.log(`  [${failure.lang}] ${failure.example}: ${failure.message}`);
+    }
+  }
 }
 
 main();

--- a/docs/examples/package.json
+++ b/docs/examples/package.json
@@ -3,7 +3,8 @@
     "transform-to-openapi": "npm run transform-to-openapi --prefix compiler --"
   },
   "dependencies": {
-    "@elastic/request-converter": "^9.1.2",
+    "@elastic/request-converter": "~9.4.1",
+    "@elastic/request-converter-dotnet": "~9.4.0",
     "@redocly/cli": "^1.34.5",
     "yaml": "^2.8.0",
     "java-caller": "^4.1.1"


### PR DESCRIPTION
## Summary

Wires C# into the language-examples generation, side by side with Python, JavaScript, Ruby, PHP, curl, and Java. `docs/examples/generate-language-examples.js` converts request examples to C# through `@elastic/request-converter`'s new `csharp` format (elastic/request-converter#107), backed by the `@elastic/request-converter-dotnet` WASM bundle (elastic/elasticsearch-net#8931). The regenerated `languageExamples.json` is deliberately not part of this PR; the C# entries land in a follow-up once the converter packages are published.

## Changes

- `'C#'` added to `LANGUAGES`. C# conversion is best-effort: a failed conversion skips that example's C# entry and is reported in an end-of-run summary instead of aborting, because the .NET converter has known endpoint coverage gaps. The other languages keep their fail-fast behavior.
- `@elastic/request-converter-dotnet` (`~9.5.0`) added to `docs/examples/package.json`; the Makefile's `generate-language-examples` target updates it together with `@elastic/request-converter`.

## Notes

- There is no CI automation for `languageExamples.json`: the `generate.yml` workflow rebuilds `output/` but never runs `generate-language-examples`, which remains a manual Makefile target. A full local dry run against locally built converter packages converted 649 of 761 request examples (112 skipped: 96 unsupported endpoints, 16 conversion issues); generated examples use fluent descriptor syntax with an illustrative `MyDocument` document type.
- `package-lock.json` is intentionally untouched: the dotnet package is published from elastic/elasticsearch-net#8931, and the lockfile refresh must follow the first publish.