### PR TITLE
Mark ES|QL data federation APIs as internal

### DIFF
--- a/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
+++ b/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.delete_data_source
  * @cluster_privileges manage
- * @availability stack stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=private
  * @ext_doc_id esql-data-federation
  * @doc_id esql-delete-data-source
  */

--- a/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
+++ b/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
@@ -30,8 +30,8 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.delete_data_source
  * @cluster_privileges manage
- * @availability stack since=9.5.0 stability=tech_preview visibility=public
- * @availability serverless stability=tech_preview visibility=public
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-delete-data-source
  */

--- a/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
+++ b/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
@@ -31,7 +31,6 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name esql.delete_data_source
  * @cluster_privileges manage
  * @availability stack since=9.5.0 stability=experimental visibility=public
- * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-delete-data-source
  */

--- a/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
+++ b/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.delete_data_source
  * @cluster_privileges manage
- * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-delete-data-source
  */

--- a/specification/esql/delete_dataset/DeleteDatasetRequest.ts
+++ b/specification/esql/delete_dataset/DeleteDatasetRequest.ts
@@ -29,7 +29,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.delete_dataset
  * @index_privileges manage
- * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-delete-dataset
  */

--- a/specification/esql/delete_dataset/DeleteDatasetRequest.ts
+++ b/specification/esql/delete_dataset/DeleteDatasetRequest.ts
@@ -30,7 +30,6 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name esql.delete_dataset
  * @index_privileges manage
  * @availability stack since=9.5.0 stability=experimental visibility=public
- * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-delete-dataset
  */

--- a/specification/esql/delete_dataset/DeleteDatasetRequest.ts
+++ b/specification/esql/delete_dataset/DeleteDatasetRequest.ts
@@ -29,7 +29,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.delete_dataset
  * @index_privileges manage
- * @availability stack stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=private
  * @ext_doc_id esql-data-federation
  * @doc_id esql-delete-dataset
  */

--- a/specification/esql/delete_dataset/DeleteDatasetRequest.ts
+++ b/specification/esql/delete_dataset/DeleteDatasetRequest.ts
@@ -29,8 +29,8 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.delete_dataset
  * @index_privileges manage
- * @availability stack since=9.5.0 stability=tech_preview visibility=public
- * @availability serverless stability=tech_preview visibility=public
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-delete-dataset
  */

--- a/specification/esql/get_data_source/GetDataSourceRequest.ts
+++ b/specification/esql/get_data_source/GetDataSourceRequest.ts
@@ -31,7 +31,6 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name esql.get_data_source
  * @cluster_privileges manage
  * @availability stack since=9.5.0 stability=experimental visibility=public
- * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-get-data-source
  */

--- a/specification/esql/get_data_source/GetDataSourceRequest.ts
+++ b/specification/esql/get_data_source/GetDataSourceRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.get_data_source
  * @cluster_privileges manage
- * @availability stack stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=private
  * @ext_doc_id esql-data-federation
  * @doc_id esql-get-data-source
  */

--- a/specification/esql/get_data_source/GetDataSourceRequest.ts
+++ b/specification/esql/get_data_source/GetDataSourceRequest.ts
@@ -30,8 +30,8 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.get_data_source
  * @cluster_privileges manage
- * @availability stack since=9.5.0 stability=tech_preview visibility=public
- * @availability serverless stability=tech_preview visibility=public
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-get-data-source
  */

--- a/specification/esql/get_data_source/GetDataSourceRequest.ts
+++ b/specification/esql/get_data_source/GetDataSourceRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.get_data_source
  * @cluster_privileges manage
- * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-get-data-source
  */

--- a/specification/esql/get_dataset/GetDatasetRequest.ts
+++ b/specification/esql/get_dataset/GetDatasetRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.get_dataset
  * @index_privileges manage
- * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-get-dataset
  */

--- a/specification/esql/get_dataset/GetDatasetRequest.ts
+++ b/specification/esql/get_dataset/GetDatasetRequest.ts
@@ -31,7 +31,6 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name esql.get_dataset
  * @index_privileges manage
  * @availability stack since=9.5.0 stability=experimental visibility=public
- * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-get-dataset
  */

--- a/specification/esql/get_dataset/GetDatasetRequest.ts
+++ b/specification/esql/get_dataset/GetDatasetRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.get_dataset
  * @index_privileges manage
- * @availability stack stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=private
  * @ext_doc_id esql-data-federation
  * @doc_id esql-get-dataset
  */

--- a/specification/esql/get_dataset/GetDatasetRequest.ts
+++ b/specification/esql/get_dataset/GetDatasetRequest.ts
@@ -30,8 +30,8 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.get_dataset
  * @index_privileges manage
- * @availability stack since=9.5.0 stability=tech_preview visibility=public
- * @availability serverless stability=tech_preview visibility=public
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-get-dataset
  */

--- a/specification/esql/put_data_source/PutDataSourceRequest.ts
+++ b/specification/esql/put_data_source/PutDataSourceRequest.ts
@@ -32,7 +32,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  *
  * @rest_spec_name esql.put_data_source
  * @cluster_privileges manage
- * @availability stack stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=private
  * @ext_doc_id esql-data-federation
  * @doc_id esql-put-data-source
  */

--- a/specification/esql/put_data_source/PutDataSourceRequest.ts
+++ b/specification/esql/put_data_source/PutDataSourceRequest.ts
@@ -33,7 +33,6 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * @rest_spec_name esql.put_data_source
  * @cluster_privileges manage
  * @availability stack since=9.5.0 stability=experimental visibility=public
- * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-put-data-source
  */

--- a/specification/esql/put_data_source/PutDataSourceRequest.ts
+++ b/specification/esql/put_data_source/PutDataSourceRequest.ts
@@ -32,8 +32,8 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  *
  * @rest_spec_name esql.put_data_source
  * @cluster_privileges manage
- * @availability stack since=9.5.0 stability=tech_preview visibility=public
- * @availability serverless stability=tech_preview visibility=public
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-put-data-source
  */

--- a/specification/esql/put_data_source/PutDataSourceRequest.ts
+++ b/specification/esql/put_data_source/PutDataSourceRequest.ts
@@ -32,7 +32,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  *
  * @rest_spec_name esql.put_data_source
  * @cluster_privileges manage
- * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-put-data-source
  */

--- a/specification/esql/put_dataset/PutDatasetRequest.ts
+++ b/specification/esql/put_dataset/PutDatasetRequest.ts
@@ -33,7 +33,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  *
  * @rest_spec_name esql.put_dataset
  * @index_privileges manage
- * @availability stack stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=private
  * @ext_doc_id esql-data-federation
  * @doc_id esql-put-dataset
  */

--- a/specification/esql/put_dataset/PutDatasetRequest.ts
+++ b/specification/esql/put_dataset/PutDatasetRequest.ts
@@ -33,8 +33,8 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  *
  * @rest_spec_name esql.put_dataset
  * @index_privileges manage
- * @availability stack since=9.5.0 stability=tech_preview visibility=public
- * @availability serverless stability=tech_preview visibility=public
+ * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-put-dataset
  */

--- a/specification/esql/put_dataset/PutDatasetRequest.ts
+++ b/specification/esql/put_dataset/PutDatasetRequest.ts
@@ -33,7 +33,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  *
  * @rest_spec_name esql.put_dataset
  * @index_privileges manage
- * @availability stack since=9.5.0 stability=experimental visibility=public
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-put-dataset
  */

--- a/specification/esql/put_dataset/PutDatasetRequest.ts
+++ b/specification/esql/put_dataset/PutDatasetRequest.ts
@@ -34,7 +34,6 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * @rest_spec_name esql.put_dataset
  * @index_privileges manage
  * @availability stack since=9.5.0 stability=experimental visibility=public
- * @availability serverless stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-put-dataset
  */


### PR DESCRIPTION
Marks the Stack ES|QL data source and dataset APIs as internal. These APIs are excluded from public Stack and all Serverless outputs.