### PR TITLE
Add automated language examples update workflow

### DIFF
--- a/.github/workflows/update-language-examples.yml
+++ b/.github/workflows/update-language-examples.yml
@@ -1,0 +1,55 @@
+name: Update language examples
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Scheduled runs always execute on the default branch (main). Version
+    # branches (e.g. 9.4) must be updated by manually dispatching this
+    # workflow from the respective branch.
+    - cron: '0 4 * * 1' # Weekly, Monday at 04:00 UTC.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-language-examples:
+    name: Update language examples
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'elastic'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install dependencies
+        run: |
+          npm install --prefix docs/examples
+          npm install --prefix compiler
+
+      - name: Generate language examples
+        run: |
+          make generate-language-examples
+
+      - name: Debug git status
+        run: |
+          git status --porcelain
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: Update language examples (${{ github.ref_name }})
+          body: >-
+            Automated update of the request converter language examples for
+            branch `${{ github.ref_name }}`.
+          commit-message: Update language examples
+          labels: specification,skip-backport
+          delete-branch: true
+          reviewers: Anaethelion,ezimuel,flobernd,JoshMock,l-trotta,miguelgrinberg,picandocodigo
+          branch: automated/update-language-examples-${{ github.ref_name }}

--- a/.github/workflows/update-language-examples.yml
+++ b/.github/workflows/update-language-examples.yml
@@ -51,5 +51,5 @@ jobs:
           commit-message: Update language examples
           labels: specification,skip-backport
           delete-branch: true
-          reviewers: Anaethelion,ezimuel,flobernd,JoshMock,l-trotta,miguelgrinberg,picandocodigo
+          reviewers: Anaethelion,flobernd,JoshMock,l-trotta
           branch: automated/update-language-examples-${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Adds a workflow that automates regenerating the request converter language examples (`make generate-language-examples`) and opens a PR with the result.

- Runs on a weekly schedule (Mondays 04:00 UTC), which by GitHub design only executes on `main`.
- Can be manually dispatched from any branch; the resulting PR targets the branch it was dispatched from (e.g. dispatch from `9.4` opens a PR against `9.4`).
- A PR is only created when the regeneration actually produced changes (default `peter-evans/create-pull-request` behavior).
- The `npm update` inside the make target picks up new `@elastic/request-converter` / `@elastic/request-converter-dotnet` releases within each branch's semver range, so weekly/dispatched runs automatically use the latest converter for that branch.

Backport labels target `8.19`, `9.4` and `9.5` so version branches can be updated via manual dispatch.
