### PR TITLE
Tighten up definitions of snapshot status

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -132488,7 +132488,7 @@
             "type": "string"
           },
           "state": {
-            "description": "The current snapshot state:\n\n* `FAILED`: The snapshot finished with an error and failed to store any data.\n* `STARTED`: The snapshot is currently running.\n* `SUCCESS`: The snapshot completed.",
+            "description": "The current snapshot state:\n\n* `STARTED`: The snapshot is currently running.\n* `SUCCESS`: All shard snapshots have completed. The snapshot may or may not have completed finalization.\n* `FAILED`: The snapshot finished with an error and failed to store any data.",
             "type": "string"
           },
           "stats": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -278002,7 +278002,7 @@
           }
         },
         {
-          "description": "The current snapshot state:\n\n* `FAILED`: The snapshot finished with an error and failed to store any data.\n* `STARTED`: The snapshot is currently running.\n* `SUCCESS`: The snapshot completed.",
+          "description": "The current snapshot state:\n\n* `STARTED`: The snapshot is currently running.\n* `SUCCESS`: All shard snapshots have completed. The snapshot may or may not have completed finalization.\n* `FAILED`: The snapshot finished with an error and failed to store any data.",
           "name": "state",
           "required": true,
           "type": {

--- a/specification/snapshot/_types/SnapshotStatus.ts
+++ b/specification/snapshot/_types/SnapshotStatus.ts
@@ -44,9 +44,9 @@ export class Status {
   /**
    * The current snapshot state:
    *
-   * * `FAILED`: The snapshot finished with an error and failed to store any data.
    * * `STARTED`: The snapshot is currently running.
-   * * `SUCCESS`: The snapshot completed.
+   * * `SUCCESS`: All shard snapshots have completed. The snapshot may or may not have completed finalization.
+   * * `FAILED`: The snapshot finished with an error and failed to store any data.
    */
   state: string
   /**


### PR DESCRIPTION
This API has (confusingly) always returned `SUCCESS` when the snapshot
is awaiting finalization. Fixing this would be a breaking change but we
can at least clarify the docs in this area.