### PR TITLE
Regenerate language examples

### DIFF
--- a/docs/examples/languageExamples.json
+++ b/docs/examples/languageExamples.json
@@ -21,6 +21,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_xpack/usage\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Xpack.UsageAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.xpack().usage(u -> u);\n"
     }
@@ -45,6 +49,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_xpack\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Xpack.InfoAsync();"
     },
     {
       "language": "Java",
@@ -184,19 +192,19 @@
   "specification/cat/pending_tasks/examples/request/CatPendingTasksRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.cat.pending_tasks(\n    v=\"true&h=insertOrder,timeInQueue,priority,source\",\n    format=\"json\",\n)"
+      "code": "resp = client.cat.pending_tasks(\n    v=True,\n    h=\"insertOrder,timeInQueue,priority,source\",\n    format=\"json\",\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.cat.pendingTasks({\n  v: \"true&h=insertOrder,timeInQueue,priority,source\",\n  format: \"json\",\n});"
+      "code": "const response = await client.cat.pendingTasks({\n  v: \"true\",\n  h: \"insertOrder,timeInQueue,priority,source\",\n  format: \"json\",\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.cat.pending_tasks(\n  v: \"true&h=insertOrder,timeInQueue,priority,source\",\n  format: \"json\"\n)"
+      "code": "response = client.cat.pending_tasks(\n  v: \"true\",\n  h: \"insertOrder,timeInQueue,priority,source\",\n  format: \"json\"\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->cat()->pendingTasks([\n    \"v\" => \"true&h=insertOrder,timeInQueue,priority,source\",\n    \"format\" => \"json\",\n]);"
+      "code": "$resp = $client->cat()->pendingTasks([\n    \"v\" => \"true\",\n    \"h\" => \"insertOrder,timeInQueue,priority,source\",\n    \"format\" => \"json\",\n]);"
     },
     {
       "language": "curl",
@@ -723,6 +731,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_searchable_snapshots/cache/stats\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SearchableSnapshots.CacheStatsAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.searchableSnapshots().cacheStats(c -> c);\n"
     }
@@ -747,6 +759,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index/_searchable_snapshots/cache/clear\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.SearchableSnapshots\n    .ClearCacheAsync(d1 => d1\n        .Indices(new[] { \"my-index\" })\n    );"
     },
     {
       "language": "Java",
@@ -775,6 +791,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"my_docs\",\"renamed_index\":\"docs\",\"index_settings\":{\"index.number_of_replicas\":0},\"ignore_index_settings\":[\"index.refresh_interval\"]}' \"$ELASTICSEARCH_URL/_snapshot/my_repository/my_snapshot/_mount?wait_for_completion=true\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SearchableSnapshots\n    .MountAsync(repository: \"my_repository\", snapshot: \"my_snapshot\", d1 => d1\n        .WaitForCompletion(true)\n        .IgnoreIndexSettings(\"index.refresh_interval\")\n        .Index(\"my_docs\")\n        .IndexSettings(new Dictionary<string, object>()\n        {\n            { \"index.number_of_replicas\", 0 }\n        })\n        .RenamedIndex(\"docs\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.searchableSnapshots().mount(m -> m\n    .ignoreIndexSettings(\"index.refresh_interval\")\n    .index(\"my_docs\")\n    .indexSettings(\"index.number_of_replicas\", JsonData.fromJson(\"0\"))\n    .renamedIndex(\"docs\")\n    .repository(\"my_repository\")\n    .snapshot(\"my_snapshot\")\n    .waitForCompletion(true)\n);\n"
     }
@@ -799,6 +819,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index/_searchable_snapshots/stats\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.SearchableSnapshots\n    .StatsAsync(d1 => d1\n        .Indices(new[] { \"my-index\" })\n    );"
     },
     {
       "language": "Java",
@@ -827,6 +851,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Snapshot.DeleteRepositoryAsync(name: new[] { \"my_repository\" });"
+    },
+    {
       "language": "Java",
       "code": "client.snapshot().deleteRepository(d -> d\n    .name(\"my_repository\")\n);\n"
     }
@@ -851,6 +879,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"s3\",\"settings\":{\"bucket\":\"my-bucket\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_s3_repository\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_s3_repository\", d1 => d1\n        .Repository(new S3Repository()\n        {\n            Settings = new()\n            {\n                Bucket = \"my-bucket\"\n            }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -879,6 +911,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"source\",\"settings\":{\"delegate_type\":\"fs\",\"location\":\"my_backup_repository\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_src_only_repository\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_src_only_repository\", d1 => d1\n        .Repository(new SourceOnlyRepository()\n        {\n            Settings = new()\n            {\n                DelegateType = \"fs\"\n            }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.snapshot().createRepository(c -> c\n    .name(\"my_src_only_repository\")\n    .repository(r -> r\n        .source(s -> s\n            .settings(se -> se\n                .delegateType(\"fs\")\n            )\n        )\n    )\n);\n"
     }
@@ -903,6 +939,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"azure\",\"settings\":{\"client\":\"secondary\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_backup\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_backup\", d1 => d1\n        .Repository(new AzureRepository()\n        {\n            Settings = new()\n            {\n                Client = \"secondary\"\n            }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -931,6 +971,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"gcs\",\"settings\":{\"bucket\":\"my_other_bucket\",\"base_path\":\"dev\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_gcs_repository\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_gcs_repository\", d1 => d1\n        .Repository(new GcsRepository()\n        {\n            Settings = new()\n            {\n                BasePath = \"dev\",\n                Bucket = \"my_other_bucket\"\n            }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.snapshot().createRepository(c -> c\n    .name(\"my_gcs_repository\")\n    .repository(r -> r\n        .gcs(g -> g\n            .settings(s -> s\n                .bucket(\"my_other_bucket\")\n                .basePath(\"dev\")\n            )\n        )\n    )\n);\n"
     }
@@ -955,6 +999,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"fs\",\"settings\":{\"location\":\"my_backup_location\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_repository\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_repository\", d1 => d1\n        .Repository(new SharedFileSystemRepository()\n        {\n            Settings = new()\n            {\n                Location = \"my_backup_location\"\n            }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -983,6 +1031,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"url\",\"settings\":{\"url\":\"file:/mount/backups/my_fs_backup_location\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_read_only_url_repository\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_read_only_url_repository\", d1 => d1\n        .Repository(new ReadOnlyUrlRepository()\n        {\n            Settings = new()\n            {\n                Url = \"file:/mount/backups/my_fs_backup_location\"\n            }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.snapshot().createRepository(c -> c\n    .name(\"my_read_only_url_repository\")\n    .repository(r -> r\n        .url(u -> u\n            .settings(s -> s\n                .url(\"file:/mount/backups/my_fs_backup_location\")\n            )\n        )\n    )\n);\n"
     }
@@ -1007,6 +1059,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_2,snapshot_3\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Snapshot.DeleteAsync(repository: \"my_repository\", snapshot: \"snapshot_2,snapshot_3\");"
     },
     {
       "language": "Java",
@@ -1035,6 +1091,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_unverified_backup/_verify\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Snapshot.VerifyRepositoryAsync(name: \"my_unverified_backup\");"
+    },
+    {
       "language": "Java",
       "code": "client.snapshot().verifyRepository(v -> v\n    .name(\"my_unverified_backup\")\n);\n"
     }
@@ -1059,6 +1119,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_*?sort=start_time&from_sort_value=1577833200000\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .GetAsync(repository: \"my_repository\", snapshot: new[] { \"snapshot_*\" }, d1 => d1\n        .FromSortValue(\"1577833200000\")\n        .Sort(SnapshotSort.StartTime)\n    );"
     },
     {
       "language": "Java",
@@ -1087,6 +1151,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/_analyze?blob_count=10&max_blob_size=1mb&timeout=120s\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .RepositoryAnalyzeAsync(name: \"my_repository\", d1 => d1\n        .BlobCount(10)\n        .MaxBlobSize(new ByteSize(\"1mb\"))\n        .Timeout(\"120s\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.snapshot().repositoryAnalyze(r -> r\n    .blobCount(10)\n    .maxBlobSize(\"1mb\")\n    .name(\"my_repository\")\n    .timeout(t -> t\n        .offset(120)\n    )\n);\n"
     }
@@ -1111,6 +1179,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_2/_status\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .StatusAsync(d1 => d1\n        .Repository(\"my_repository\")\n        .Snapshot(new[] { \"snapshot_2\" })\n    );"
     },
     {
       "language": "Java",
@@ -1139,6 +1211,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/_cleanup\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Snapshot.CleanupRepositoryAsync(name: \"my_repository\");"
+    },
+    {
       "language": "Java",
       "code": "client.snapshot().cleanupRepository(c -> c\n    .name(\"my_repository\")\n);\n"
     }
@@ -1146,11 +1222,11 @@
   "specification/snapshot/repository_verify_integrity/examples/request/SnapshotRepositoryVerifyIntegrityExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.perform_request(\n    \"POST\",\n    \"/_snapshot/my_repository/_verify_integrity\",\n)"
+      "code": "resp = client.snapshot.repository_verify_integrity(\n    name=\"my_repository\",\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.transport.request({\n  method: \"POST\",\n  path: \"/_snapshot/my_repository/_verify_integrity\",\n});"
+      "code": "const response = await client.snapshot.repositoryVerifyIntegrity({\n  name: \"my_repository\",\n});"
     },
     {
       "language": "Ruby",
@@ -1163,6 +1239,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/_verify_integrity\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Snapshot.RepositoryVerifyIntegrityAsync(name: new[] { \"my_repository\" });"
     },
     {
       "language": "Java",
@@ -1191,6 +1271,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":\"index_a,index_b\"}' \"$ELASTICSEARCH_URL/_snapshot/my_repository/source_snapshot/_clone/target_snapshot\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .CloneAsync(repository: \"my_repository\", snapshot: \"source_snapshot\", targetSnapshot: \"target_snapshot\", d1 => d1\n        .Indices(\"index_a,index_b\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.snapshot().clone(c -> c\n    .indices(\"index_a,index_b\")\n    .repository(\"my_repository\")\n    .snapshot(\"source_snapshot\")\n    .targetSnapshot(\"target_snapshot\")\n);\n"
     }
@@ -1217,6 +1301,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .GetRepositoryAsync(d1 => d1\n        .Name(new[] { \"my_repository\" })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.snapshot().getRepository(g -> g\n    .name(\"my_repository\")\n);\n"
     }
@@ -1224,23 +1312,27 @@
   "specification/snapshot/create/examples/request/SnapshotCreateRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.snapshot.create(\n    repository=\"my_repository\",\n    snapshot=\"snapshot_2\",\n    wait_for_completion=True,\n    indices=\"index_1,index_2\",\n    ignore_unavailable=True,\n    include_global_state=False,\n    metadata={\n        \"taken_by\": \"user123\",\n        \"taken_because\": \"backup before upgrading\"\n    },\n)"
+      "code": "resp = client.snapshot.create(\n    repository=\"my_repository\",\n    snapshot=\"snapshot_2\",\n    wait_for_completion=True,\n    partial=True,\n    indices=\"index_1,index_2\",\n    ignore_unavailable=True,\n    include_global_state=False,\n    metadata={\n        \"taken_by\": \"user123\",\n        \"taken_because\": \"backup before upgrading\"\n    },\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.snapshot.create({\n  repository: \"my_repository\",\n  snapshot: \"snapshot_2\",\n  wait_for_completion: \"true\",\n  indices: \"index_1,index_2\",\n  ignore_unavailable: true,\n  include_global_state: false,\n  metadata: {\n    taken_by: \"user123\",\n    taken_because: \"backup before upgrading\",\n  },\n});"
+      "code": "const response = await client.snapshot.create({\n  repository: \"my_repository\",\n  snapshot: \"snapshot_2\",\n  wait_for_completion: \"true\",\n  partial: true,\n  indices: \"index_1,index_2\",\n  ignore_unavailable: true,\n  include_global_state: false,\n  metadata: {\n    taken_by: \"user123\",\n    taken_because: \"backup before upgrading\",\n  },\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.snapshot.create(\n  repository: \"my_repository\",\n  snapshot: \"snapshot_2\",\n  wait_for_completion: \"true\",\n  body: {\n    \"indices\": \"index_1,index_2\",\n    \"ignore_unavailable\": true,\n    \"include_global_state\": false,\n    \"metadata\": {\n      \"taken_by\": \"user123\",\n      \"taken_because\": \"backup before upgrading\"\n    }\n  }\n)"
+      "code": "response = client.snapshot.create(\n  repository: \"my_repository\",\n  snapshot: \"snapshot_2\",\n  wait_for_completion: \"true\",\n  body: {\n    \"partial\": true,\n    \"indices\": \"index_1,index_2\",\n    \"ignore_unavailable\": true,\n    \"include_global_state\": false,\n    \"metadata\": {\n      \"taken_by\": \"user123\",\n      \"taken_because\": \"backup before upgrading\"\n    }\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->snapshot()->create([\n    \"repository\" => \"my_repository\",\n    \"snapshot\" => \"snapshot_2\",\n    \"wait_for_completion\" => \"true\",\n    \"body\" => [\n        \"indices\" => \"index_1,index_2\",\n        \"ignore_unavailable\" => true,\n        \"include_global_state\" => false,\n        \"metadata\" => [\n            \"taken_by\" => \"user123\",\n            \"taken_because\" => \"backup before upgrading\",\n        ],\n    ],\n]);"
+      "code": "$resp = $client->snapshot()->create([\n    \"repository\" => \"my_repository\",\n    \"snapshot\" => \"snapshot_2\",\n    \"wait_for_completion\" => \"true\",\n    \"body\" => [\n        \"partial\" => true,\n        \"indices\" => \"index_1,index_2\",\n        \"ignore_unavailable\" => true,\n        \"include_global_state\" => false,\n        \"metadata\" => [\n            \"taken_by\" => \"user123\",\n            \"taken_because\" => \"backup before upgrading\",\n        ],\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":\"index_1,index_2\",\"ignore_unavailable\":true,\"include_global_state\":false,\"metadata\":{\"taken_by\":\"user123\",\"taken_because\":\"backup before upgrading\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_2?wait_for_completion=true\""
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"partial\":true,\"indices\":\"index_1,index_2\",\"ignore_unavailable\":true,\"include_global_state\":false,\"metadata\":{\"taken_by\":\"user123\",\"taken_because\":\"backup before upgrading\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_2?wait_for_completion=true\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .CreateAsync(repository: \"my_repository\", snapshot: \"snapshot_2\", d1 => d1\n        .WaitForCompletion(true)\n        .IgnoreUnavailable(true)\n        .IncludeGlobalState(false)\n        .Indices(new[] { \"index_1,index_2\" })\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"taken_by\", \"user123\" },\n            { \"taken_because\", \"backup before upgrading\" }\n        })\n        .Partial(true)\n    );"
     },
     {
       "language": "Java",
@@ -1269,6 +1361,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":\"index_1\"}' \"$ELASTICSEARCH_URL/_cluster/settings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Cluster.PutSettingsAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.cluster().putSettings();\n"
     }
@@ -1293,6 +1389,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":\"index_1,index_2\",\"ignore_unavailable\":true,\"include_global_state\":false,\"rename_pattern\":\"index_(.+)\",\"rename_replacement\":\"restored_index_$1\",\"include_aliases\":false}' \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_2/_restore?wait_for_completion=true\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Snapshot\n    .RestoreAsync(repository: \"my_repository\", snapshot: \"snapshot_2\", d1 => d1\n        .WaitForCompletion(true)\n        .IgnoreUnavailable(true)\n        .IncludeAliases(false)\n        .IncludeGlobalState(false)\n        .Indices(new[] { \"index_1,index_2\" })\n        .RenamePattern(\"index_(.+)\")\n        .RenameReplacement(\"restored_index_$1\")\n    );"
     },
     {
       "language": "Java",
@@ -1321,6 +1421,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_component_template/template_1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Cluster.DeleteComponentTemplateAsync(name: new[] { \"template_1\" });"
+    },
+    {
       "language": "Java",
       "code": "client.cluster().deleteComponentTemplate(d -> d\n    .name(\"template_1\")\n);\n"
     }
@@ -1347,6 +1451,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cluster/pending_tasks\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Cluster.PendingTasksAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.cluster().pendingTasks(p -> p);\n"
     }
@@ -1354,23 +1462,27 @@
   "specification/cluster/put_component_template/examples/request/ClusterPutComponentTemplateRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.cluster.put_component_template(\n    name=\"template_1\",\n    template=None,\n    settings={\n        \"number_of_shards\": 1\n    },\n    mappings={\n        \"_source\": {\n            \"enabled\": False\n        },\n        \"properties\": {\n            \"host_name\": {\n                \"type\": \"keyword\"\n            },\n            \"created_at\": {\n                \"type\": \"date\",\n                \"format\": \"EEE MMM dd HH:mm:ss Z yyyy\"\n            }\n        }\n    },\n)"
+      "code": "resp = client.cluster.put_component_template(\n    name=\"template_1\",\n    template={\n        \"settings\": {\n            \"number_of_shards\": 1\n        },\n        \"mappings\": {\n            \"_source\": {\n                \"enabled\": False\n            },\n            \"properties\": {\n                \"host_name\": {\n                    \"type\": \"keyword\"\n                },\n                \"created_at\": {\n                    \"type\": \"date\",\n                    \"format\": \"EEE MMM dd HH:mm:ss Z yyyy\"\n                }\n            }\n        }\n    },\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.cluster.putComponentTemplate({\n  name: \"template_1\",\n  template: null,\n  settings: {\n    number_of_shards: 1,\n  },\n  mappings: {\n    _source: {\n      enabled: false,\n    },\n    properties: {\n      host_name: {\n        type: \"keyword\",\n      },\n      created_at: {\n        type: \"date\",\n        format: \"EEE MMM dd HH:mm:ss Z yyyy\",\n      },\n    },\n  },\n});"
+      "code": "const response = await client.cluster.putComponentTemplate({\n  name: \"template_1\",\n  template: {\n    settings: {\n      number_of_shards: 1,\n    },\n    mappings: {\n      _source: {\n        enabled: false,\n      },\n      properties: {\n        host_name: {\n          type: \"keyword\",\n        },\n        created_at: {\n          type: \"date\",\n          format: \"EEE MMM dd HH:mm:ss Z yyyy\",\n        },\n      },\n    },\n  },\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.cluster.put_component_template(\n  name: \"template_1\",\n  body: {\n    \"template\": nil,\n    \"settings\": {\n      \"number_of_shards\": 1\n    },\n    \"mappings\": {\n      \"_source\": {\n        \"enabled\": false\n      },\n      \"properties\": {\n        \"host_name\": {\n          \"type\": \"keyword\"\n        },\n        \"created_at\": {\n          \"type\": \"date\",\n          \"format\": \"EEE MMM dd HH:mm:ss Z yyyy\"\n        }\n      }\n    }\n  }\n)"
+      "code": "response = client.cluster.put_component_template(\n  name: \"template_1\",\n  body: {\n    \"template\": {\n      \"settings\": {\n        \"number_of_shards\": 1\n      },\n      \"mappings\": {\n        \"_source\": {\n          \"enabled\": false\n        },\n        \"properties\": {\n          \"host_name\": {\n            \"type\": \"keyword\"\n          },\n          \"created_at\": {\n            \"type\": \"date\",\n            \"format\": \"EEE MMM dd HH:mm:ss Z yyyy\"\n          }\n        }\n      }\n    }\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->cluster()->putComponentTemplate([\n    \"name\" => \"template_1\",\n    \"body\" => [\n        \"template\" => null,\n        \"settings\" => [\n            \"number_of_shards\" => 1,\n        ],\n        \"mappings\" => [\n            \"_source\" => [\n                \"enabled\" => false,\n            ],\n            \"properties\" => [\n                \"host_name\" => [\n                    \"type\" => \"keyword\",\n                ],\n                \"created_at\" => [\n                    \"type\" => \"date\",\n                    \"format\" => \"EEE MMM dd HH:mm:ss Z yyyy\",\n                ],\n            ],\n        ],\n    ],\n]);"
+      "code": "$resp = $client->cluster()->putComponentTemplate([\n    \"name\" => \"template_1\",\n    \"body\" => [\n        \"template\" => [\n            \"settings\" => [\n                \"number_of_shards\" => 1,\n            ],\n            \"mappings\" => [\n                \"_source\" => [\n                    \"enabled\" => false,\n                ],\n                \"properties\" => [\n                    \"host_name\" => [\n                        \"type\" => \"keyword\",\n                    ],\n                    \"created_at\" => [\n                        \"type\" => \"date\",\n                        \"format\" => \"EEE MMM dd HH:mm:ss Z yyyy\",\n                    ],\n                ],\n            ],\n        ],\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"template\":null,\"settings\":{\"number_of_shards\":1},\"mappings\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"keyword\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z yyyy\"}}}}' \"$ELASTICSEARCH_URL/_component_template/template_1\""
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"template\":{\"settings\":{\"number_of_shards\":1},\"mappings\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"keyword\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z yyyy\"}}}}}' \"$ELASTICSEARCH_URL/_component_template/template_1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Cluster\n    .PutComponentTemplateAsync(name: \"template_1\", d1 => d1\n        .Template(d2 => d2\n            .Mappings(d3 => d3\n                .Properties(d4 => d4\n                    .Keyword(x => x.HostName)\n                    .Date(x => x.CreatedAt, d5 => d5\n                        .Format(\"EEE MMM dd HH:mm:ss Z yyyy\")\n                    )\n                )\n                .Source(d4 => d4\n                    .Enabled(false)\n                )\n            )\n            .Settings(d3 => d3\n                .NumberOfShards(1)\n            )\n        )\n    );"
     }
   ],
   "specification/cluster/put_component_template/examples/request/ClusterPutComponentTemplateRequestExample2.yaml": [
@@ -1415,6 +1527,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cluster/settings?filter_path=persistent.cluster.remote\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Cluster.GetSettingsAsync();"
     },
     {
       "language": "Java",
@@ -1465,6 +1581,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"my-index-000001\",\"shard\":0,\"primary\":false,\"current_node\":\"my-node\"}' \"$ELASTICSEARCH_URL/_cluster/allocation/explain\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Cluster\n    .AllocationExplainAsync(d1 => d1\n        .CurrentNode(\"my-node\")\n        .Index(\"my-index-000001\")\n        .Primary(false)\n        .Shard(0)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.cluster().allocationExplain(a -> a\n    .currentNode(\"my-node\")\n    .index(\"my-index-000001\")\n    .primary(false)\n    .shard(0)\n);\n"
     }
@@ -1489,6 +1609,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"persistent\":{\"action.auto_create_index\":\"my-index-000001,index10,-index1*,+ind*\"}}' \"$ELASTICSEARCH_URL/_cluster/settings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Cluster\n    .PutSettingsAsync(d1 => d1\n        .Persistent(new Dictionary<string, object>()\n        {\n            { \"action.auto_create_index\", \"my-index-000001,index10,-index1*,+ind*\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -1517,6 +1641,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"persistent\":{\"indices.recovery.max_bytes_per_sec\":\"50mb\"}}' \"$ELASTICSEARCH_URL/_cluster/settings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Cluster\n    .PutSettingsAsync(d1 => d1\n        .Persistent(new Dictionary<string, object>()\n        {\n            { \"indices.recovery.max_bytes_per_sec\", \"50mb\" }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.cluster().putSettings(p -> p\n    .persistent(\"indices.recovery.max_bytes_per_sec\", JsonData.fromJson(\"\\\"50mb\\\"\"))\n);\n"
     }
@@ -1541,6 +1669,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cluster/health\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Cluster.HealthAsync();"
     },
     {
       "language": "Java",
@@ -1595,6 +1727,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_info/_all\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Cluster.InfoAsync(target: [ClusterInfoTarget.All]);"
+    },
+    {
       "language": "Java",
       "code": "client.cluster().info(i -> i\n    .target(\"_all\")\n);\n"
     }
@@ -1647,6 +1783,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cluster/stats?human&filter_path=indices.mappings.total_deduplicated_mapping_size*\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Cluster.StatsAsync();"
+    },
+    {
       "language": "Java",
       "code": "\n"
     }
@@ -1671,6 +1811,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_component_template/template_1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Cluster\n    .GetComponentTemplateAsync(d1 => d1\n        .Name(\"template_1\")\n    );"
     },
     {
       "language": "Java",
@@ -1749,6 +1893,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_tasks?detailed=true&actions=*/delete/byquery\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Tasks\n    .ListAsync(d1 => d1\n        .Actions(\"*/delete/byquery\")\n        .Detailed(true)\n    );"
     }
   ],
   "specification/tasks/list/examples/request/ListTasksRequestExample1.yaml": [
@@ -1771,6 +1919,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_tasks?actions=*search&detailed\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Tasks\n    .ListAsync(d1 => d1\n        .Actions(\"*search\")\n        .Detailed(true)\n    );"
     }
   ],
   "specification/indices/simulate_template/examples/request/indicesSimulateTemplateRequestExample1.yaml": [
@@ -1793,6 +1945,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"my-index-*\"],\"composed_of\":[\"ct2\"],\"priority\":10,\"template\":{\"settings\":{\"index.number_of_replicas\":1}}}' \"$ELASTICSEARCH_URL/_index_template/_simulate\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .SimulateTemplateAsync(d1 => d1\n        .ComposedOf([\"ct2\"])\n        .IndexPatterns(new[] { \"my-index-*\" })\n        .Priority(10L)\n        .Template(d2 => d2\n            .Settings(d3 => d3\n                .OtherSettings(new Dictionary<string, object>()\n                {\n                    { \"index.number_of_replicas\", 1 }\n                })\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -1821,6 +1977,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"settings\":{\"index.number_of_shards\":2}}' \"$ELASTICSEARCH_URL/my-index-000001/_split/split-my-index-000001\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .SplitAsync(index: \"my-index-000001\", target: \"split-my-index-000001\", d1 => d1\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.number_of_shards\", 2 }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().split(s -> s\n    .index(\"my-index-000001\")\n    .settings(\"index.number_of_shards\", JsonData.fromJson(\"2\"))\n    .target(\"split-my-index-000001\")\n);\n"
     }
@@ -1847,6 +2007,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"actions\":[{\"add\":{\"index\":\"logs-nginx.access-prod\",\"alias\":\"logs\"}}]}' \"$ELASTICSEARCH_URL/_aliases\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .UpdateAliasesAsync(d1 => d1\n        .Actions(d2 => d2\n            .Add(d3 => d3\n                .Alias(\"logs\")\n                .Index(\"logs-nginx.access-prod\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().updateAliases(u -> u\n    .actions(a -> a\n        .add(ad -> ad\n            .alias(\"logs\")\n            .index(\"logs-nginx.access-prod\")\n        )\n    )\n);\n"
     }
@@ -1871,6 +2035,10 @@
     {
       "language": "curl",
       "code": "curl --head -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_alias/my-alias\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .ExistsAliasAsync(new ExistsAliasRequest()\n    {\n        Name = new[] { \"my-alias\" }\n    });"
     },
     {
       "language": "Java",
@@ -1921,6 +2089,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_template/.cloud-hot-warm-allocation-0\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.DeleteTemplateAsync(name: \".cloud-hot-warm-allocation-0\");"
+    },
+    {
       "language": "Java",
       "code": "client.indices().deleteTemplate(d -> d\n    .name(\".cloud-hot-warm-allocation-0\")\n);\n"
     }
@@ -1945,6 +2117,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/my-index-000001/_stats\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .DataStreamsStatsAsync(d1 => d1\n        .Name(\"my-index-000001\")\n    );"
     },
     {
       "language": "Java",
@@ -1973,6 +2149,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_index_template/my-index-template\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.DeleteIndexTemplateAsync(name: new[] { \"my-index-template\" });"
+    },
+    {
       "language": "Java",
       "code": "client.indices().deleteIndexTemplate(d -> d\n    .name(\"my-index-template\")\n);\n"
     }
@@ -1980,11 +2160,11 @@
   "specification/indices/simulate_index_template/examples/request/indicesSimulateIndexTemplateRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.indices.simulate_index_template(\n    name=\"my-index-000001\",\n)"
+      "code": "resp = client.indices.simulate_index_template(\n    name=\"my-index-000001\",\n    index_template=None,\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.indices.simulateIndexTemplate({\n  name: \"my-index-000001\",\n});"
+      "code": "const response = await client.indices.simulateIndexTemplate({\n  name: \"my-index-000001\",\n  index_template: null,\n});"
     },
     {
       "language": "Ruby",
@@ -2025,6 +2205,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"te*\"],\"settings\":{\"number_of_shards\":1},\"aliases\":{\"alias1\":{},\"alias2\":{\"filter\":{\"term\":{\"user.id\":\"kimchy\"}},\"routing\":\"shard-1\"},\"{index}-alias\":{}}}' \"$ELASTICSEARCH_URL/_template/template_1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutTemplateAsync(name: \"template_1\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"alias1\", new Alias())\n            .Add(\"alias2\", d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n                .Routing(\"shard-1\")\n            )\n            .Add(\"{index}-alias\", new Alias())\n        )\n        .IndexPatterns(\"te*\")\n        .Settings(d2 => d2\n            .NumberOfShards(1)\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().putTemplate(p -> p\n    .aliases(Map.of(\"alias1\", Alias.of(a -> a),\"{index}-alias\", Alias.of(a -> a),\"alias2\", Alias.of(a -> a\n            .filter(f -> f\n                .term(t -> t\n                    .field(\"user.id\")\n                    .value(FieldValue.of(\"kimchy\"))\n                )\n            )\n            .routing(\"shard-1\"))))\n    .indexPatterns(\"te*\")\n    .name(\"template_1\")\n    .settings(s -> s\n        .numberOfShards(\"1\")\n    )\n);\n"
     }
@@ -2032,23 +2216,27 @@
   "specification/indices/put_template/examples/request/indicesPutTemplateRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.indices.put_template(\n    name=\"template_1\",\n    index_patterns=[\n        \"te*\",\n        \"bar*\"\n    ],\n    settings={\n        \"number_of_shards\": 1\n    },\n    mappings={\n        \"_source\": {\n            \"enabled\": False\n        }\n    },\n    properties={\n        \"host_name\": {\n            \"type\": \"keyword\"\n        },\n        \"created_at\": {\n            \"type\": \"date\",\n            \"format\": \"EEE MMM dd HH:mm:ss Z yyyy\"\n        }\n    },\n)"
+      "code": "resp = client.indices.put_template(\n    name=\"template_1\",\n    index_patterns=[\n        \"te*\",\n        \"bar*\"\n    ],\n    settings={\n        \"number_of_shards\": 1\n    },\n    mappings={\n        \"_source\": {\n            \"enabled\": False\n        },\n        \"properties\": {\n            \"host_name\": {\n                \"type\": \"keyword\"\n            },\n            \"created_at\": {\n                \"type\": \"date\",\n                \"format\": \"EEE MMM dd HH:mm:ss Z yyyy\"\n            }\n        }\n    },\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.indices.putTemplate({\n  name: \"template_1\",\n  index_patterns: [\"te*\", \"bar*\"],\n  settings: {\n    number_of_shards: 1,\n  },\n  mappings: {\n    _source: {\n      enabled: false,\n    },\n  },\n  properties: {\n    host_name: {\n      type: \"keyword\",\n    },\n    created_at: {\n      type: \"date\",\n      format: \"EEE MMM dd HH:mm:ss Z yyyy\",\n    },\n  },\n});"
+      "code": "const response = await client.indices.putTemplate({\n  name: \"template_1\",\n  index_patterns: [\"te*\", \"bar*\"],\n  settings: {\n    number_of_shards: 1,\n  },\n  mappings: {\n    _source: {\n      enabled: false,\n    },\n    properties: {\n      host_name: {\n        type: \"keyword\",\n      },\n      created_at: {\n        type: \"date\",\n        format: \"EEE MMM dd HH:mm:ss Z yyyy\",\n      },\n    },\n  },\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.indices.put_template(\n  name: \"template_1\",\n  body: {\n    \"index_patterns\": [\n      \"te*\",\n      \"bar*\"\n    ],\n    \"settings\": {\n      \"number_of_shards\": 1\n    },\n    \"mappings\": {\n      \"_source\": {\n        \"enabled\": false\n      }\n    },\n    \"properties\": {\n      \"host_name\": {\n        \"type\": \"keyword\"\n      },\n      \"created_at\": {\n        \"type\": \"date\",\n        \"format\": \"EEE MMM dd HH:mm:ss Z yyyy\"\n      }\n    }\n  }\n)"
+      "code": "response = client.indices.put_template(\n  name: \"template_1\",\n  body: {\n    \"index_patterns\": [\n      \"te*\",\n      \"bar*\"\n    ],\n    \"settings\": {\n      \"number_of_shards\": 1\n    },\n    \"mappings\": {\n      \"_source\": {\n        \"enabled\": false\n      },\n      \"properties\": {\n        \"host_name\": {\n          \"type\": \"keyword\"\n        },\n        \"created_at\": {\n          \"type\": \"date\",\n          \"format\": \"EEE MMM dd HH:mm:ss Z yyyy\"\n        }\n      }\n    }\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->indices()->putTemplate([\n    \"name\" => \"template_1\",\n    \"body\" => [\n        \"index_patterns\" => array(\n            \"te*\",\n            \"bar*\",\n        ),\n        \"settings\" => [\n            \"number_of_shards\" => 1,\n        ],\n        \"mappings\" => [\n            \"_source\" => [\n                \"enabled\" => false,\n            ],\n        ],\n        \"properties\" => [\n            \"host_name\" => [\n                \"type\" => \"keyword\",\n            ],\n            \"created_at\" => [\n                \"type\" => \"date\",\n                \"format\" => \"EEE MMM dd HH:mm:ss Z yyyy\",\n            ],\n        ],\n    ],\n]);"
+      "code": "$resp = $client->indices()->putTemplate([\n    \"name\" => \"template_1\",\n    \"body\" => [\n        \"index_patterns\" => array(\n            \"te*\",\n            \"bar*\",\n        ),\n        \"settings\" => [\n            \"number_of_shards\" => 1,\n        ],\n        \"mappings\" => [\n            \"_source\" => [\n                \"enabled\" => false,\n            ],\n            \"properties\" => [\n                \"host_name\" => [\n                    \"type\" => \"keyword\",\n                ],\n                \"created_at\" => [\n                    \"type\" => \"date\",\n                    \"format\" => \"EEE MMM dd HH:mm:ss Z yyyy\",\n                ],\n            ],\n        ],\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"te*\",\"bar*\"],\"settings\":{\"number_of_shards\":1},\"mappings\":{\"_source\":{\"enabled\":false}},\"properties\":{\"host_name\":{\"type\":\"keyword\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z yyyy\"}}}' \"$ELASTICSEARCH_URL/_template/template_1\""
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"te*\",\"bar*\"],\"settings\":{\"number_of_shards\":1},\"mappings\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"keyword\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z yyyy\"}}}}' \"$ELASTICSEARCH_URL/_template/template_1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutTemplateAsync(name: \"template_1\", d1 => d1\n        .IndexPatterns(\"te*\", \"bar*\")\n        .Mappings(d2 => d2\n            .Properties(d3 => d3\n                .Keyword(x => x.HostName)\n                .Date(x => x.CreatedAt, d4 => d4\n                    .Format(\"EEE MMM dd HH:mm:ss Z yyyy\")\n                )\n            )\n            .Source(d3 => d3\n                .Enabled(false)\n            )\n        )\n        .Settings(d2 => d2\n            .NumberOfShards(1)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -2099,6 +2287,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/my-data-stream/_lifecycle\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.DeleteDataLifecycleAsync(name: new[] { \"my-data-stream\" });"
+    },
+    {
       "language": "Java",
       "code": "client.indices().deleteDataLifecycle(d -> d\n    .name(\"my-data-stream\")\n);\n"
     }
@@ -2106,15 +2298,15 @@
   "specification/indices/create_from/examples/request/IndicesCreateFromExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.perform_request(\n    \"POST\",\n    \"/_create_from/my-index/my-new-index\",\n)"
+      "code": "resp = client.indices.create_from(\n    source=\"my-index\",\n    dest=\"my-new-index\",\n    create_from=None,\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.transport.request({\n  method: \"POST\",\n  path: \"/_create_from/my-index/my-new-index\",\n});"
+      "code": "const response = await client.indices.createFrom({\n  source: \"my-index\",\n  dest: \"my-new-index\",\n  create_from: null,\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.perform_request(\n  \"POST\",\n  \"/_create_from/my-index/my-new-index\",\n  {},\n)"
+      "code": "response = client.indices.create_from(\n  source: \"my-index\",\n  dest: \"my-new-index\"\n)"
     },
     {
       "language": "PHP",
@@ -2123,6 +2315,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_create_from/my-index/my-new-index\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .CreateFromAsync(source: \"my-index\", dest: \"my-new-index\", d1 => d1\n        .CreateFrom()\n    );"
     },
     {
       "language": "Java",
@@ -2151,6 +2347,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-00001/_close\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.CloseAsync(indices: new[] { \"my-index-00001\" });"
+    },
+    {
       "language": "Java",
       "code": "client.indices().close(c -> c\n    .index(\"my-index-00001\")\n);\n"
     }
@@ -2158,15 +2358,15 @@
   "specification/indices/get_migrate_reindex_status/examples/request/IndicesGetMigrateReindexStatusExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.perform_request(\n    \"GET\",\n    \"/_migration/reindex/my-data-stream/_status\",\n)"
+      "code": "resp = client.indices.get_migrate_reindex_status(\n    index=\"my-data-stream\",\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.transport.request({\n  method: \"GET\",\n  path: \"/_migration/reindex/my-data-stream/_status\",\n});"
+      "code": "const response = await client.indices.getMigrateReindexStatus({\n  index: \"my-data-stream\",\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.perform_request(\n  \"GET\",\n  \"/_migration/reindex/my-data-stream/_status\",\n  {},\n)"
+      "code": "response = client.indices.get_migrate_reindex_status(\n  index: \"my-data-stream\"\n)"
     },
     {
       "language": "PHP",
@@ -2175,6 +2375,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_migration/reindex/my-data-stream/_status\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.GetMigrateReindexStatusAsync(indices: new[] { \"my-data-stream\" });"
     },
     {
       "language": "Java",
@@ -2201,6 +2405,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_all/_settings?expand_wildcards=all&filter_path=*.settings.index.*.slowlog\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .GetSettingsAsync(d1 => d1\n        .Indices(new[] { \"_all\" })\n        .ExpandWildcards(ExpandWildcard.All)\n    );"
     }
   ],
   "specification/indices/promote_data_stream/examples/request/IndicesPromoteDataStreamExample1.yaml": [
@@ -2223,6 +2431,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/_promote/my-data-stream\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.PromoteDataStreamAsync(name: \"my-data-stream\");"
     },
     {
       "language": "Java",
@@ -2251,6 +2463,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_flush\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.FlushAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.indices().flush(f -> f);\n"
     }
@@ -2275,6 +2491,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/books\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.DeleteAsync(indices: new[] { \"books\" });"
     },
     {
       "language": "Java",
@@ -2303,6 +2523,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_refresh\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.RefreshAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.indices().refresh(r -> r);\n"
     }
@@ -2327,6 +2551,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_resolve/index/f*,remoteCluster1:bar*?expand_wildcards=all\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .ResolveIndexAsync(name: new[] { \"f*\", \"remoteCluster1:bar*\" }, d1 => d1\n        .ExpandWildcards(ExpandWildcard.All)\n    );"
     }
   ],
   "specification/indices/exists/examples/request/IndicesExistsExample1.yaml": [
@@ -2349,6 +2577,10 @@
     {
       "language": "curl",
       "code": "curl --head -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-data-stream\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.ExistsAsync(indices: new[] { \"my-data-stream\" });"
     },
     {
       "language": "Java",
@@ -2377,6 +2609,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_recovery?human\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.RecoveryAsync();"
+    },
+    {
       "language": "Java",
       "code": "\n"
     }
@@ -2401,6 +2637,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"analysis\":{\"analyzer\":{\"content\":{\"type\":\"custom\",\"tokenizer\":\"whitespace\"}}}}' \"$ELASTICSEARCH_URL/my-index-000001/_settings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutSettingsAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Settings(d2 => d2\n            .Analysis(d3 => d3\n                .Analyzers(d4 => d4\n                    .Custom(\"content\", d5 => d5\n                        .Tokenizer(\"whitespace\")\n                    )\n                )\n            )\n        )\n    );"
     }
   ],
   "specification/indices/put_settings/examples/request/indicesPutSettingsRequestExample2.yaml": [
@@ -2423,6 +2663,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":{\"refresh_interval\":null}}' \"$ELASTICSEARCH_URL/my-index-000001/_settings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutSettingsAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Settings(d2 => d2\n            .Index()\n        )\n    );"
     }
   ],
   "specification/indices/put_settings/examples/request/IndicesPutSettingsRequestExample1.yaml": [
@@ -2445,6 +2689,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":{\"number_of_replicas\":2}}' \"$ELASTICSEARCH_URL/my-index-000001/_settings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutSettingsAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Settings(d2 => d2\n            .Index(d3 => d3\n                .NumberOfReplicas(2)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -2473,6 +2721,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001,my-index-000002/_cache/clear?request=true\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .ClearCacheAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\", \"my-index-000002\" })\n        .Request(true)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().clearCache(c -> c\n    .index(List.of(\"my-index-000001\",\"my-index-000002\"))\n    .request(true)\n);\n"
     }
@@ -2488,29 +2740,33 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.indices.reload_search_analyzers(\n  index: \"my-index-000001\",\n  body: {\n    \"_shards\": {\n      \"total\": 2,\n      \"successful\": 2,\n      \"failed\": 0\n    },\n    \"reload_details\": [\n      {\n        \"index\": \"my-index-000001\",\n        \"reloaded_analyzers\": [\n          \"my_synonyms\"\n        ],\n        \"reloaded_node_ids\": [\n          \"mfdqTXn_T7SGr2Ho2KT8uw\"\n        ]\n      }\n    ]\n  }\n)"
+      "code": "response = client.indices.reload_search_analyzers(\n  index: \"my-index-000001\"\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->indices()->reloadSearchAnalyzers([\n    \"index\" => \"my-index-000001\",\n    \"body\" => [\n        \"_shards\" => [\n            \"total\" => 2,\n            \"successful\" => 2,\n            \"failed\" => 0,\n        ],\n        \"reload_details\" => array(\n            [\n                \"index\" => \"my-index-000001\",\n                \"reloaded_analyzers\" => array(\n                    \"my_synonyms\",\n                ),\n                \"reloaded_node_ids\" => array(\n                    \"mfdqTXn_T7SGr2Ho2KT8uw\",\n                ),\n            ],\n        ),\n    ],\n]);"
+      "code": "$resp = $client->indices()->reloadSearchAnalyzers([\n    \"index\" => \"my-index-000001\",\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"_shards\":{\"total\":2,\"successful\":2,\"failed\":0},\"reload_details\":[{\"index\":\"my-index-000001\",\"reloaded_analyzers\":[\"my_synonyms\"],\"reloaded_node_ids\":[\"mfdqTXn_T7SGr2Ho2KT8uw\"]}]}' \"$ELASTICSEARCH_URL/my-index-000001/_reload_search_analyzers\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_reload_search_analyzers\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.ReloadSearchAnalyzersAsync(indices: new[] { \"my-index-000001\" });"
     }
   ],
   "specification/indices/cancel_migrate_reindex/examples/request/IndicesCancelMigrateReindexExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.perform_request(\n    \"POST\",\n    \"/_migration/reindex/my-data-stream/_cancel\",\n)"
+      "code": "resp = client.indices.cancel_migrate_reindex(\n    index=\"my-data-stream\",\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.transport.request({\n  method: \"POST\",\n  path: \"/_migration/reindex/my-data-stream/_cancel\",\n});"
+      "code": "const response = await client.indices.cancelMigrateReindex({\n  index: \"my-data-stream\",\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.perform_request(\n  \"POST\",\n  \"/_migration/reindex/my-data-stream/_cancel\",\n  {},\n)"
+      "code": "response = client.indices.cancel_migrate_reindex(\n  index: \"my-data-stream\"\n)"
     },
     {
       "language": "PHP",
@@ -2519,6 +2775,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_migration/reindex/my-data-stream/_cancel\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.CancelMigrateReindexAsync(indices: new[] { \"my-data-stream\" });"
     },
     {
       "language": "Java",
@@ -2547,6 +2807,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/my-data-stream\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.DeleteDataStreamAsync(name: new[] { \"my-data-stream\" });"
+    },
+    {
       "language": "Java",
       "code": "client.indices().deleteDataStream(d -> d\n    .name(\"my-data-stream\")\n);\n"
     }
@@ -2571,6 +2835,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.GetAsync(indices: new[] { \"my-index-000001\" });"
     },
     {
       "language": "Java",
@@ -2599,6 +2867,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_disk_usage?run_expensive_tasks=true\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .DiskUsageAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .RunExpensiveTasks(true)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().diskUsage(d -> d\n    .index(\"my-index-000001\")\n    .runExpensiveTasks(true)\n);\n"
     }
@@ -2623,6 +2895,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/logs-foo-bar\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.CreateDataStreamAsync(name: \"logs-foo-bar\");"
     },
     {
       "language": "Java",
@@ -2651,6 +2927,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-data-stream/_alias/my-alias\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.DeleteAliasAsync(indices: new[] { \"my-data-stream\" }, name: new[] { \"my-alias\" });"
+    },
+    {
       "language": "Java",
       "code": "client.indices().deleteAlias(d -> d\n    .index(\"my-data-stream\")\n    .name(\"my-alias\")\n);\n"
     }
@@ -2675,6 +2955,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_forcemerge\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .ForcemergeAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n    );"
     },
     {
       "language": "Java",
@@ -2703,6 +2987,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"fixed_interval\":\"1d\"}' \"$ELASTICSEARCH_URL/my-time-series-index/_downsample/my-downsampled-time-series-index\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .DownsampleAsync(index: \"my-time-series-index\", targetIndex: \"my-downsampled-time-series-index\", d1 => d1\n        .Config(d2 => d2\n            .FixedInterval(\"1d\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().downsample(d -> d\n    .index(\"my-time-series-index\")\n    .targetIndex(\"my-downsampled-time-series-index\")\n    .config(c -> c\n        .fixedInterval(f -> f\n            .time(\"1d\")\n        )\n    )\n);\n"
     }
@@ -2727,6 +3015,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_template/.monitoring-*\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .GetTemplateAsync(d1 => d1\n        .Name(new[] { \".monitoring-*\" })\n    );"
     },
     {
       "language": "Java",
@@ -2755,6 +3047,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"settings\":{\"index.routing.allocation.require._name\":null,\"index.blocks.write\":null}}' \"$ELASTICSEARCH_URL/my_source_index/_shrink/my_target_index\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .ShrinkAsync(index: \"my_source_index\", target: \"my_target_index\", d1 => d1\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.routing.allocation.require._name\", null },\n            { \"index.blocks.write\", null }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().shrink(s -> s\n    .index(\"my_source_index\")\n    .settings(Map.of(\"index.blocks.write\", JsonData.fromJson(\"null\"),\"index.routing.allocation.require._name\", JsonData.fromJson(\"null\")))\n    .target(\"my_target_index\")\n);\n"
     }
@@ -2779,6 +3075,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/.ds-metrics-2023.03.22-000001/_lifecycle/explain\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.ExplainDataLifecycleAsync(indices: new[] { \".ds-metrics-2023.03.22-000001\" });"
     },
     {
       "language": "Java",
@@ -2807,6 +3107,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/books/_mapping\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .GetMappingAsync(d1 => d1\n        .Indices(new[] { \"books\" })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().getMapping(g -> g\n    .index(\"books\")\n);\n"
     }
@@ -2831,6 +3135,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_lifecycle/stats?human&pretty\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.GetDataLifecycleStatsAsync();"
     },
     {
       "language": "Java",
@@ -2885,6 +3193,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"conditions\":{\"max_age\":\"7d\",\"max_docs\":1000,\"max_primary_shard_size\":\"50gb\",\"max_primary_shard_docs\":\"2000\"}}' \"$ELASTICSEARCH_URL/my-data-stream/_rollover\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .RolloverAsync(new RolloverRequest()\n    {\n        Alias = \"my-data-stream\",\n        Conditions = new()\n        {\n            MaxAge = \"7d\",\n            MaxDocs = 1000L,\n            MaxPrimaryShardDocs = 2000L,\n            MaxPrimaryShardSize = new ByteSize(\"50gb\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.indices().rollover(r -> r\n    .alias(\"my-data-stream\")\n    .conditions(c -> c\n        .maxAge(m -> m\n            .time(\"7d\")\n        )\n        .maxDocs(1000L)\n        .maxPrimaryShardSize(\"50gb\")\n        .maxPrimaryShardDocs(2000L)\n    )\n);\n"
     }
@@ -2909,6 +3221,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"data_retention\":\"7d\"}' \"$ELASTICSEARCH_URL/_data_stream/my-data-stream/_lifecycle\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutDataLifecycleAsync(name: new[] { \"my-data-stream\" }, d1 => d1\n        .DataRetention(\"7d\")\n    );"
     },
     {
       "language": "Java",
@@ -2959,6 +3275,10 @@
       "code": "curl --head -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_template/template_1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.ExistsTemplateAsync(name: new[] { \"template_1\" });"
+    },
+    {
       "language": "Java",
       "code": "client.indices().existsTemplate(e -> e\n    .name(\"template_1\")\n);\n"
     }
@@ -2983,6 +3303,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_validate/query?q=user.id:kimchy\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .ValidateQueryAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .QueryLuceneSyntax(\"user.id:kimchy\")\n    );"
     },
     {
       "language": "Java",
@@ -3011,6 +3335,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"template*\"],\"priority\":1,\"template\":{\"settings\":{\"number_of_shards\":2}}}' \"$ELASTICSEARCH_URL/_index_template/template_1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutIndexTemplateAsync(name: \"template_1\", d1 => d1\n        .IndexPatterns(new[] { \"template*\" })\n        .Priority(1L)\n        .Template(d2 => d2\n            .Settings(d3 => d3\n                .NumberOfShards(2)\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().putIndexTemplate(p -> p\n    .indexPatterns(\"template*\")\n    .name(\"template_1\")\n    .priority(1L)\n    .template(t -> t\n        .settings(s -> s\n            .numberOfShards(\"2\")\n        )\n    )\n);\n"
     }
@@ -3035,6 +3363,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"template*\"],\"template\":{\"settings\":{\"number_of_shards\":1},\"aliases\":{\"alias1\":{},\"alias2\":{\"filter\":{\"term\":{\"user.id\":\"kimchy\"}},\"routing\":\"shard-1\"},\"{index}-alias\":{}}}}' \"$ELASTICSEARCH_URL/_index_template/template_1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutIndexTemplateAsync(name: \"template_1\", d1 => d1\n        .IndexPatterns(new[] { \"template*\" })\n        .Template(d2 => d2\n            .Aliases(d3 => d3\n                .Add(\"alias1\", new Alias())\n                .Add(\"alias2\", d4 => d4\n                    .Filter(d5 => d5\n                        .Term(d6 => d6\n                            .Field(x => x.User.Id)\n                            .Value(\"kimchy\")\n                        )\n                    )\n                    .Routing(\"shard-1\")\n                )\n                .Add(\"{index}-alias\", new Alias())\n            )\n            .Settings(d3 => d3\n                .NumberOfShards(1)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -3063,6 +3395,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"settings\":{\"index.number_of_shards\":5},\"aliases\":{\"my_search_indices\":{}}}' \"$ELASTICSEARCH_URL/my_source_index/_clone/my_target_index\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .CloneAsync(index: \"my_source_index\", target: \"my_target_index\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"my_search_indices\", new Alias())\n        )\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.number_of_shards\", 5 }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().clone(c -> c\n    .aliases(\"my_search_indices\", a -> a)\n    .index(\"my_source_index\")\n    .settings(\"index.number_of_shards\", JsonData.fromJson(\"5\"))\n    .target(\"my_target_index\")\n);\n"
     }
@@ -3087,6 +3423,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_index_template/*?filter_path=index_templates.name,index_templates.index_template.index_patterns,index_templates.index_template.data_stream\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .GetIndexTemplateAsync(d1 => d1\n        .Name(\"*\")\n    );"
     },
     {
       "language": "Java",
@@ -3115,6 +3455,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/%7Bname%7D/_lifecycle?human&pretty\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.GetDataLifecycleAsync(name: new[] { \"{name}\" });"
+    },
+    {
       "language": "Java",
       "code": "\n"
     }
@@ -3141,6 +3485,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/my-data-stream\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .GetDataStreamAsync(d1 => d1\n        .Name(new[] { \"my-data-stream\" })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().getDataStream(g -> g\n    .name(\"my-data-stream\")\n);\n"
     }
@@ -3165,6 +3513,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"actions\":[{\"remove_backing_index\":{\"data_stream\":\"my-data-stream\",\"index\":\".ds-my-data-stream-2023.07.26-000001\"}},{\"add_backing_index\":{\"data_stream\":\"my-data-stream\",\"index\":\".ds-my-data-stream-2023.07.26-000001-downsample\"}}]}' \"$ELASTICSEARCH_URL/_data_stream/_modify\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .ModifyDataStreamAsync(d1 => d1\n        .Actions(d2 => d2\n            .RemoveBackingIndex(d3 => d3\n                .DataStream(\"my-data-stream\")\n                .Index(\".ds-my-data-stream-2023.07.26-000001\")\n            ), d2 => d2\n            .AddBackingIndex(d3 => d3\n                .DataStream(\"my-data-stream\")\n                .Index(\".ds-my-data-stream-2023.07.26-000001-downsample\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -3219,6 +3571,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"analyzer\":\"standard\",\"text\":[\"this is a test\",\"the second text\"]}' \"$ELASTICSEARCH_URL/_analyze\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .AnalyzeAsync(d1 => d1\n        .Analyzer(\"standard\")\n        .Text(\"this is a test\", \"the second text\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().analyze(a -> a\n    .analyzer(\"standard\")\n    .text(List.of(\"this is a test\",\"the second text\"))\n);\n"
     }
@@ -3243,6 +3599,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"field\":\"obj1.field1\",\"text\":\"this is a test\"}' \"$ELASTICSEARCH_URL/analyze_sample/_analyze\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .AnalyzeAsync(d1 => d1\n        .Index(\"analyze_sample\")\n        .Field(x => x.Obj1.Field1)\n        .Text(\"this is a test\")\n    );"
     },
     {
       "language": "Java",
@@ -3323,6 +3683,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"normalizer\":\"my_normalizer\",\"text\":\"BaR\"}' \"$ELASTICSEARCH_URL/analyze_sample/_analyze\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .AnalyzeAsync(d1 => d1\n        .Index(\"analyze_sample\")\n        .Normalizer(\"my_normalizer\")\n        .Text(\"BaR\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().analyze(a -> a\n    .index(\"analyze_sample\")\n    .normalizer(\"my_normalizer\")\n    .text(\"BaR\")\n);\n"
     }
@@ -3349,6 +3713,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"analyzer\":\"standard\",\"text\":\"this is a test\"}' \"$ELASTICSEARCH_URL/_analyze\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .AnalyzeAsync(d1 => d1\n        .Analyzer(\"standard\")\n        .Text(\"this is a test\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().analyze(a -> a\n    .analyzer(\"standard\")\n    .text(\"this is a test\")\n);\n"
     }
@@ -3373,6 +3741,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_shard_stores?status=green\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .ShardStoresAsync(d1 => d1\n        .Status(ShardStoreStatus.Green)\n    );"
     }
   ],
   "specification/indices/get_data_stream_settings/examples/request/IndicesGetDataStreamSettingsRequestExample1.yaml": [
@@ -3419,6 +3791,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_alias\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.GetAliasAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.indices().getAlias(g -> g);\n"
     }
@@ -3452,23 +3828,27 @@
   "specification/indices/put_alias/examples/request/indicesPutAliasRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.indices.update_aliases(\n    actions=[\n        {\n            \"add\": {\n                \"index\": \"my-data-stream\",\n                \"alias\": \"my-alias\"\n            }\n        }\n    ],\n)"
+      "code": "resp = client.indices.put_alias(\n    index=\"my-index-2099.05.06-000001\",\n    name=\"my-alias\",\n    filter={\n        \"bool\": {\n            \"filter\": [\n                {\n                    \"range\": {\n                        \"@timestamp\": {\n                            \"gte\": \"now-1d/d\",\n                            \"lt\": \"now/d\"\n                        }\n                    }\n                },\n                {\n                    \"term\": {\n                        \"user.id\": \"kimchy\"\n                    }\n                }\n            ]\n        }\n    },\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.indices.updateAliases({\n  actions: [\n    {\n      add: {\n        index: \"my-data-stream\",\n        alias: \"my-alias\",\n      },\n    },\n  ],\n});"
+      "code": "const response = await client.indices.putAlias({\n  index: \"my-index-2099.05.06-000001\",\n  name: \"my-alias\",\n  filter: {\n    bool: {\n      filter: [\n        {\n          range: {\n            \"@timestamp\": {\n              gte: \"now-1d/d\",\n              lt: \"now/d\",\n            },\n          },\n        },\n        {\n          term: {\n            \"user.id\": \"kimchy\",\n          },\n        },\n      ],\n    },\n  },\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.indices.update_aliases(\n  body: {\n    \"actions\": [\n      {\n        \"add\": {\n          \"index\": \"my-data-stream\",\n          \"alias\": \"my-alias\"\n        }\n      }\n    ]\n  }\n)"
+      "code": "response = client.indices.put_alias(\n  index: \"my-index-2099.05.06-000001\",\n  name: \"my-alias\",\n  body: {\n    \"filter\": {\n      \"bool\": {\n        \"filter\": [\n          {\n            \"range\": {\n              \"@timestamp\": {\n                \"gte\": \"now-1d/d\",\n                \"lt\": \"now/d\"\n              }\n            }\n          },\n          {\n            \"term\": {\n              \"user.id\": \"kimchy\"\n            }\n          }\n        ]\n      }\n    }\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->indices()->updateAliases([\n    \"body\" => [\n        \"actions\" => array(\n            [\n                \"add\" => [\n                    \"index\" => \"my-data-stream\",\n                    \"alias\" => \"my-alias\",\n                ],\n            ],\n        ),\n    ],\n]);"
+      "code": "$resp = $client->indices()->putAlias([\n    \"index\" => \"my-index-2099.05.06-000001\",\n    \"name\" => \"my-alias\",\n    \"body\" => [\n        \"filter\" => [\n            \"bool\" => [\n                \"filter\" => array(\n                    [\n                        \"range\" => [\n                            \"@timestamp\" => [\n                                \"gte\" => \"now-1d/d\",\n                                \"lt\" => \"now/d\",\n                            ],\n                        ],\n                    ],\n                    [\n                        \"term\" => [\n                            \"user.id\" => \"kimchy\",\n                        ],\n                    ],\n                ),\n            ],\n        ],\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"actions\":[{\"add\":{\"index\":\"my-data-stream\",\"alias\":\"my-alias\"}}]}' \"$ELASTICSEARCH_URL/_aliases\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"filter\":{\"bool\":{\"filter\":[{\"range\":{\"@timestamp\":{\"gte\":\"now-1d/d\",\"lt\":\"now/d\"}}},{\"term\":{\"user.id\":\"kimchy\"}}]}}}' \"$ELASTICSEARCH_URL/my-index-2099.05.06-000001/_alias/my-alias\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutAliasAsync(indices: new[] { \"my-index-2099.05.06-000001\" }, name: \"my-alias\", d1 => d1\n        .Filter(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Range(new UntypedRangeQuery()\n                    {\n                        Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Timestamp),\n                        Gte = \"now-1d/d\",\n                        Lt = \"now/d\"\n                    }), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -3495,6 +3875,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index.lifecycle.name\":\"new-test-policy\",\"index.number_of_shards\":11}' \"$ELASTICSEARCH_URL/_data_stream/my-data-stream/_settings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutDataStreamSettingsAsync(name: new[] { \"my-data-stream\" }, d1 => d1\n        .Settings(d2 => d2\n            .OtherSettings(new Dictionary<string, object>()\n            {\n                { \"index.lifecycle.name\", \"new-test-policy\" },\n                { \"index.number_of_shards\", 11 }\n            })\n        )\n    );"
     }
   ],
   "specification/indices/get_field_mapping/examples/request/indicesGetFieldMappingRequestExample1.yaml": [
@@ -3519,6 +3903,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/publications/_mapping/field/title\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .GetFieldMappingAsync(new GetFieldMappingRequest()\n    {\n        Fields = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.Title),\n        Indices = new[] { \"publications\" }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.indices().getFieldMapping(g -> g\n    .fields(\"title\")\n    .index(\"publications\")\n);\n"
     }
@@ -3526,15 +3914,15 @@
   "specification/indices/migrate_reindex/examples/request/IndicesMigrateReindexExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.perform_request(\n    \"POST\",\n    \"/_migration/reindex\",\n    headers={\"Content-Type\": \"application/json\"},\n    body={\n        \"source\": {\n            \"index\": \"my-data-stream\"\n        },\n        \"mode\": \"upgrade\"\n    },\n)"
+      "code": "resp = client.indices.migrate_reindex(\n    reindex={\n        \"source\": {\n            \"index\": \"my-data-stream\"\n        },\n        \"mode\": \"upgrade\"\n    },\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.transport.request({\n  method: \"POST\",\n  path: \"/_migration/reindex\",\n  body: {\n    source: {\n      index: \"my-data-stream\",\n    },\n    mode: \"upgrade\",\n  },\n});"
+      "code": "const response = await client.indices.migrateReindex({\n  reindex: {\n    source: {\n      index: \"my-data-stream\",\n    },\n    mode: \"upgrade\",\n  },\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.perform_request(\n  \"POST\",\n  \"/_migration/reindex\",\n  {},\n  {\n    \"source\": {\n      \"index\": \"my-data-stream\"\n    },\n    \"mode\": \"upgrade\"\n  },\n  { \"Content-Type\": \"application/json\" },\n)"
+      "code": "response = client.indices.migrate_reindex(\n  body: {\n    \"source\": {\n      \"index\": \"my-data-stream\"\n    },\n    \"mode\": \"upgrade\"\n  }\n)"
     },
     {
       "language": "PHP",
@@ -3543,6 +3931,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-data-stream\"},\"mode\":\"upgrade\"}' \"$ELASTICSEARCH_URL/_migration/reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .MigrateReindexAsync(d1 => d1\n        .Reindex(d2 => d2\n            .Mode(ModeEnum.Upgrade)\n            .Source(d3 => d3\n                .Index(\"my-data-stream\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -3571,6 +3963,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"settings\":{\"number_of_shards\":3,\"number_of_replicas\":2}}' \"$ELASTICSEARCH_URL/my-index-000001\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .CreateAsync(index: \"my-index-000001\", d1 => d1\n        .Settings(d2 => d2\n            .NumberOfReplicas(2)\n            .NumberOfShards(3)\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().create(c -> c\n    .index(\"my-index-000001\")\n    .settings(s -> s\n        .numberOfShards(\"3\")\n        .numberOfReplicas(\"2\")\n    )\n);\n"
     }
@@ -3595,6 +3991,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"settings\":{\"number_of_shards\":1},\"mappings\":{\"properties\":{\"field1\":{\"type\":\"text\"}}}}' \"$ELASTICSEARCH_URL/test\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .CreateAsync(index: \"test\", d1 => d1\n        .Mappings(d2 => d2\n            .Properties(d3 => d3\n                .Text(x => x.Field1)\n            )\n        )\n        .Settings(d2 => d2\n            .NumberOfShards(1)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -3623,6 +4023,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"aliases\":{\"alias_1\":{},\"alias_2\":{\"filter\":{\"term\":{\"user.id\":\"kimchy\"}},\"routing\":\"shard-1\"}}}' \"$ELASTICSEARCH_URL/test\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .CreateAsync(index: \"test\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"alias_1\", new Alias())\n            .Add(\"alias_2\", d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n                .Routing(\"shard-1\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().create(c -> c\n    .aliases(Map.of(\"alias_2\", Alias.of(a -> a\n            .filter(f -> f\n                .term(t -> t\n                    .field(\"user.id\")\n                    .value(FieldValue.of(\"kimchy\"))\n                )\n            )\n            .routing(\"shard-1\")),\"alias_1\", Alias.of(al -> al)))\n    .index(\"test\")\n);\n"
     }
@@ -3647,6 +4051,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_field_usage_stats\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.FieldUsageStatsAsync(indices: new[] { \"my-index-000001\" });"
     },
     {
       "language": "Java",
@@ -3675,6 +4083,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/_migrate/my-time-series-data\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices.MigrateToDataStreamAsync(name: \"my-time-series-data\");"
+    },
+    {
       "language": "Java",
       "code": "client.indices().migrateToDataStream(m -> m\n    .name(\"my-time-series-data\")\n);\n"
     }
@@ -3699,6 +4111,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/.ds-my-data-stream-2099.03.07-000001/_open/\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.OpenAsync(indices: new[] { \".ds-my-data-stream-2099.03.07-000001\" });"
     },
     {
       "language": "Java",
@@ -3727,6 +4143,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_stats/fielddata?human&fields=my_join_field#question\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .StatsAsync(d1 => d1\n        .Metric(\"fielddata\")\n        .Fields(x => x.MyJoinField)\n    );"
+    },
+    {
       "language": "Java",
       "code": "\n"
     }
@@ -3751,6 +4171,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_segments\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .SegmentsAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n    );"
     },
     {
       "language": "Java",
@@ -3779,6 +4203,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"properties\":{\"user\":{\"properties\":{\"name\":{\"type\":\"keyword\"}}}}}' \"$ELASTICSEARCH_URL/my-index-000001/_mapping\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutMappingAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Properties(d2 => d2\n            .Object(x => x.User, d3 => d3\n                .Properties(d4 => d4\n                    .Keyword(x => x.Name)\n                )\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.indices().putMapping(p -> p\n    .index(\"my-index-000001\")\n    .properties(\"user\", pr -> pr\n        .object(o -> o\n            .properties(\"name\", pro -> pro\n                .keyword(k -> k)\n            )\n        )\n    )\n);\n"
     }
@@ -3803,6 +4231,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_resolve/cluster/not-present,clust*:my-index*,oldcluster:*?ignore_unavailable=false&timeout=5s\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .ResolveClusterAsync(d1 => d1\n        .Name(new[] { \"not-present\", \"clust*:my-index*\", \"oldcluster:*\" })\n        .IgnoreUnavailable(false)\n        .Timeout(\"5s\")\n    );"
     },
     {
       "language": "Java",
@@ -3831,6 +4263,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_source/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.GetSourceAsync<MyDocument>(index: \"my-index-000001\", id: \"1\");"
+    },
+    {
       "language": "Java",
       "code": "client.getSource(g -> g\n    .id(\"1\")\n    .index(\"my-index-000001\")\n);\n"
     }
@@ -3855,6 +4291,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_script_language\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.GetScriptLanguagesAsync();"
     },
     {
       "language": "Java",
@@ -3883,6 +4323,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_update_by_query/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateByQueryRethrottleAsync(taskId: \"r1A2WoRbTwKZ516z6NEs5A:36619\", d1 => d1\n        .RequestsPerSecond(-1f)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.updateByQueryRethrottle(u -> u\n    .requestsPerSecond(-1.0F)\n    .taskId(\"r1A2WoRbTwKZ516z6NEs5A:36619\")\n);\n"
     }
@@ -3907,6 +4351,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"doc['\"'\"'field'\"'\"'].value.length() <= params.max_length\",\"params\":{\"max_length\":4}},\"context\":\"filter\",\"context_setup\":{\"index\":\"my-index-000001\",\"document\":{\"field\":\"four\"}}}' \"$ELASTICSEARCH_URL/_scripts/painless/_execute\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ScriptsPainlessExecuteAsync<MyDocument, MyDocument>(d1 => d1\n        .Context(PainlessContext.Filter)\n        .ContextSetup(d2 => d2\n            .Document(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field\": \"four\"\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\")\n        )\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"max_length\", 4 }\n            })\n            .Source(\"doc['field'].value.length() <= params.max_length\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -3935,6 +4383,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"doc['\"'\"'rank'\"'\"'].value / params.max_rank\",\"params\":{\"max_rank\":5}},\"context\":\"score\",\"context_setup\":{\"index\":\"my-index-000001\",\"document\":{\"rank\":4}}}' \"$ELASTICSEARCH_URL/_scripts/painless/_execute\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .ScriptsPainlessExecuteAsync<MyDocument, MyDocument>(d1 => d1\n        .Context(PainlessContext.Score)\n        .ContextSetup(d2 => d2\n            .Document(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"rank\": 4\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\")\n        )\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"max_rank\", 5 }\n            })\n            .Source(\"doc['rank'].value / params.max_rank\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.scriptsPainlessExecute(s -> s\n    .context(PainlessContext.Score)\n    .contextSetup(c -> c\n        .document(JsonData.fromJson(\"{\\\"rank\\\":4}\"))\n        .index(\"my-index-000001\")\n    )\n    .script(sc -> sc\n        .source(so -> so\n            .scriptString(\"doc['rank'].value / params.max_rank\")\n        )\n        .params(\"max_rank\", JsonData.fromJson(\"5\"))\n    )\n);\n"
     }
@@ -3959,6 +4411,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"params.count / params.total\",\"params\":{\"count\":100,\"total\":1000}}}' \"$ELASTICSEARCH_URL/_scripts/painless/_execute\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ScriptsPainlessExecuteAsync<MyDocument, MyDocument>(d1 => d1\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 100 },\n                { \"total\", 1000 }\n            })\n            .Source(\"params.count / params.total\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -3987,6 +4443,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_script_context\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.GetScriptContextAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.getScriptContext();\n"
     }
@@ -4010,7 +4470,11 @@
     },
     {
       "language": "curl",
-      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '[{},{\"id\":\"my-search-template\",\"params\":{\"query_string\":\"hello world\",\"from\":0,\"size\":10}},{},{\"id\":\"my-other-search-template\",\"params\":{\"query_type\":\"match_all\"}}]' \"$ELASTICSEARCH_URL/my-index/_msearch/template\""
+      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/x-ndjson\" -d $'{}\\n{\"id\":\"my-search-template\",\"params\":{\"query_string\":\"hello world\",\"from\":0,\"size\":10}}\\n{}\\n{\"id\":\"my-other-search-template\",\"params\":{\"query_type\":\"match_all\"}}\\n' \"$ELASTICSEARCH_URL/my-index/_msearch/template\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .MultiSearchTemplateAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"my-index\" })\n        .SearchTemplates([new SearchTemplateRequestItem(new MultisearchHeader(), new TemplateConfig()\n        {\n            Id = \"my-search-template\",\n            Params = new Dictionary<string, object>()\n            {\n                { \"query_string\", \"hello world\" },\n                { \"from\", 0 },\n                { \"size\", 10 }\n            }\n        }), new SearchTemplateRequestItem(new MultisearchHeader(), new TemplateConfig()\n        {\n            Id = \"my-other-search-template\",\n            Params = new Dictionary<string, object>()\n            {\n                { \"query_type\", \"match_all\" }\n            }\n        })])\n    );"
     }
   ],
   "specification/_global/terms_enum/examples/request/TermsEnumRequestExample1.yaml": [
@@ -4033,6 +4497,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"field\":\"tags\",\"string\":\"kiba\"}' \"$ELASTICSEARCH_URL/stackoverflow/_terms_enum\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .TermsEnumAsync(index: \"stackoverflow\", d1 => d1\n        .Field(x => x.Tags)\n        .String(\"kiba\")\n    );"
     },
     {
       "language": "Java",
@@ -4058,7 +4526,11 @@
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '[{\"index\":{\"_index\":\"my_index\",\"_id\":\"1\",\"dynamic_templates\":{\"work_location\":\"geo_point\"}}},{\"field\":\"value1\",\"work_location\":\"41.12,-71.34\",\"raw_location\":\"41.12,-71.34\"},{\"create\":{\"_index\":\"my_index\",\"_id\":\"2\",\"dynamic_templates\":{\"home_location\":\"geo_point\"}}},{\"field\":\"value2\",\"home_location\":\"41.12,-71.34\"}]' \"$ELASTICSEARCH_URL/_bulk\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/x-ndjson\" -d $'{\"index\":{\"_index\":\"my_index\",\"_id\":\"1\",\"dynamic_templates\":{\"work_location\":\"geo_point\"}}}\\n{\"field\":\"value1\",\"work_location\":\"41.12,-71.34\",\"raw_location\":\"41.12,-71.34\"}\\n{\"create\":{\"_index\":\"my_index\",\"_id\":\"2\",\"dynamic_templates\":{\"home_location\":\"geo_point\"}}}\\n{\"field\":\"value2\",\"home_location\":\"41.12,-71.34\"}\\n' \"$ELASTICSEARCH_URL/_bulk\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkIndexOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field\": \"value1\",\n              \"work_location\": \"41.12,-71.34\",\n              \"raw_location\": \"41.12,-71.34\"\n            }\n            \"\"\"))\n            {\n                Id = \"1\",\n                Index = \"my_index\",\n                DynamicTemplates = new Dictionary<string, string>()\n                {\n                    { \"work_location\", \"geo_point\" }\n                }\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkCreateOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field\": \"value2\",\n              \"home_location\": \"41.12,-71.34\"\n            }\n            \"\"\"))\n            {\n                Id = \"2\",\n                Index = \"my_index\",\n                DynamicTemplates = new Dictionary<string, string>()\n                {\n                    { \"home_location\", \"geo_point\" }\n                }\n            }\n        }\n    });"
     }
   ],
   "specification/_global/bulk/examples/request/BulkRequestExample3.yaml": [
@@ -4080,7 +4552,11 @@
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '[{\"update\":{\"_id\":\"5\",\"_index\":\"index1\"}},{\"doc\":{\"my_field\":\"foo\"}},{\"update\":{\"_id\":\"6\",\"_index\":\"index1\"}},{\"doc\":{\"my_field\":\"foo\"}},{\"create\":{\"_id\":\"7\",\"_index\":\"index1\"}},{\"my_field\":\"foo\"}]' \"$ELASTICSEARCH_URL/_bulk\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/x-ndjson\" -d $'{\"update\":{\"_id\":\"5\",\"_index\":\"index1\"}}\\n{\"doc\":{\"my_field\":\"foo\"}}\\n{\"update\":{\"_id\":\"6\",\"_index\":\"index1\"}}\\n{\"doc\":{\"my_field\":\"foo\"}}\\n{\"create\":{\"_id\":\"7\",\"_index\":\"index1\"}}\\n{\"my_field\":\"foo\"}\\n' \"$ELASTICSEARCH_URL/_bulk\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"5\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"my_field\": \"foo\"\n                }\n                \"\"\")\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"6\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"my_field\": \"foo\"\n                }\n                \"\"\")\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkCreateOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"my_field\": \"foo\"\n            }\n            \"\"\"))\n            {\n                Id = \"7\",\n                Index = \"index1\"\n            }\n        }\n    });"
     }
   ],
   "specification/_global/bulk/examples/request/BulkRequestExample2.yaml": [
@@ -4102,7 +4578,11 @@
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '[{\"update\":{\"_id\":\"1\",\"_index\":\"index1\",\"retry_on_conflict\":3}},{\"doc\":{\"field\":\"value\"}},{\"update\":{\"_id\":\"0\",\"_index\":\"index1\",\"retry_on_conflict\":3}},{\"script\":{\"source\":\"ctx._source.counter += params.param1\",\"lang\":\"painless\",\"params\":{\"param1\":1}},\"upsert\":{\"counter\":1}},{\"update\":{\"_id\":\"2\",\"_index\":\"index1\",\"retry_on_conflict\":3}},{\"doc\":{\"field\":\"value\"},\"doc_as_upsert\":true},{\"update\":{\"_id\":\"3\",\"_index\":\"index1\",\"_source\":true}},{\"doc\":{\"field\":\"value\"}},{\"update\":{\"_id\":\"4\",\"_index\":\"index1\"}},{\"doc\":{\"field\":\"value\"},\"_source\":true}]' \"$ELASTICSEARCH_URL/_bulk\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/x-ndjson\" -d $'{\"update\":{\"_id\":\"1\",\"_index\":\"index1\",\"retry_on_conflict\":3}}\\n{\"doc\":{\"field\":\"value\"}}\\n{\"update\":{\"_id\":\"0\",\"_index\":\"index1\",\"retry_on_conflict\":3}}\\n{\"script\":{\"source\":\"ctx._source.counter += params.param1\",\"lang\":\"painless\",\"params\":{\"param1\":1}},\"upsert\":{\"counter\":1}}\\n{\"update\":{\"_id\":\"2\",\"_index\":\"index1\",\"retry_on_conflict\":3}}\\n{\"doc\":{\"field\":\"value\"},\"doc_as_upsert\":true}\\n{\"update\":{\"_id\":\"3\",\"_index\":\"index1\",\"_source\":true}}\\n{\"doc\":{\"field\":\"value\"}}\\n{\"update\":{\"_id\":\"4\",\"_index\":\"index1\"}}\\n{\"doc\":{\"field\":\"value\"},\"_source\":true}\\n' \"$ELASTICSEARCH_URL/_bulk\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"1\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\"),\n                RetryOnConflict = 3\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"0\")\n            {\n                Index = \"index1\",\n                Upsert = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"counter\": 1\n                }\n                \"\"\"),\n                Script = new()\n                {\n                    Lang = ScriptLanguage.Painless,\n                    Params = new Dictionary<string, object>()\n                    {\n                        { \"param1\", 1 }\n                    },\n                    Source = \"ctx._source.counter += params.param1\"\n                },\n                RetryOnConflict = 3\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"2\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\"),\n                DocAsUpsert = true,\n                RetryOnConflict = 3\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"3\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\")\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"4\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\"),\n                Source = new global::Elastic.Clients.Elasticsearch.Union<bool, SourceFilter>(true)\n            }\n        }\n    });"
     }
   ],
   "specification/_global/bulk/examples/request/BulkRequestExample1.yaml": [
@@ -4124,7 +4604,11 @@
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '[{\"index\":{\"_index\":\"test\",\"_id\":\"1\"}},{\"field1\":\"value1\"},{\"delete\":{\"_index\":\"test\",\"_id\":\"2\"}},{\"create\":{\"_index\":\"test\",\"_id\":\"3\"}},{\"field1\":\"value3\"},{\"update\":{\"_id\":\"1\",\"_index\":\"test\"}},{\"doc\":{\"field2\":\"value2\"}}]' \"$ELASTICSEARCH_URL/_bulk\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/x-ndjson\" -d $'{\"index\":{\"_index\":\"test\",\"_id\":\"1\"}}\\n{\"field1\":\"value1\"}\\n{\"delete\":{\"_index\":\"test\",\"_id\":\"2\"}}\\n{\"create\":{\"_index\":\"test\",\"_id\":\"3\"}}\\n{\"field1\":\"value3\"}\\n{\"update\":{\"_id\":\"1\",\"_index\":\"test\"}}\\n{\"doc\":{\"field2\":\"value2\"}}\\n' \"$ELASTICSEARCH_URL/_bulk\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkIndexOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field1\": \"value1\"\n            }\n            \"\"\"))\n            {\n                Id = \"1\",\n                Index = \"test\"\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkDeleteOperation(\"2\")\n            {\n                Index = \"test\"\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkCreateOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field1\": \"value3\"\n            }\n            \"\"\"))\n            {\n                Id = \"3\",\n                Index = \"test\"\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"1\")\n            {\n                Index = \"test\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field2\": \"value2\"\n                }\n                \"\"\")\n            }\n        }\n    });"
     }
   ],
   "specification/_global/explain/examples/request/ExplainRequestExample1.yaml": [
@@ -4147,6 +4631,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"match\":{\"message\":\"elasticsearch\"}}}' \"$ELASTICSEARCH_URL/my-index-000001/_explain/0\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ExplainAsync<MyDocument>(index: \"my-index-000001\", id: \"0\", d1 => d1\n        .Query(d2 => d2\n            .Match(d3 => d3\n                .Field(x => x.Message)\n                .Query(\"elasticsearch\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4175,6 +4663,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_scripts/my-search-template\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.GetScriptAsync(id: \"my-search-template\");"
+    },
+    {
       "language": "Java",
       "code": "client.getScript(g -> g\n    .id(\"my-search-template\")\n);\n"
     }
@@ -4199,6 +4691,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"id\":\"my-search-template\",\"params\":{\"query_string\":\"hello world\",\"from\":0,\"size\":10}}' \"$ELASTICSEARCH_URL/my-index/_search/template\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .SearchTemplateAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"my-index\" })\n        .Id(\"my-search-template\")\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"hello world\" },\n            { \"from\", 0 },\n            { \"size\", 10 }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -4227,6 +4723,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"scroll_id\":\"DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==\"}' \"$ELASTICSEARCH_URL/_search/scroll\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .ScrollAsync<MyDocument>(d1 => d1\n        .ScrollId(\"DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.scroll(s -> s\n    .scrollId(\"DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==\")\n);\n"
     }
@@ -4251,6 +4751,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"if (ctx._source.tags.contains(params.tag)) { ctx.op = '\"'\"'delete'\"'\"' } else { ctx.op = '\"'\"'noop'\"'\"' }\",\"lang\":\"painless\",\"params\":{\"tag\":\"green\"}}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"tag\", \"green\" }\n            })\n            .Source(\"if (ctx._source.tags.contains(params.tag)) { ctx.op = 'delete' } else { ctx.op = 'noop' }\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4279,6 +4783,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":\"ctx._source['\"'\"'my-object'\"'\"'].remove('\"'\"'my-subfield'\"'\"')\"}' \"$ELASTICSEARCH_URL/test/_update/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Source(\"ctx._source['my-object'].remove('my-subfield')\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source['my-object'].remove('my-subfield')\")\n        )\n    )\n,Void.class);\n"
     }
@@ -4303,6 +4811,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"ctx._source.counter += params.count\",\"lang\":\"painless\",\"params\":{\"count\":4}}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 4 }\n            })\n            .Source(\"ctx._source.counter += params.count\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4331,6 +4843,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"if (ctx._source.tags.contains(params.tag)) { ctx._source.tags.remove(ctx._source.tags.indexOf(params.tag)) }\",\"lang\":\"painless\",\"params\":{\"tag\":\"blue\"}}}' \"$ELASTICSEARCH_URL/test/_update/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"tag\", \"blue\" }\n            })\n            .Source(\"if (ctx._source.tags.contains(params.tag)) { ctx._source.tags.remove(ctx._source.tags.indexOf(params.tag)) }\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"if (ctx._source.tags.contains(params.tag)) { ctx._source.tags.remove(ctx._source.tags.indexOf(params.tag)) }\")\n        )\n        .params(\"tag\", JsonData.fromJson(\"\\\"blue\\\"\"))\n        .lang(\"painless\")\n    )\n,Void.class);\n"
     }
@@ -4355,6 +4871,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"ctx._source.tags.add(params.tag)\",\"lang\":\"painless\",\"params\":{\"tag\":\"blue\"}}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"tag\", \"blue\" }\n            })\n            .Source(\"ctx._source.tags.add(params.tag)\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4383,6 +4903,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":\"ctx._source.remove('\"'\"'new_field'\"'\"')\"}' \"$ELASTICSEARCH_URL/test/_update/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Source(\"ctx._source.remove('new_field')\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source.remove('new_field')\")\n        )\n    )\n,Void.class);\n"
     }
@@ -4407,6 +4931,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"scripted_upsert\":true,\"script\":{\"source\":\"\\n      if ( ctx.op == '\"'\"'create'\"'\"' ) {\\n        ctx._source.counter = params.count\\n      } else {\\n        ctx._source.counter += params.count\\n      }\\n    \",\"params\":{\"count\":4}},\"upsert\":{}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 4 }\n            })\n            .Source(\"\\n      if ( ctx.op == 'create' ) {\\n        ctx._source.counter = params.count\\n      } else {\\n        ctx._source.counter += params.count\\n      }\\n    \")\n        )\n        .ScriptedUpsert(true)\n        .Upsert(new MyDocument())\n    );"
     },
     {
       "language": "Java",
@@ -4435,6 +4963,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"ctx._source.counter += params.count\",\"lang\":\"painless\",\"params\":{\"count\":4}},\"upsert\":{\"counter\":1}}' \"$ELASTICSEARCH_URL/test/_update/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 4 }\n            })\n            .Source(\"ctx._source.counter += params.count\")\n        )\n        .Upsert(new MyDocument()\n        {\n            Counter = 1\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source.counter += params.count\")\n        )\n        .params(\"count\", JsonData.fromJson(\"4\"))\n        .lang(\"painless\")\n    )\n    .upsert(JsonData.fromJson(\"{\\\"counter\\\":1}\"))\n,Void.class);\n"
     }
@@ -4459,6 +4991,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"doc\":{\"name\":\"new_name\"}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Doc(new MyDocument()\n        {\n            Name = \"new_name\"\n        })\n    );"
     },
     {
       "language": "Java",
@@ -4487,6 +5023,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"doc\":{\"name\":\"new_name\"},\"doc_as_upsert\":true}' \"$ELASTICSEARCH_URL/test/_update/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Doc(new MyDocument()\n        {\n            Name = \"new_name\"\n        })\n        .DocAsUpsert(true)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.update(u -> u\n    .doc(JsonData.fromJson(\"{\\\"name\\\":\\\"new_name\\\"}\"))\n    .docAsUpsert(true)\n    .id(\"1\")\n    .index(\"test\")\n,Void.class);\n"
     }
@@ -4511,6 +5051,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":\"ctx._source.new_field = '\"'\"'value_of_new_field'\"'\"'\"}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Source(\"ctx._source.new_field = 'value_of_new_field'\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4539,6 +5083,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_doc/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.DeleteAsync(index: \"my-index-000001\", id: \"1\");"
+    },
+    {
       "language": "Java",
       "code": "client.delete(d -> d\n    .id(\"1\")\n    .index(\"my-index-000001\")\n);\n"
     }
@@ -4563,6 +5111,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"ctx._source['\"'\"'extra'\"'\"'] = '\"'\"'test'\"'\"'\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_update_by_query?refresh&slices=5\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Refresh(true)\n        .Slices(new Slices(5))\n        .Script(d2 => d2\n            .Source(\"ctx._source['extra'] = 'test'\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4591,6 +5143,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"ctx._source.count++\",\"lang\":\"painless\"},\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}' \"$ELASTICSEARCH_URL/my-index-000001/_update_by_query\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.User.Id)\n                .Value(\"kimchy\")\n            )\n        )\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Source(\"ctx._source.count++\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.updateByQuery(u -> u\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"user.id\")\n            .value(FieldValue.of(\"kimchy\"))\n        )\n    )\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source.count++\")\n        )\n        .lang(\"painless\")\n    )\n);\n"
     }
@@ -4615,6 +5171,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"slice\":{\"id\":0,\"max\":2},\"script\":{\"source\":\"ctx._source['\"'\"'extra'\"'\"'] = '\"'\"'test'\"'\"'\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_update_by_query\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Script(d2 => d2\n            .Source(\"ctx._source['extra'] = 'test'\")\n        )\n        .Slice(d2 => d2\n            .Id(0L)\n            .Max(2)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4643,6 +5203,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}' \"$ELASTICSEARCH_URL/my-index-000001/_update_by_query?conflicts=proceed\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .UpdateByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.User.Id)\n                .Value(\"kimchy\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.updateByQuery(u -> u\n    .conflicts(Conflicts.Proceed)\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"user.id\")\n            .value(FieldValue.of(\"kimchy\"))\n        )\n    )\n);\n"
     }
@@ -4667,6 +5231,10 @@
     {
       "language": "curl",
       "code": "curl --head -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_doc/0\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.ExistsAsync(index: \"my-index-000001\", id: \"0\");"
     },
     {
       "language": "Java",
@@ -4717,6 +5285,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"lang\":\"painless\",\"source\":\"Math.log(_score * 2) + params['\"'\"'my_modifier'\"'\"']\"}}' \"$ELASTICSEARCH_URL/_scripts/my-stored-script\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .PutScriptAsync(new PutScriptRequest()\n    {\n        Id = \"my-stored-script\",\n        Script = new()\n        {\n            Language = ScriptLanguage.Painless,\n            Source = \"Math.log(_score * 2) + params['my_modifier']\"\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.putScript(p -> p\n    .id(\"my-stored-script\")\n    .script(s -> s\n        .lang(\"painless\")\n        .source(so -> so\n            .scriptString(\"Math.log(_score * 2) + params['my_modifier']\")\n        )\n    )\n);\n"
     }
@@ -4741,6 +5313,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_reindex/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexRethrottleAsync(taskId: \"r1A2WoRbTwKZ516z6NEs5A:36619\", d1 => d1\n        .RequestsPerSecond(-1f)\n    );"
     },
     {
       "language": "Java",
@@ -4769,6 +5345,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}' \"$ELASTICSEARCH_URL/my-index-000001/_count\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .CountAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.User.Id)\n                .Value(\"kimchy\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.count(c -> c\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"user.id\")\n            .value(FieldValue.of(\"kimchy\"))\n        )\n    )\n);\n"
     }
@@ -4793,6 +5373,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"doc\":{\"plot\":\"When wealthy industrialist Tony Stark is forced to build an armored suit after a life-threatening incident, he ultimately decides to use its technology to fight against evil.\"},\"term_statistics\":true,\"field_statistics\":true,\"positions\":false,\"offsets\":false,\"filter\":{\"max_num_terms\":3,\"min_term_freq\":1,\"min_doc_freq\":1}}' \"$ELASTICSEARCH_URL/imdb/_termvectors\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .TermvectorsAsync<MyDocument>(index: \"imdb\", id: null, d1 => d1\n        .Doc(new MyDocument()\n        {\n            Plot = \"When wealthy industrialist Tony Stark is forced to build an armored suit after a life-threatening incident, he ultimately decides to use its technology to fight against evil.\"\n        })\n        .FieldStatistics(true)\n        .Filter(d2 => d2\n            .MaxNumTerms(3)\n            .MinDocFreq(1)\n            .MinTermFreq(1)\n        )\n        .Offsets(false)\n        .Positions(false)\n        .TermStatistics(true)\n    );"
     },
     {
       "language": "Java",
@@ -4821,6 +5405,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"doc\":{\"fullname\":\"John Doe\",\"text\":\"test test test\"},\"fields\":[\"fullname\"],\"per_field_analyzer\":{\"fullname\":\"keyword\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_termvectors\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .TermvectorsAsync<MyDocument>(index: \"my-index-000001\", id: null, d1 => d1\n        .Doc(new MyDocument()\n        {\n            Fullname = \"John Doe\",\n            Text = \"test test test\"\n        })\n        .Fields(x => x.Fullname)\n        .PerFieldAnalyzer(new Dictionary<Field, string>()\n        {\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Fullname), \"keyword\" }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.termvectors(t -> t\n    .doc(JsonData.fromJson(\"{\\\"fullname\\\":\\\"John Doe\\\",\\\"text\\\":\\\"test test test\\\"}\"))\n    .fields(\"fullname\")\n    .index(\"my-index-000001\")\n    .perFieldAnalyzer(\"fullname\", \"keyword\")\n);\n"
     }
@@ -4845,6 +5433,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"doc\":{\"fullname\":\"John Doe\",\"text\":\"test test test\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_termvectors\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .TermvectorsAsync<MyDocument>(index: \"my-index-000001\", id: null, d1 => d1\n        .Doc(new MyDocument()\n        {\n            Fullname = \"John Doe\",\n            Text = \"test test test\"\n        })\n    );"
     },
     {
       "language": "Java",
@@ -4873,6 +5465,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"fields\":[\"text\",\"some_field_without_term_vectors\"],\"offsets\":true,\"positions\":true,\"term_statistics\":true,\"field_statistics\":true}' \"$ELASTICSEARCH_URL/my-index-000001/_termvectors/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .TermvectorsAsync<MyDocument>(index: \"my-index-000001\", id: \"1\", d1 => d1\n        .Fields(x => x.Text, x => x.SomeFieldWithoutTermVectors)\n        .FieldStatistics(true)\n        .Offsets(true)\n        .Positions(true)\n        .TermStatistics(true)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.termvectors(t -> t\n    .fieldStatistics(true)\n    .fields(List.of(\"text\",\"some_field_without_term_vectors\"))\n    .id(\"1\")\n    .index(\"my-index-000001\")\n    .offsets(true)\n    .positions(true)\n    .termStatistics(true)\n);\n"
     }
@@ -4899,6 +5495,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"fields\":[\"text\"],\"offsets\":true,\"payloads\":true,\"positions\":true,\"term_statistics\":true,\"field_statistics\":true}' \"$ELASTICSEARCH_URL/my-index-000001/_termvectors/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .TermvectorsAsync<MyDocument>(index: \"my-index-000001\", id: \"1\", d1 => d1\n        .Fields(x => x.Text)\n        .FieldStatistics(true)\n        .Offsets(true)\n        .Payloads(true)\n        .Positions(true)\n        .TermStatistics(true)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.termvectors(t -> t\n    .fieldStatistics(true)\n    .fields(\"text\")\n    .id(\"1\")\n    .index(\"my-index-000001\")\n    .offsets(true)\n    .payloads(true)\n    .positions(true)\n    .termStatistics(true)\n);\n"
     }
@@ -4923,6 +5523,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grid_agg\":\"geotile\",\"grid_precision\":2,\"fields\":[\"name\",\"price\"],\"query\":{\"term\":{\"included\":true}},\"aggs\":{\"min_price\":{\"min\":{\"field\":\"price\"}},\"max_price\":{\"max\":{\"field\":\"price\"}},\"avg_price\":{\"avg\":{\"field\":\"price\"}}}}' \"$ELASTICSEARCH_URL/museums/_mvt/location/13/4207/2692\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .SearchMvtAsync(indices: new[] { \"museums\" }, field: global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Location), zoom: 13, x: 4207, y: 2692, d1 => d1\n        .Aggs(d2 => d2\n            .Add(\"min_price\", d3 => d3\n                .Min(d4 => d4\n                    .Field(x => x.Price)\n                )\n            )\n            .Add(\"max_price\", d3 => d3\n                .Max(d4 => d4\n                    .Field(x => x.Price)\n                )\n            )\n            .Add(\"avg_price\", d3 => d3\n                .Avg(d4 => d4\n                    .Field(x => x.Price)\n                )\n            )\n        )\n        .Fields(x => x.Name, x => x.Price)\n        .GridAgg(GridAggregationType.Geotile)\n        .GridPrecision(2)\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.Included)\n                .Value(true)\n            )\n        )\n    );"
     }
   ],
   "specification/_global/delete_by_query_rethrottle/examples/request/DeleteByQueryRethrottleRequestExample1.yaml": [
@@ -4945,6 +5549,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_delete_by_query/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .DeleteByQueryRethrottleAsync(taskId: \"r1A2WoRbTwKZ516z6NEs5A:36619\", d1 => d1\n        .RequestsPerSecond(-1f)\n    );"
     },
     {
       "language": "Java",
@@ -4971,6 +5579,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_doc/1?stored_fields=tags,counter\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .GetAsync<MyDocument>(index: \"my-index-000001\", id: \"1\", d1 => d1\n        .StoredFields(x => x.Tags, x => x.Counter)\n    );"
     }
   ],
   "specification/_global/render_search_template/examples/request/RenderSearchTemplateRequestExample1.yaml": [
@@ -4993,6 +5605,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"id\":\"my-search-template\",\"params\":{\"query_string\":\"hello world\",\"from\":20,\"size\":10}}' \"$ELASTICSEARCH_URL/_render/template\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .RenderSearchTemplateAsync(d1 => d1\n        .Id(\"my-search-template\")\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"hello world\" },\n            { \"from\", 20 },\n            { \"size\", 10 }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -5021,6 +5637,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_pit?keep_alive=1m&allow_partial_search_results=true\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .OpenPointInTimeAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .AllowPartialSearchResults(true)\n        .KeepAlive(\"1m\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.openPointInTime(o -> o\n    .allowPartialSearchResults(true)\n    .index(\"my-index-000001\")\n    .keepAlive(k -> k\n        .offset(1)\n    )\n);\n"
     }
@@ -5045,6 +5665,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_search_shards\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .SearchShardsAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n    );"
     },
     {
       "language": "Java",
@@ -5073,6 +5697,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"match_all\":{}}}' \"$ELASTICSEARCH_URL/my-index-000001,my-index-000002/_delete_by_query\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .DeleteByQueryAsync(indices: new[] { \"my-index-000001\", \"my-index-000002\" }, d1 => d1\n        .Query(d2 => d2\n            .MatchAll()\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.deleteByQuery(d -> d\n    .index(List.of(\"my-index-000001\",\"my-index-000002\"))\n    .query(q -> q\n        .matchAll(m -> m)\n    )\n);\n"
     }
@@ -5097,6 +5725,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"user.id\":\"kimchy\"}},\"max_docs\":1}' \"$ELASTICSEARCH_URL/my-index-000001/_delete_by_query\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .DeleteByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .MaxDocs(1L)\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.User.Id)\n                .Value(\"kimchy\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5125,6 +5757,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"slice\":{\"id\":0,\"max\":2},\"query\":{\"range\":{\"http.response.bytes\":{\"lt\":2000000}}}}' \"$ELASTICSEARCH_URL/my-index-000001/_delete_by_query\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .DeleteByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Query(d2 => d2\n            .Range(new UntypedRangeQuery()\n            {\n                Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Http.Response.Bytes),\n                Lt = 2000000\n            })\n        )\n        .Slice(d2 => d2\n            .Id(0L)\n            .Max(2)\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.deleteByQuery(d -> d\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .range(r -> r\n            .untyped(u -> u\n                .field(\"http.response.bytes\")\n                .lt(JsonData.fromJson(\"2000000\"))\n            )\n        )\n    )\n    .slice(s -> s\n        .id(\"0\")\n        .max(2)\n    )\n);\n"
     }
@@ -5149,6 +5785,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"range\":{\"http.response.bytes\":{\"lt\":2000000}}}}' \"$ELASTICSEARCH_URL/my-index-000001/_delete_by_query?refresh&slices=5\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .DeleteByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Refresh(true)\n        .Slices(new Slices(5))\n        .Query(d2 => d2\n            .Range(new UntypedRangeQuery()\n            {\n                Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Http.Response.Bytes),\n                Lt = 2000000\n            })\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5177,6 +5817,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_health_report\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.HealthReportAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.healthReport(h -> h);\n"
     }
@@ -5201,12 +5845,16 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_filter\":{\"range\":{\"@timestamp\":{\"gte\":\"2018\"}}}}' \"$ELASTICSEARCH_URL/my-index-*/_field_caps?fields=rating\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .FieldCapsAsync(d1 => d1\n        .Indices(new[] { \"my-index-*\" })\n        .IndexFilter(d2 => d2\n            .Range(new UntypedRangeQuery()\n            {\n                Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Timestamp),\n                Gte = \"2018\"\n            })\n        )\n    );"
     }
   ],
   "specification/_global/search/examples/request/SearchRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.search(\n    index=\"my-index-000001\",\n    from=\"40\",\n    size=\"20\",\n    query={\n        \"term\": {\n            \"user.id\": \"kimchy\"\n        }\n    },\n)"
+      "code": "resp = client.search(\n    index=\"my-index-000001\",\n    from_=\"40\",\n    size=\"20\",\n    query={\n        \"term\": {\n            \"user.id\": \"kimchy\"\n        }\n    },\n)"
     },
     {
       "language": "JavaScript",
@@ -5223,6 +5871,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}' \"$ELASTICSEARCH_URL/my-index-000001/_search?from=40&size=20\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .SearchAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.User.Id)\n                .Value(\"kimchy\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5251,6 +5903,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"size\":100,\"query\":{\"match\":{\"title\":\"elasticsearch\"}},\"pit\":{\"id\":\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\",\"keep_alive\":\"1m\"}}' \"$ELASTICSEARCH_URL/_search\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .SearchAsync<MyDocument>(d1 => d1\n        .Pit(d2 => d2\n            .Id(\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\")\n            .KeepAlive(\"1m\")\n        )\n        .Query(d2 => d2\n            .Match(d3 => d3\n                .Field(x => x.Title)\n                .Query(\"elasticsearch\")\n            )\n        )\n        .Size(100)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.search(s -> s\n    .pit(p -> p\n        .id(\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\")\n        .keepAlive(k -> k\n            .time(\"1m\")\n        )\n    )\n    .query(q -> q\n        .match(m -> m\n            .field(\"title\")\n            .query(FieldValue.of(\"elasticsearch\"))\n        )\n    )\n    .size(100)\n,Void.class);\n"
     }
@@ -5275,6 +5931,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"slice\":{\"id\":0,\"max\":2},\"query\":{\"match\":{\"message\":\"foo\"}},\"pit\":{\"id\":\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\"}}' \"$ELASTICSEARCH_URL/_search\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .SearchAsync<MyDocument>(d1 => d1\n        .Pit(d2 => d2\n            .Id(\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\")\n        )\n        .Query(d2 => d2\n            .Match(d3 => d3\n                .Field(x => x.Message)\n                .Query(\"foo\")\n            )\n        )\n        .Slice(d2 => d2\n            .Id(0L)\n            .Max(2)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5303,6 +5963,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_id\":\"2\",\"fields\":[\"message\"],\"term_statistics\":true},{\"_id\":\"1\"}]}' \"$ELASTICSEARCH_URL/my-index-000001/_mtermvectors\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .MtermvectorsAsync(d1 => d1\n        .Index(\"my-index-000001\")\n        .Docs(d2 => d2\n            .Fields(x => x.Message)\n            .Id(\"2\")\n            .TermStatistics(true), d2 => d2\n            .Id(\"1\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.mtermvectors(m -> m\n    .docs(List.of(MultiTermVectorsOperation.of(mu -> mu\n            .id(\"2\")\n            .fields(\"message\")\n            .termStatistics(true)),MultiTermVectorsOperation.of(mu -> mu\n            .id(\"1\"))))\n    .index(\"my-index-000001\")\n);\n"
     }
@@ -5327,6 +5991,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"ids\":[\"1\",\"2\"],\"fields\":[\"message\"],\"term_statistics\":true}' \"$ELASTICSEARCH_URL/my-index-000001/_mtermvectors\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .MtermvectorsAsync(d1 => d1\n        .Index(\"my-index-000001\")\n        .Ids([\"1\", \"2\"])\n    );"
     },
     {
       "language": "Java",
@@ -5355,6 +6023,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"my-index-000001\",\"doc\":{\"message\":\"test test test\"}},{\"_index\":\"my-index-000001\",\"doc\":{\"message\":\"Another test ...\"}}]}' \"$ELASTICSEARCH_URL/_mtermvectors\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .MtermvectorsAsync(d1 => d1\n        .Docs(d2 => d2\n            .Doc(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"message\": \"test test test\"\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\"), d2 => d2\n            .Doc(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"message\": \"Another test ...\"\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.mtermvectors(m -> m\n    .docs(List.of(MultiTermVectorsOperation.of(mu -> mu\n            .index(\"my-index-000001\")\n            .doc(JsonData.fromJson(\"{\\\"message\\\":\\\"test test test\\\"}\"))),MultiTermVectorsOperation.of(mu -> mu\n            .index(\"my-index-000001\")\n            .doc(JsonData.fromJson(\"{\\\"message\\\":\\\"Another test ...\\\"}\")))))\n);\n"
     }
@@ -5379,6 +6051,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.InfoAsync();"
     },
     {
       "language": "Java",
@@ -5407,6 +6083,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"scroll_id\":\"DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==\"}' \"$ELASTICSEARCH_URL/_search/scroll\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .ClearScrollAsync(d1 => d1\n        .ScrollId(new[] { \"DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==\" })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.clearScroll(c -> c\n    .scrollId(\"DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==\")\n);\n"
     }
@@ -5431,6 +6111,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\"},\"dest\":{\"index\":\"my-new-index-000001\"},\"script\":{\"source\":\"ctx._source.tag = ctx._source.remove(\\\"flag\\\")\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .Script(d2 => d2\n            .Source(\"ctx._source.tag = ctx._source.remove(\\\"flag\\\")\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample5.yaml": [
@@ -5453,6 +6137,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"source\"},\"dest\":{\"index\":\"dest\",\"pipeline\":\"some_ingest_pipeline\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"dest\")\n            .Pipeline(\"some_ingest_pipeline\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"source\" })\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample11.yaml": [
@@ -5475,6 +6163,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"max_docs\":10,\"source\":{\"index\":\"my-index-000001\",\"query\":{\"function_score\":{\"random_score\":{},\"min_score\":0.9}}},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .MaxDocs(10L)\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n            .Query(d3 => d3\n                .FunctionScore(d4 => d4\n                    .MinScore(0.9d)\n                )\n            )\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample10.yaml": [
@@ -5497,6 +6189,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"metricbeat-*\"},\"dest\":{\"index\":\"metricbeat\"},\"script\":{\"lang\":\"painless\",\"source\":\"ctx._index = '\"'\"'metricbeat-'\"'\"' + (ctx._index.substring('\"'\"'metricbeat-'\"'\"'.length(), ctx._index.length())) + '\"'\"'-1'\"'\"'\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"metricbeat\")\n        )\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Source(\"ctx._index = 'metricbeat-' + (ctx._index.substring('metricbeat-'.length(), ctx._index.length())) + '-1'\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"metricbeat-*\" })\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample4.yaml": [
@@ -5519,6 +6215,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"source\",\"query\":{\"match\":{\"company\":\"cat\"}}},\"dest\":{\"index\":\"dest\",\"routing\":\"=cat\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"dest\")\n            .Routing(\"=cat\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"source\" })\n            .Query(d3 => d3\n                .Match(d4 => d4\n                    .Field(x => x.Company)\n                    .Query(\"cat\")\n                )\n            )\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample8.yaml": [
@@ -5541,6 +6241,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\",\"_source\":[\"user.id\",\"_doc\"]},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n            .SourceFields(new SourceConfig(new SourceFilter()\n            {\n                Includes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.User.Id, x => x.Doc)\n            }))\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample3.yaml": [
@@ -5563,6 +6267,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\"},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex?slices=5&refresh\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Refresh(true)\n        .Slices(new Slices(5))\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample2.yaml": [
@@ -5585,6 +6293,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\",\"slice\":{\"id\":0,\"max\":2}},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n            .Slice(d3 => d3\n                .Id(0L)\n                .Max(2)\n            )\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample1.yaml": [
@@ -5607,6 +6319,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":[\"my-index-000001\",\"my-index-000002\"]},\"dest\":{\"index\":\"my-new-index-000002\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000002\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\", \"my-index-000002\" })\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5633,6 +6349,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"remote\":{\"host\":\"http://otherhost:9200\",\"username\":\"user\",\"password\":\"pass\"},\"index\":\"my-index-000001\",\"query\":{\"match\":{\"test\":\"data\"}}},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n            .Query(d3 => d3\n                .Match(d4 => d4\n                    .Field(x => x.Test)\n                    .Query(\"data\")\n                )\n            )\n            .Remote(d3 => d3\n                .Host(\"http://otherhost:9200\")\n                .Password(\"pass\")\n                .Username(\"user\")\n            )\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample7.yaml": [
@@ -5655,6 +6375,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"max_docs\":1,\"source\":{\"index\":\"my-index-000001\"},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .MaxDocs(1L)\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample6.yaml": [
@@ -5677,6 +6401,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\",\"query\":{\"term\":{\"user.id\":\"kimchy\"}}},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n            .Query(d3 => d3\n                .Term(d4 => d4\n                    .Field(x => x.User.Id)\n                    .Value(\"kimchy\")\n                )\n            )\n        )\n    );"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample12.yaml": [
@@ -5699,6 +6427,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\"},\"dest\":{\"index\":\"my-new-index-000001\",\"version_type\":\"external\"},\"script\":{\"source\":\"if (ctx._source.foo == '\"'\"'bar'\"'\"') {ctx._version++; ctx._source.remove('\"'\"'foo'\"'\"')}\",\"lang\":\"painless\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n            .VersionType(VersionType.External)\n        )\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Source(\"if (ctx._source.foo == 'bar') {ctx._version++; ctx._source.remove('foo')}\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n        )\n    );"
     }
   ],
   "specification/_global/index/examples/request/IndexRequestExample1.yaml": [
@@ -5721,6 +6453,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"@timestamp\":\"2099-11-15T13:12:00\",\"message\":\"GET /search HTTP/1.1 200 1070000\",\"user\":{\"id\":\"kimchy\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_doc/\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.IndexAsync<MyDocument>(document: new MyDocument()\n{\n    Timestamp = \"2099-11-15T13:12:00\",\n    Message = \"GET /search HTTP/1.1 200 1070000\",\n    User = new()\n    {\n        Id = \"kimchy\"\n    }\n}, index: \"my-index-000001\", id: null);"
     },
     {
       "language": "Java",
@@ -5749,6 +6485,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"@timestamp\":\"2099-11-15T13:12:00\",\"message\":\"GET /search HTTP/1.1 200 1070000\",\"user\":{\"id\":\"kimchy\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_doc/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.IndexAsync<MyDocument>(document: new MyDocument()\n{\n    Timestamp = \"2099-11-15T13:12:00\",\n    Message = \"GET /search HTTP/1.1 200 1070000\",\n    User = new()\n    {\n        Id = \"kimchy\"\n    }\n}, index: \"my-index-000001\", id: \"1\");"
+    },
+    {
       "language": "Java",
       "code": "client.index(i -> i\n    .id(\"1\")\n    .index(\"my-index-000001\")\n    .document(JsonData.fromJson(\"{\\\"@timestamp\\\":\\\"2099-11-15T13:12:00\\\",\\\"message\\\":\\\"GET /search HTTP/1.1 200 1070000\\\",\\\"user\\\":{\\\"id\\\":\\\"kimchy\\\"}}\"))\n);\n"
     }
@@ -5772,7 +6512,11 @@
     },
     {
       "language": "curl",
-      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '[{},{\"query\":{\"match\":{\"message\":\"this is a test\"}}},{\"index\":\"my-index-000002\"},{\"query\":{\"match_all\":{}}}]' \"$ELASTICSEARCH_URL/my-index-000001/_msearch\""
+      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/x-ndjson\" -d $'{}\\n{\"query\":{\"match\":{\"message\":\"this is a test\"}}}\\n{\"index\":\"my-index-000002\"}\\n{\"query\":{\"match_all\":{}}}\\n' \"$ELASTICSEARCH_URL/my-index-000001/_msearch\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .MultiSearchAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Searches([new SearchRequestItem(new MultisearchHeader(), new MultisearchBody()\n        {\n            Query = new Query()\n            {\n                Match = new()\n                {\n                    Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Message),\n                    Query = \"this is a test\"\n                }\n            }\n        }), new SearchRequestItem(new MultisearchHeader()\n        {\n            Indices = new[] { \"my-index-000002\" }\n        }, new MultisearchBody()\n        {\n            Query = new Query()\n            {\n                MatchAll = new()\n            }\n        })])\n    );"
     }
   ],
   "specification/_global/delete_script/examples/request/DeleteScriptRequestExample1.yaml": [
@@ -5795,6 +6539,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_scripts/my-search-template\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.DeleteScriptAsync(id: \"my-search-template\");"
     },
     {
       "language": "Java",
@@ -5821,6 +6569,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"test\",\"_id\":\"1\",\"_source\":false},{\"_index\":\"test\",\"_id\":\"2\",\"_source\":[\"field3\",\"field4\"]},{\"_index\":\"test\",\"_id\":\"3\",\"_source\":{\"include\":[\"user\"],\"exclude\":[\"user.location\"]}}]}' \"$ELASTICSEARCH_URL/_mget\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .MultiGetAsync<MyDocument>(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"1\")\n            .Index(\"test\")\n            .Source(new SourceConfig(false)), d2 => d2\n            .Id(\"2\")\n            .Index(\"test\")\n            .Source(new SourceConfig(new SourceFilter()\n            {\n                Includes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.Field3, x => x.Field4)\n            })), d2 => d2\n            .Id(\"3\")\n            .Index(\"test\")\n            .Source(new SourceConfig(new SourceFilter()\n            {\n                Excludes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.User.Location),\n                Includes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.User)\n            }))\n        )\n    );"
     }
   ],
   "specification/_global/mget/examples/request/MultiGetRequestExample3.yaml": [
@@ -5843,6 +6595,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"test\",\"_id\":\"1\",\"stored_fields\":[\"field1\",\"field2\"]},{\"_index\":\"test\",\"_id\":\"2\",\"stored_fields\":[\"field3\",\"field4\"]}]}' \"$ELASTICSEARCH_URL/_mget\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .MultiGetAsync<MyDocument>(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"1\")\n            .Index(\"test\")\n            .StoredFields(x => x.Field1, x => x.Field2), d2 => d2\n            .Id(\"2\")\n            .Index(\"test\")\n            .StoredFields(x => x.Field3, x => x.Field4)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5871,6 +6627,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"test\",\"_id\":\"1\",\"routing\":\"key2\"},{\"_index\":\"test\",\"_id\":\"2\"}]}' \"$ELASTICSEARCH_URL/_mget?routing=key1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .MultiGetAsync<MyDocument>(d1 => d1\n        .Routing(\"key1\")\n        .Docs(d2 => d2\n            .Id(\"1\")\n            .Index(\"test\")\n            .Routing(\"key2\"), d2 => d2\n            .Id(\"2\")\n            .Index(\"test\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.mget(m -> m\n    .docs(List.of(MultiGetOperation.of(mu -> mu\n            .id(\"1\")\n            .index(\"test\")\n            .routing(\"key2\")),MultiGetOperation.of(mu -> mu\n            .id(\"2\")\n            .index(\"test\"))))\n    .routing(\"key1\")\n);\n"
     }
@@ -5895,6 +6655,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_id\":\"1\"},{\"_id\":\"2\"}]}' \"$ELASTICSEARCH_URL/my-index-000001/_mget\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .MultiGetAsync<MyDocument>(d1 => d1\n        .Index(\"my-index-000001\")\n        .Docs(d2 => d2\n            .Id(\"1\"), d2 => d2\n            .Id(\"2\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5923,6 +6687,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"@timestamp\":\"2099-11-15T13:12:00\",\"message\":\"GET /search HTTP/1.1 200 1070000\",\"user\":{\"id\":\"kimchy\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_create/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.CreateAsync<MyDocument>(document: new MyDocument()\n{\n    Timestamp = \"2099-11-15T13:12:00\",\n    Message = \"GET /search HTTP/1.1 200 1070000\",\n    User = new()\n    {\n        Id = \"kimchy\"\n    }\n}, index: \"my-index-000001\", id: \"1\");"
+    },
+    {
       "language": "Java",
       "code": "client.create(c -> c\n    .id(\"1\")\n    .index(\"my-index-000001\")\n    .document(JsonData.fromJson(\"{\\\"@timestamp\\\":\\\"2099-11-15T13:12:00\\\",\\\"message\\\":\\\"GET /search HTTP/1.1 200 1070000\\\",\\\"user\\\":{\\\"id\\\":\\\"kimchy\\\"}}\"))\n);\n"
     }
@@ -5947,6 +6715,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"requests\":[{\"id\":\"JFK query\",\"request\":{\"query\":{\"match_all\":{}}},\"ratings\":[]}],\"metric\":{\"precision\":{\"k\":20,\"relevant_rating_threshold\":1,\"ignore_unlabeled\":false}}}' \"$ELASTICSEARCH_URL/my-index-000001/_rank_eval\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client\n    .RankEvalAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Metric(d2 => d2\n            .Precision(d3 => d3\n                .IgnoreUnlabeled(false)\n                .K(20)\n                .RelevantRatingThreshold(1)\n            )\n        )\n        .Requests(d2 => d2\n            .Id(\"JFK query\")\n            .Ratings(new List<DocumentRating>())\n            .Request(d3 => d3\n                .Query(d4 => d4\n                    .MatchAll()\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5975,6 +6747,10 @@
       "code": "curl --head -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_source/1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.ExistsSourceAsync(index: \"my-index-000001\", id: \"1\");"
+    },
+    {
       "language": "Java",
       "code": "client.existsSource(e -> e\n    .id(\"1\")\n    .index(\"my-index-000001\")\n);\n"
     }
@@ -6001,6 +6777,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"id\":\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\"}' \"$ELASTICSEARCH_URL/_pit\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client\n    .ClosePointInTimeAsync(d1 => d1\n        .Id(\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.closePointInTime(c -> c\n    .id(\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\")\n);\n"
     }
@@ -6016,7 +6796,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.shutdown.put_node(\n  node_id: \"USpTGYaBSIKbgSUJR2Z9lg\",\n  body: {\n    \"type\": \"restart\",\n    \"reason\": \"Demonstrating how the node shutdown API works\",\n    \"allocation_delay\": \"20m\"\n  }\n)"
+      "code": "response = client.perform_request(\n  \"PUT\",\n  \"/_nodes/USpTGYaBSIKbgSUJR2Z9lg/shutdown\",\n  {},\n  {\n    \"type\": \"restart\",\n    \"reason\": \"Demonstrating how the node shutdown API works\",\n    \"allocation_delay\": \"20m\"\n  },\n  { \"Content-Type\": \"application/json\" },\n)"
     },
     {
       "language": "PHP",
@@ -6042,7 +6822,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.shutdown.delete_node(\n  node_id: \"USpTGYaBSIKbgSUJR2Z9lg\"\n)"
+      "code": "response = client.perform_request(\n  \"DELETE\",\n  \"/_nodes/USpTGYaBSIKbgSUJR2Z9lg/shutdown\",\n  {},\n)"
     },
     {
       "language": "PHP",
@@ -6068,7 +6848,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.shutdown.get_node(\n  node_id: \"USpTGYaBSIKbgSUJR2Z9lg\"\n)"
+      "code": "response = client.perform_request(\n  \"GET\",\n  \"/_nodes/USpTGYaBSIKbgSUJR2Z9lg/shutdown\",\n  {},\n)"
     },
     {
       "language": "PHP",
@@ -6086,7 +6866,7 @@
   "specification/watcher/update_settings/examples/request/WatcherUpdateSettingsRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.watcher.update_settings(\n    index.auto_expand_replicas=\"0-4\",\n)"
+      "code": "resp = client.watcher.update_settings(\n    index_auto_expand_replicas=\"0-4\",\n)"
     },
     {
       "language": "JavaScript",
@@ -6495,6 +7275,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"licenses\":[{\"uid\":\"893361dc-9749-4997-93cb-802e3d7fa4xx\",\"type\":\"basic\",\"issue_date_in_millis\":1411948800000,\"expiry_date_in_millis\":1914278399999,\"max_nodes\":1,\"issued_to\":\"issuedTo\",\"issuer\":\"issuer\",\"signature\":\"xx\"}]}' \"$ELASTICSEARCH_URL/_license\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.LicenseManagement\n    .PostAsync(d1 => d1\n        .Licenses(d2 => d2\n            .ExpiryDateInMillis(DateTimeOffset.Parse(\"2030-08-29T23:59:59.9990000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .IssueDateInMillis(DateTimeOffset.Parse(\"2014-09-29T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .IssuedTo(\"issuedTo\")\n            .Issuer(\"issuer\")\n            .MaxNodes(1L)\n            .Signature(\"xx\")\n            .Type(LicenseType.Basic)\n            .Uid(\"893361dc-9749-4997-93cb-802e3d7fa4xx\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.license().post(p -> p\n    .licenses(l -> l\n        .expiryDateInMillis(1914278399999L)\n        .issueDateInMillis(1411948800000L)\n        .issuedTo(\"issuedTo\")\n        .issuer(\"issuer\")\n        .maxNodes(1L)\n        .signature(\"xx\")\n        .type(LicenseType.Basic)\n        .uid(\"893361dc-9749-4997-93cb-802e3d7fa4xx\")\n    )\n);\n"
     }
@@ -6519,6 +7303,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.LicenseManagement.DeleteAsync();"
     },
     {
       "language": "Java",
@@ -6547,6 +7335,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.LicenseManagement.GetAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.license().get(g -> g);\n"
     }
@@ -6571,6 +7363,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license/trial_status\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.LicenseManagement.GetTrialStatusAsync();"
     },
     {
       "language": "Java",
@@ -6599,6 +7395,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license/start_trial?acknowledge=true\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.LicenseManagement\n    .PostStartTrialAsync(d1 => d1\n        .Acknowledge(true)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.license().postStartTrial(p -> p\n    .acknowledge(true)\n);\n"
     }
@@ -6625,6 +7425,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license/basic_status\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.LicenseManagement.GetBasicStatusAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.license().getBasicStatus();\n"
     }
@@ -6649,6 +7453,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license/start_basic?acknowledge=true\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.LicenseManagement\n    .PostStartBasicAsync(d1 => d1\n        .Acknowledge(true)\n    );"
     },
     {
       "language": "Java",
@@ -6755,6 +7563,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm\":\"saml1\",\"ids\":[\"_1c368075e0b3...\"],\"content\":\"PHNhbWxwOkxvZ291dFJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46...\"}' \"$ELASTICSEARCH_URL/_security/saml/complete_logout\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .SamlCompleteLogoutAsync(d1 => d1\n        .Content(\"PHNhbWxwOkxvZ291dFJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46...\")\n        .Ids(new[] { \"_1c368075e0b3...\" })\n        .Realm(\"saml1\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().samlCompleteLogout(s -> s\n    .content(\"PHNhbWxwOkxvZ291dFJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46...\")\n    .ids(\"_1c368075e0b3...\")\n    .realm(\"saml1\")\n);\n"
     }
@@ -6779,6 +7591,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm\":\"saml1\",\"ids\":[\"_1c368075e0b3...\"],\"query_string\":\"SAMLResponse=fZHLasMwEEVbfb1bf...&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1&Signature=CuCmFn%2BLqnaZGZJqK...\"}' \"$ELASTICSEARCH_URL/_security/saml/complete_logout\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .SamlCompleteLogoutAsync(d1 => d1\n        .Ids(new[] { \"_1c368075e0b3...\" })\n        .QueryString(\"SAMLResponse=fZHLasMwEEVbfb1bf...&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1&Signature=CuCmFn%2BLqnaZGZJqK...\")\n        .Realm(\"saml1\")\n    );"
     },
     {
       "language": "Java",
@@ -6807,6 +7623,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/user/jacknich/_disable\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.DisableUserAsync(username: \"jacknich\");"
+    },
+    {
       "language": "Java",
       "code": "client.security().disableUser(d -> d\n    .username(\"jacknich\")\n);\n"
     }
@@ -6814,7 +7634,7 @@
   "specification/security/update_settings/examples/request/SecurityUpdateSettingsRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.security.update_settings(\n    security={\n        \"index.auto_expand_replicas\": \"0-all\"\n    },\n    security-tokens={\n        \"index.auto_expand_replicas\": \"0-all\"\n    },\n    security-profile={\n        \"index.auto_expand_replicas\": \"0-all\"\n    },\n)"
+      "code": "resp = client.security.update_settings(\n    security={\n        \"index.auto_expand_replicas\": \"0-all\"\n    },\n    security_tokens={\n        \"index.auto_expand_replicas\": \"0-all\"\n    },\n    security_profile={\n        \"index.auto_expand_replicas\": \"0-all\"\n    },\n)"
     },
     {
       "language": "JavaScript",
@@ -6831,6 +7651,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"security\":{\"index.auto_expand_replicas\":\"0-all\"},\"security-tokens\":{\"index.auto_expand_replicas\":\"0-all\"},\"security-profile\":{\"index.auto_expand_replicas\":\"0-all\"}}' \"$ELASTICSEARCH_URL/_security/settings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .UpdateSettingsAsync(d1 => d1\n        .Security()\n        .SecurityProfile()\n        .SecurityTokens()\n    );"
     },
     {
       "language": "Java",
@@ -6859,6 +7683,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/profile/u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.GetUserProfileAsync(uid: [\"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\"]);"
+    },
+    {
       "language": "Java",
       "code": "client.security().getUserProfile(g -> g\n    .uid(\"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\")\n);\n"
     }
@@ -6883,6 +7711,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"my-api-key\",\"expiration\":\"1d\",\"role_descriptors\":{\"role-a\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index-a*\"],\"privileges\":[\"read\"]}]},\"role-b\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index-b*\"],\"privileges\":[\"all\"]}]}},\"metadata\":{\"application\":\"my-application\",\"environment\":{\"level\":1,\"trusted\":true,\"tags\":[\"dev\",\"staging\"]}}}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .CreateApiKeyAsync(d1 => d1\n        .Expiration(\"1d\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"application\", \"my-application\" },\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 1,\n              \"trusted\": true,\n              \"tags\": [\n                \"dev\",\n                \"staging\"\n              ]\n            }\n            \"\"\") }\n        })\n        .Name(\"my-api-key\")\n        .RoleDescriptors(d2 => d2\n            .Add(\"role-a\", d3 => d3\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .Names([\"index-a*\"])\n                    .Privileges(IndexPrivilege.Read)\n                )\n            )\n            .Add(\"role-b\", d3 => d3\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .Names([\"index-b*\"])\n                    .Privileges(IndexPrivilege.All)\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -6911,6 +7743,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/privilege/myapp/read\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .GetPrivilegesAsync(d1 => d1\n        .Application(\"myapp\")\n        .Name(new[] { \"read\" })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().getPrivileges(g -> g\n    .application(\"myapp\")\n    .name(\"read\")\n);\n"
     }
@@ -6935,6 +7771,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"access\":{\"replication\":[{\"names\":[\"archive\"]}]},\"metadata\":{\"application\":\"replication\"}}' \"$ELASTICSEARCH_URL/_security/cross_cluster/api_key/VuaCfGcBCdbkQm-e5aOx\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .UpdateCrossClusterApiKeyAsync(id: \"VuaCfGcBCdbkQm-e5aOx\", d1 => d1\n        .Access(d2 => d2\n            .Replication(d3 => d3\n                .Names([\"archive\"])\n            )\n        )\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"application\", \"replication\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -6963,6 +7803,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/settings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.GetSettingsAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.security().getSettings(g -> g);\n"
     }
@@ -6987,6 +7831,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/privilege/_builtin\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security.GetBuiltinPrivilegesAsync();"
     },
     {
       "language": "Java",
@@ -7015,6 +7863,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"uids\":[\"u_LQPnxDxEjIH0GOUoFkZr5Y57YUwSkL9Joiq-g4OCbPc_0\",\"u_rzRnxDgEHIH0GOUoFkZr5Y27YUwSk19Joiq=g4OCxxB_1\",\"u_does-not-exist_0\"],\"privileges\":{\"cluster\":[\"monitor\",\"create_snapshot\",\"manage_ml\"],\"index\":[{\"names\":[\"suppliers\",\"products\"],\"privileges\":[\"create_doc\"]},{\"names\":[\"inventory\"],\"privileges\":[\"read\",\"write\"]}],\"application\":[{\"application\":\"inventory_manager\",\"privileges\":[\"read\",\"data:write/inventory\"],\"resources\":[\"product/1852563\"]}]}}' \"$ELASTICSEARCH_URL/_security/profile/_has_privileges\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .HasPrivilegesUserProfileAsync(d1 => d1\n        .Privileges(d2 => d2\n            .Application(d3 => d3\n                .Application(\"inventory_manager\")\n                .Privileges(\"read\", \"data:write/inventory\")\n                .Resources(\"product/1852563\")\n            )\n            .Cluster(ClusterPrivilege.Monitor, ClusterPrivilege.CreateSnapshot, ClusterPrivilege.ManageMl)\n            .Index(d3 => d3\n                .Names(new[] { \"suppliers\", \"products\" })\n                .Privileges(IndexPrivilege.CreateDoc), d3 => d3\n                .Names(new[] { \"inventory\" })\n                .Privileges(IndexPrivilege.Read, IndexPrivilege.Write)\n            )\n        )\n        .Uids(\"u_LQPnxDxEjIH0GOUoFkZr5Y57YUwSkL9Joiq-g4OCbPc_0\", \"u_rzRnxDgEHIH0GOUoFkZr5Y27YUwSk19Joiq=g4OCxxB_1\", \"u_does-not-exist_0\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().hasPrivilegesUserProfile(h -> h\n    .privileges(p -> p\n        .application(a -> a\n            .application(\"inventory_manager\")\n            .privileges(List.of(\"read\",\"data:write/inventory\"))\n            .resources(\"product/1852563\")\n        )\n        .cluster(List.of(\"monitor\",\"create_snapshot\",\"manage_ml\"))\n        .index(List.of(IndexPrivilegesCheck.of(i -> i\n                .names(List.of(\"suppliers\",\"products\"))\n                .privileges(\"create_doc\")),IndexPrivilegesCheck.of(i -> i\n                .names(\"inventory\")\n                .privileges(List.of(\"read\",\"write\")))))\n    )\n    .uids(List.of(\"u_LQPnxDxEjIH0GOUoFkZr5Y57YUwSkL9Joiq-g4OCbPc_0\",\"u_rzRnxDgEHIH0GOUoFkZr5Y27YUwSk19Joiq=g4OCxxB_1\",\"u_does-not-exist_0\"))\n);\n"
     }
@@ -7039,6 +7891,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/role/my_admin_role/_clear_cache\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security.ClearCachedRolesAsync(name: new[] { \"my_admin_role\" });"
     },
     {
       "language": "Java",
@@ -7067,6 +7923,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/_authenticate\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.AuthenticateAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.security().authenticate();\n"
     }
@@ -7091,6 +7951,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grant_type\":\"password\",\"username\":\"jacknich\",\"password\":\"l0ng-r4nd0m-p@ssw0rd\"}' \"$ELASTICSEARCH_URL/_security/profile/_activate\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .ActivateUserProfileAsync(d1 => d1\n        .GrantType(GrantType.Password)\n        .Password(\"l0ng-r4nd0m-p@ssw0rd\")\n        .Username(\"jacknich\")\n    );"
     },
     {
       "language": "Java",
@@ -7119,6 +7983,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm\":\"oidc1\",\"state\":\"lGYK0EcSLjqH6pkT5EVZjC6eIW5YCGgywj2sxROO\",\"nonce\":\"zOBXLJGUooRrbLbQk5YCcyC8AXw3iloynvluYhZ5\"}' \"$ELASTICSEARCH_URL/_security/oidc/prepare\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .OidcPrepareAuthenticationAsync(d1 => d1\n        .Nonce(\"zOBXLJGUooRrbLbQk5YCcyC8AXw3iloynvluYhZ5\")\n        .Realm(\"oidc1\")\n        .State(\"lGYK0EcSLjqH6pkT5EVZjC6eIW5YCGgywj2sxROO\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().oidcPrepareAuthentication(o -> o\n    .nonce(\"zOBXLJGUooRrbLbQk5YCcyC8AXw3iloynvluYhZ5\")\n    .realm(\"oidc1\")\n    .state(\"lGYK0EcSLjqH6pkT5EVZjC6eIW5YCGgywj2sxROO\")\n);\n"
     }
@@ -7143,6 +8011,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"iss\":\"http://127.0.0.1:8080\",\"login_hint\":\"this_is_an_opaque_string\"}' \"$ELASTICSEARCH_URL/_security/oidc/prepare\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .OidcPrepareAuthenticationAsync(d1 => d1\n        .Iss(\"http://127.0.0.1:8080\")\n        .LoginHint(\"this_is_an_opaque_string\")\n    );"
     },
     {
       "language": "Java",
@@ -7171,6 +8043,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm\":\"oidc1\"}' \"$ELASTICSEARCH_URL/_security/oidc/prepare\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .OidcPrepareAuthenticationAsync(d1 => d1\n        .Realm(\"oidc1\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().oidcPrepareAuthentication(o -> o\n    .realm(\"oidc1\")\n);\n"
     }
@@ -7195,6 +8071,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"cluster\":[\"monitor\",\"manage\"],\"index\":[{\"names\":[\"suppliers\",\"products\"],\"privileges\":[\"read\"]},{\"names\":[\"inventory\"],\"privileges\":[\"read\",\"write\"]}],\"application\":[{\"application\":\"inventory_manager\",\"privileges\":[\"read\",\"data:write/inventory\"],\"resources\":[\"product/1852563\"]}]}' \"$ELASTICSEARCH_URL/_security/user/_has_privileges\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .HasPrivilegesAsync(d1 => d1\n        .Application(d2 => d2\n            .Application(\"inventory_manager\")\n            .Privileges(\"read\", \"data:write/inventory\")\n            .Resources(\"product/1852563\")\n        )\n        .Cluster(ClusterPrivilege.Monitor, ClusterPrivilege.Manage)\n        .Index(d2 => d2\n            .Names(new[] { \"suppliers\", \"products\" })\n            .Privileges(IndexPrivilege.Read), d2 => d2\n            .Names(new[] { \"inventory\" })\n            .Privileges(IndexPrivilege.Read, IndexPrivilege.Write)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -7223,6 +8103,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"token\":\"dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==\",\"refresh_token\":\"vLBPvmAB6KvwvJZr27cS\"}' \"$ELASTICSEARCH_URL/_security/oidc/logout\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .OidcLogoutAsync(d1 => d1\n        .RefreshToken(\"vLBPvmAB6KvwvJZr27cS\")\n        .Token(\"dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().oidcLogout(o -> o\n    .refreshToken(\"vLBPvmAB6KvwvJZr27cS\")\n    .token(\"dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==\")\n);\n"
     }
@@ -7247,6 +8131,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"ids\":[\"VuaCfGcBCdbkQm-e5aOx\"]}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateApiKeyAsync(d1 => d1\n        .Ids([\"VuaCfGcBCdbkQm-e5aOx\"])\n    );"
     },
     {
       "language": "Java",
@@ -7275,6 +8163,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"username\":\"myuser\",\"realm_name\":\"native1\"}' \"$ELASTICSEARCH_URL/_security/api_key\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateApiKeyAsync(d1 => d1\n        .RealmName(\"native1\")\n        .Username(\"myuser\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().invalidateApiKey(i -> i\n    .realmName(\"native1\")\n    .username(\"myuser\")\n);\n"
     }
@@ -7299,6 +8191,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"ids\":[\"VuaCfGcBCdbkQm-e5aOx\"],\"owner\":\"true\"}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateApiKeyAsync(d1 => d1\n        .Ids([\"VuaCfGcBCdbkQm-e5aOx\"])\n        .Owner(true)\n    );"
     },
     {
       "language": "Java",
@@ -7327,6 +8223,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"username\":\"myuser\"}' \"$ELASTICSEARCH_URL/_security/api_key\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateApiKeyAsync(d1 => d1\n        .Username(\"myuser\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().invalidateApiKey(i -> i\n    .username(\"myuser\")\n);\n"
     }
@@ -7351,6 +8251,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm_name\":\"native1\"}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateApiKeyAsync(d1 => d1\n        .RealmName(\"native1\")\n    );"
     },
     {
       "language": "Java",
@@ -7379,6 +8283,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"my-api-key\"}' \"$ELASTICSEARCH_URL/_security/api_key\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateApiKeyAsync(d1 => d1\n        .Name(\"my-api-key\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().invalidateApiKey(i -> i\n    .name(\"my-api-key\")\n);\n"
     }
@@ -7403,6 +8311,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"ids\":[\"VuaCfGcBCdbkQm-e5aOx\",\"H3_AhoIBA9hmeQJdg7ij\"],\"role_descriptors\":{\"role-a\":{\"indices\":[{\"names\":[\"*\"],\"privileges\":[\"write\"]}]}},\"metadata\":{\"environment\":{\"level\":2,\"trusted\":true,\"tags\":[\"production\"]}},\"expiration\":\"30d\"}' \"$ELASTICSEARCH_URL/_security/api_key/_bulk_update\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .BulkUpdateApiKeysAsync(d1 => d1\n        .Expiration(\"30d\")\n        .Ids(\"VuaCfGcBCdbkQm-e5aOx\", \"H3_AhoIBA9hmeQJdg7ij\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 2,\n              \"trusted\": true,\n              \"tags\": [\n                \"production\"\n              ]\n            }\n            \"\"\") }\n        })\n        .RoleDescriptors(d2 => d2\n            .Add(\"role-a\", d3 => d3\n                .Indices(d4 => d4\n                    .Names([\"*\"])\n                    .Privileges(IndexPrivilege.Write)\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -7431,6 +8343,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"ids\":[\"VuaCfGcBCdbkQm-e5aOx\",\"H3_AhoIBA9hmeQJdg7ij\"],\"role_descriptors\":{}}' \"$ELASTICSEARCH_URL/_security/api_key/_bulk_update\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .BulkUpdateApiKeysAsync(d1 => d1\n        .Ids(\"VuaCfGcBCdbkQm-e5aOx\", \"H3_AhoIBA9hmeQJdg7ij\")\n        .RoleDescriptors()\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().bulkUpdateApiKeys(b -> b\n    .ids(List.of(\"VuaCfGcBCdbkQm-e5aOx\",\"H3_AhoIBA9hmeQJdg7ij\"))\n);\n"
     }
@@ -7455,6 +8371,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"jack\",\"hint\":{\"uids\":[\"u_8RKO7AKfEbSiIHZkZZ2LJy2MUSDPWDr3tMI_CkIGApU_0\",\"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\"],\"labels\":{\"direction\":[\"north\",\"east\"]}}}' \"$ELASTICSEARCH_URL/_security/profile/_suggest\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .SuggestUserProfilesAsync(d1 => d1\n        .Hint(d2 => d2\n            .Labels(new Dictionary<string, ICollection<string>>()\n            {\n                { \"direction\", [\"north\", \"east\"] }\n            })\n            .Uids(\"u_8RKO7AKfEbSiIHZkZZ2LJy2MUSDPWDr3tMI_CkIGApU_0\", \"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\")\n        )\n        .Name(\"jack\")\n    );"
     },
     {
       "language": "Java",
@@ -7483,6 +8403,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"name\":{\"value\":\"application-key-1\"}}}}' \"$ELASTICSEARCH_URL/_security/_query/api_key\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .QueryApiKeysAsync(d1 => d1\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.Name)\n                .Value(\"application-key-1\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().queryApiKeys(q -> q\n    .query(qu -> qu\n        .term(t -> t\n            .field(\"name\")\n            .value(FieldValue.of(\"application-key-1\"))\n        )\n    )\n);\n"
     }
@@ -7490,7 +8414,7 @@
   "specification/security/query_api_keys/examples/request/QueryApiKeysRequestExample2.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.security.query_api_keys(\n    query={\n        \"bool\": {\n            \"must\": [\n                {\n                    \"prefix\": {\n                        \"name\": \"app1-key-\"\n                    }\n                },\n                {\n                    \"term\": {\n                        \"invalidated\": \"false\"\n                    }\n                }\n            ],\n            \"must_not\": [\n                {\n                    \"term\": {\n                        \"name\": \"app1-key-01\"\n                    }\n                }\n            ],\n            \"filter\": [\n                {\n                    \"wildcard\": {\n                        \"username\": \"org-*-user\"\n                    }\n                },\n                {\n                    \"term\": {\n                        \"metadata.environment\": \"production\"\n                    }\n                }\n            ]\n        }\n    },\n    from=20,\n    size=10,\n    sort=[\n        {\n            \"creation\": {\n                \"order\": \"desc\",\n                \"format\": \"date_time\"\n            }\n        },\n        \"name\"\n    ],\n)"
+      "code": "resp = client.security.query_api_keys(\n    query={\n        \"bool\": {\n            \"must\": [\n                {\n                    \"prefix\": {\n                        \"name\": \"app1-key-\"\n                    }\n                },\n                {\n                    \"term\": {\n                        \"invalidated\": \"false\"\n                    }\n                }\n            ],\n            \"must_not\": [\n                {\n                    \"term\": {\n                        \"name\": \"app1-key-01\"\n                    }\n                }\n            ],\n            \"filter\": [\n                {\n                    \"wildcard\": {\n                        \"username\": \"org-*-user\"\n                    }\n                },\n                {\n                    \"term\": {\n                        \"metadata.environment\": \"production\"\n                    }\n                }\n            ]\n        }\n    },\n    from_=20,\n    size=10,\n    sort=[\n        {\n            \"creation\": {\n                \"order\": \"desc\",\n                \"format\": \"date_time\"\n            }\n        },\n        \"name\"\n    ],\n)"
     },
     {
       "language": "JavaScript",
@@ -7507,6 +8431,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"bool\":{\"must\":[{\"prefix\":{\"name\":\"app1-key-\"}},{\"term\":{\"invalidated\":\"false\"}}],\"must_not\":[{\"term\":{\"name\":\"app1-key-01\"}}],\"filter\":[{\"wildcard\":{\"username\":\"org-*-user\"}},{\"term\":{\"metadata.environment\":\"production\"}}]}},\"from\":20,\"size\":10,\"sort\":[{\"creation\":{\"order\":\"desc\",\"format\":\"date_time\"}},\"name\"]}' \"$ELASTICSEARCH_URL/_security/_query/api_key\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .QueryApiKeysAsync(d1 => d1\n        .From(20)\n        .Query(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Wildcard(d5 => d5\n                        .Field(x => x.Username)\n                        .Value(\"org-*-user\")\n                    ), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Metadata.Environment)\n                        .Value(\"production\")\n                    )\n                )\n                .Must(d4 => d4\n                    .Prefix(d5 => d5\n                        .Field(x => x.Name)\n                        .Value(\"app1-key-\")\n                    ), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Invalidated)\n                        .Value(\"false\")\n                    )\n                )\n                .MustNot(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Name)\n                        .Value(\"app1-key-01\")\n                    )\n                )\n            )\n        )\n        .Size(10)\n        .Sort(d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Creation)\n                .Format(\"date_time\")\n                .Order(SortOrder.Desc)\n            ), d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Name)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -7535,6 +8463,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"ids\":{\"values\":[\"VuaCfGcBCdbkQm-e5aOx\"]}}}' \"$ELASTICSEARCH_URL/_security/_query/api_key?with_limited_by=true\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .QueryApiKeysAsync(d1 => d1\n        .WithLimitedBy(true)\n        .Query(d2 => d2\n            .Ids(d3 => d3\n                .Values(new[] { \"VuaCfGcBCdbkQm-e5aOx\" })\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().queryApiKeys(q -> q\n    .query(qu -> qu\n        .ids(i -> i\n            .values(\"VuaCfGcBCdbkQm-e5aOx\")\n        )\n    )\n    .withLimitedBy(true)\n);\n"
     }
@@ -7559,6 +8491,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"my-cross-cluster-api-key\",\"expiration\":\"1d\",\"access\":{\"search\":[{\"names\":[\"logs*\"]}],\"replication\":[{\"names\":[\"archive*\"]}]},\"metadata\":{\"description\":\"phase one\",\"environment\":{\"level\":1,\"trusted\":true,\"tags\":[\"dev\",\"staging\"]}}}' \"$ELASTICSEARCH_URL/_security/cross_cluster/api_key\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .CreateCrossClusterApiKeyAsync(d1 => d1\n        .Access(d2 => d2\n            .Replication(d3 => d3\n                .Names([\"archive*\"])\n            )\n            .Search(d3 => d3\n                .Names([\"logs*\"])\n            )\n        )\n        .Expiration(\"1d\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"description\", \"phase one\" },\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 1,\n              \"trusted\": true,\n              \"tags\": [\n                \"dev\",\n                \"staging\"\n              ]\n            }\n            \"\"\") }\n        })\n        .Name(\"my-cross-cluster-api-key\")\n    );"
     },
     {
       "language": "Java",
@@ -7587,6 +8523,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"content\":\"PHNhbWxwOlJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMD.....\",\"ids\":[\"4fee3b046395c4e751011e97f8900b5273d56685\"]}' \"$ELASTICSEARCH_URL/_security/saml/authenticate\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .SamlAuthenticateAsync(d1 => d1\n        .Content(\"PHNhbWxwOlJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMD.....\")\n        .Ids(new[] { \"4fee3b046395c4e751011e97f8900b5273d56685\" })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().samlAuthenticate(s -> s\n    .content(\"PHNhbWxwOlJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMD.....\")\n    .ids(\"4fee3b046395c4e751011e97f8900b5273d56685\")\n);\n"
     }
@@ -7611,6 +8551,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"password\":\"new-test-password\"}' \"$ELASTICSEARCH_URL/_security/user/jacknich/_password\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .ChangePasswordAsync(d1 => d1\n        .Username(\"jacknich\")\n        .Password(\"new-test-password\")\n    );"
     },
     {
       "language": "Java",
@@ -7639,6 +8583,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/service/elastic/fleet-server/credential\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.GetServiceCredentialsAsync(@namespace: \"elastic\", service: \"fleet-server\");"
+    },
+    {
       "language": "Java",
       "code": "client.security().getServiceCredentials(g -> g\n    .namespace(\"elastic\")\n    .service(\"fleet-server\")\n);\n"
     }
@@ -7663,6 +8611,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/role_mapping/mapping1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .GetRoleMappingAsync(d1 => d1\n        .Name(new[] { \"mapping1\" })\n    );"
     },
     {
       "language": "Java",
@@ -7691,6 +8643,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/profile/u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0/_disable\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.DisableUserProfileAsync(uid: \"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\");"
+    },
+    {
       "language": "Java",
       "code": "client.security().disableUserProfile(d -> d\n    .uid(\"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\")\n);\n"
     }
@@ -7715,6 +8671,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/user/_privileges\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security.GetUserPrivilegesAsync();"
     },
     {
       "language": "Java",
@@ -7743,6 +8703,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"match\":{\"description\":{\"query\":\"user access\"}}},\"size\":1}' \"$ELASTICSEARCH_URL/_security/_query/role\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .QueryRoleAsync(d1 => d1\n        .Query(d2 => d2\n            .Match(d3 => d3\n                .Field(x => x.Description)\n                .Query(\"user access\")\n            )\n        )\n        .Size(1)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().queryRole(q -> q\n    .query(qu -> qu\n        .match(m -> m\n            .field(\"description\")\n            .query(FieldValue.of(\"user access\"))\n        )\n    )\n    .size(1)\n);\n"
     }
@@ -7767,6 +8731,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"sort\":[\"name\"]}' \"$ELASTICSEARCH_URL/_security/_query/role\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .QueryRoleAsync(d1 => d1\n        .Sort(d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Name)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -7795,6 +8763,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/privilege/myapp/read\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.DeletePrivilegesAsync(application: \"myapp\", name: new[] { \"read\" });"
+    },
+    {
       "language": "Java",
       "code": "client.security().deletePrivileges(d -> d\n    .application(\"myapp\")\n    .name(\"read\")\n);\n"
     }
@@ -7819,6 +8791,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/privilege/myapp/_clear_cache\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security.ClearCachedPrivilegesAsync(application: \"myapp\");"
     },
     {
       "language": "Java",
@@ -7847,6 +8823,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/service/elastic/fleet-server/credential/token/token1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .CreateServiceTokenAsync(new CreateServiceTokenRequest()\n    {\n        Name = \"token1\",\n        Namespace = \"elastic\",\n        Service = \"fleet-server\"\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.security().createServiceToken(c -> c\n    .name(\"token1\")\n    .namespace(\"elastic\")\n    .service(\"fleet-server\")\n);\n"
     }
@@ -7871,6 +8851,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/user/jacknich\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security.DeleteUserAsync(username: \"jacknich\");"
     },
     {
       "language": "Java",
@@ -7899,6 +8883,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/realm/default_file/_clear_cache\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.ClearCachedRealmsAsync(realms: new[] { \"default_file\" });"
+    },
+    {
       "language": "Java",
       "code": "client.security().clearCachedRealms(c -> c\n    .realms(\"default_file\")\n);\n"
     }
@@ -7923,6 +8911,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/user/jacknich?with_profile_uid=true\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .GetUserAsync(d1 => d1\n        .Username([\"jacknich\"])\n        .WithProfileUid(true)\n    );"
     },
     {
       "language": "Java",
@@ -7951,6 +8943,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"labels\":{\"direction\":\"east\"},\"data\":{\"app1\":{\"theme\":\"default\"}}}' \"$ELASTICSEARCH_URL/_security/profile/u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0/_data\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .UpdateUserProfileDataAsync(uid: \"u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0\", d1 => d1\n        .Data(new Dictionary<string, object>()\n        {\n            { \"app1\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"theme\": \"default\"\n            }\n            \"\"\") }\n        })\n        .Labels(new Dictionary<string, object>()\n        {\n            { \"direction\", \"east\" }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().updateUserProfileData(u -> u\n    .data(\"app1\", JsonData.fromJson(\"{\\\"theme\\\":\\\"default\\\"}\"))\n    .labels(\"direction\", JsonData.fromJson(\"\\\"east\\\"\"))\n    .uid(\"u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0\")\n);\n"
     }
@@ -7958,15 +8954,15 @@
   "specification/security/delegate_pki/examples/request/SecurityDelegatePkiRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.perform_request(\n    \"POST\",\n    \"/_security/delegate_pki\",\n    headers={\"Content-Type\": \"application/json\"},\n    body={\n        \"x509_certificate_chain\": [\n            \"MIIDeDCCAmCgAwIBAgIUBzj/nGGKxP2iXawsSquHmQjCJmMwDQYJKoZIhvcNAQELBQAwUzErMCkGA1UEAxMiRWxhc3RpY3NlYXJjaCBUZXN0IEludGVybWVkaWF0ZSBDQTEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMB4XDTIzMDcxODE5MjkwNloXDTQzMDcxMzE5MjkwNlowSjEiMCAGA1UEAxMZRWxhc3RpY3NlYXJjaCBUZXN0IENsaWVudDEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAllHL4pQkkfwAm/oLkxYYO+r950DEy1bjH+4viCHzNADLCTWO+lOZJVlNx7QEzJE3QGMdif9CCBBxQFMapA7oUFCLq84fPSQQu5AnvvbltVD9nwVtCs+9ZGDjMKsz98RhSLMFIkxdxi6HkQ3Lfa4ZSI4lvba4oo+T/GveazBDS+NgmKyq00EOXt3tWi1G9vEVItommzXWfv0agJWzVnLMldwkPqsw0W7zrpyT7FZS4iLbQADGceOW8fiauOGMkscu9zAnDR/SbWl/chYioQOdw6ndFLn1YIFPd37xL0WsdsldTpn0vH3YfzgLMffT/3P6YlwBegWzsx6FnM/93Ecb4wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBQKNRwjW+Ad/FN1Rpoqme/5+jrFWzAfBgNVHSMEGDAWgBRcya0c0x/PaI7MbmJVIylWgLqXNjANBgkqhkiG9w0BAQsFAAOCAQEACZ3PF7Uqu47lplXHP6YlzYL2jL0D28hpj5lGtdha4Muw1m/BjDb0Pu8l0NQ1z3AP6AVcvjNDkQq6Y5jeSz0bwQlealQpYfo7EMXjOidrft1GbqOMFmTBLpLA9SvwYGobSTXWTkJzonqVaTcf80HpMgM2uEhodwTcvz6v1WEfeT/HMjmdIsq4ImrOL9RNrcZG6nWfw0HR3JNOgrbfyEztEI471jHznZ336OEcyX7gQuvHE8tOv5+oD1d7s3Xg1yuFp+Ynh+FfOi3hPCuaHA+7F6fLmzMDLVUBAllugst1C3U+L/paD7tqIa4ka+KNPCbSfwazmJrt4XNiivPR4hwH5g==\"\n        ]\n    },\n)"
+      "code": "resp = client.security.delegate_pki(\n    x509_certificate_chain=[\n        \"MIIDeDCCAmCgAwIBAgIUBzj/nGGKxP2iXawsSquHmQjCJmMwDQYJKoZIhvcNAQELBQAwUzErMCkGA1UEAxMiRWxhc3RpY3NlYXJjaCBUZXN0IEludGVybWVkaWF0ZSBDQTEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMB4XDTIzMDcxODE5MjkwNloXDTQzMDcxMzE5MjkwNlowSjEiMCAGA1UEAxMZRWxhc3RpY3NlYXJjaCBUZXN0IENsaWVudDEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAllHL4pQkkfwAm/oLkxYYO+r950DEy1bjH+4viCHzNADLCTWO+lOZJVlNx7QEzJE3QGMdif9CCBBxQFMapA7oUFCLq84fPSQQu5AnvvbltVD9nwVtCs+9ZGDjMKsz98RhSLMFIkxdxi6HkQ3Lfa4ZSI4lvba4oo+T/GveazBDS+NgmKyq00EOXt3tWi1G9vEVItommzXWfv0agJWzVnLMldwkPqsw0W7zrpyT7FZS4iLbQADGceOW8fiauOGMkscu9zAnDR/SbWl/chYioQOdw6ndFLn1YIFPd37xL0WsdsldTpn0vH3YfzgLMffT/3P6YlwBegWzsx6FnM/93Ecb4wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBQKNRwjW+Ad/FN1Rpoqme/5+jrFWzAfBgNVHSMEGDAWgBRcya0c0x/PaI7MbmJVIylWgLqXNjANBgkqhkiG9w0BAQsFAAOCAQEACZ3PF7Uqu47lplXHP6YlzYL2jL0D28hpj5lGtdha4Muw1m/BjDb0Pu8l0NQ1z3AP6AVcvjNDkQq6Y5jeSz0bwQlealQpYfo7EMXjOidrft1GbqOMFmTBLpLA9SvwYGobSTXWTkJzonqVaTcf80HpMgM2uEhodwTcvz6v1WEfeT/HMjmdIsq4ImrOL9RNrcZG6nWfw0HR3JNOgrbfyEztEI471jHznZ336OEcyX7gQuvHE8tOv5+oD1d7s3Xg1yuFp+Ynh+FfOi3hPCuaHA+7F6fLmzMDLVUBAllugst1C3U+L/paD7tqIa4ka+KNPCbSfwazmJrt4XNiivPR4hwH5g==\"\n    ],\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.transport.request({\n  method: \"POST\",\n  path: \"/_security/delegate_pki\",\n  body: {\n    x509_certificate_chain: [\n      \"MIIDeDCCAmCgAwIBAgIUBzj/nGGKxP2iXawsSquHmQjCJmMwDQYJKoZIhvcNAQELBQAwUzErMCkGA1UEAxMiRWxhc3RpY3NlYXJjaCBUZXN0IEludGVybWVkaWF0ZSBDQTEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMB4XDTIzMDcxODE5MjkwNloXDTQzMDcxMzE5MjkwNlowSjEiMCAGA1UEAxMZRWxhc3RpY3NlYXJjaCBUZXN0IENsaWVudDEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAllHL4pQkkfwAm/oLkxYYO+r950DEy1bjH+4viCHzNADLCTWO+lOZJVlNx7QEzJE3QGMdif9CCBBxQFMapA7oUFCLq84fPSQQu5AnvvbltVD9nwVtCs+9ZGDjMKsz98RhSLMFIkxdxi6HkQ3Lfa4ZSI4lvba4oo+T/GveazBDS+NgmKyq00EOXt3tWi1G9vEVItommzXWfv0agJWzVnLMldwkPqsw0W7zrpyT7FZS4iLbQADGceOW8fiauOGMkscu9zAnDR/SbWl/chYioQOdw6ndFLn1YIFPd37xL0WsdsldTpn0vH3YfzgLMffT/3P6YlwBegWzsx6FnM/93Ecb4wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBQKNRwjW+Ad/FN1Rpoqme/5+jrFWzAfBgNVHSMEGDAWgBRcya0c0x/PaI7MbmJVIylWgLqXNjANBgkqhkiG9w0BAQsFAAOCAQEACZ3PF7Uqu47lplXHP6YlzYL2jL0D28hpj5lGtdha4Muw1m/BjDb0Pu8l0NQ1z3AP6AVcvjNDkQq6Y5jeSz0bwQlealQpYfo7EMXjOidrft1GbqOMFmTBLpLA9SvwYGobSTXWTkJzonqVaTcf80HpMgM2uEhodwTcvz6v1WEfeT/HMjmdIsq4ImrOL9RNrcZG6nWfw0HR3JNOgrbfyEztEI471jHznZ336OEcyX7gQuvHE8tOv5+oD1d7s3Xg1yuFp+Ynh+FfOi3hPCuaHA+7F6fLmzMDLVUBAllugst1C3U+L/paD7tqIa4ka+KNPCbSfwazmJrt4XNiivPR4hwH5g==\",\n    ],\n  },\n});"
+      "code": "const response = await client.security.delegatePki({\n  x509_certificate_chain: [\n    \"MIIDeDCCAmCgAwIBAgIUBzj/nGGKxP2iXawsSquHmQjCJmMwDQYJKoZIhvcNAQELBQAwUzErMCkGA1UEAxMiRWxhc3RpY3NlYXJjaCBUZXN0IEludGVybWVkaWF0ZSBDQTEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMB4XDTIzMDcxODE5MjkwNloXDTQzMDcxMzE5MjkwNlowSjEiMCAGA1UEAxMZRWxhc3RpY3NlYXJjaCBUZXN0IENsaWVudDEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAllHL4pQkkfwAm/oLkxYYO+r950DEy1bjH+4viCHzNADLCTWO+lOZJVlNx7QEzJE3QGMdif9CCBBxQFMapA7oUFCLq84fPSQQu5AnvvbltVD9nwVtCs+9ZGDjMKsz98RhSLMFIkxdxi6HkQ3Lfa4ZSI4lvba4oo+T/GveazBDS+NgmKyq00EOXt3tWi1G9vEVItommzXWfv0agJWzVnLMldwkPqsw0W7zrpyT7FZS4iLbQADGceOW8fiauOGMkscu9zAnDR/SbWl/chYioQOdw6ndFLn1YIFPd37xL0WsdsldTpn0vH3YfzgLMffT/3P6YlwBegWzsx6FnM/93Ecb4wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBQKNRwjW+Ad/FN1Rpoqme/5+jrFWzAfBgNVHSMEGDAWgBRcya0c0x/PaI7MbmJVIylWgLqXNjANBgkqhkiG9w0BAQsFAAOCAQEACZ3PF7Uqu47lplXHP6YlzYL2jL0D28hpj5lGtdha4Muw1m/BjDb0Pu8l0NQ1z3AP6AVcvjNDkQq6Y5jeSz0bwQlealQpYfo7EMXjOidrft1GbqOMFmTBLpLA9SvwYGobSTXWTkJzonqVaTcf80HpMgM2uEhodwTcvz6v1WEfeT/HMjmdIsq4ImrOL9RNrcZG6nWfw0HR3JNOgrbfyEztEI471jHznZ336OEcyX7gQuvHE8tOv5+oD1d7s3Xg1yuFp+Ynh+FfOi3hPCuaHA+7F6fLmzMDLVUBAllugst1C3U+L/paD7tqIa4ka+KNPCbSfwazmJrt4XNiivPR4hwH5g==\",\n  ],\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.perform_request(\n  \"POST\",\n  \"/_security/delegate_pki\",\n  {},\n  {\n    \"x509_certificate_chain\": [\n      \"MIIDeDCCAmCgAwIBAgIUBzj/nGGKxP2iXawsSquHmQjCJmMwDQYJKoZIhvcNAQELBQAwUzErMCkGA1UEAxMiRWxhc3RpY3NlYXJjaCBUZXN0IEludGVybWVkaWF0ZSBDQTEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMB4XDTIzMDcxODE5MjkwNloXDTQzMDcxMzE5MjkwNlowSjEiMCAGA1UEAxMZRWxhc3RpY3NlYXJjaCBUZXN0IENsaWVudDEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAllHL4pQkkfwAm/oLkxYYO+r950DEy1bjH+4viCHzNADLCTWO+lOZJVlNx7QEzJE3QGMdif9CCBBxQFMapA7oUFCLq84fPSQQu5AnvvbltVD9nwVtCs+9ZGDjMKsz98RhSLMFIkxdxi6HkQ3Lfa4ZSI4lvba4oo+T/GveazBDS+NgmKyq00EOXt3tWi1G9vEVItommzXWfv0agJWzVnLMldwkPqsw0W7zrpyT7FZS4iLbQADGceOW8fiauOGMkscu9zAnDR/SbWl/chYioQOdw6ndFLn1YIFPd37xL0WsdsldTpn0vH3YfzgLMffT/3P6YlwBegWzsx6FnM/93Ecb4wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBQKNRwjW+Ad/FN1Rpoqme/5+jrFWzAfBgNVHSMEGDAWgBRcya0c0x/PaI7MbmJVIylWgLqXNjANBgkqhkiG9w0BAQsFAAOCAQEACZ3PF7Uqu47lplXHP6YlzYL2jL0D28hpj5lGtdha4Muw1m/BjDb0Pu8l0NQ1z3AP6AVcvjNDkQq6Y5jeSz0bwQlealQpYfo7EMXjOidrft1GbqOMFmTBLpLA9SvwYGobSTXWTkJzonqVaTcf80HpMgM2uEhodwTcvz6v1WEfeT/HMjmdIsq4ImrOL9RNrcZG6nWfw0HR3JNOgrbfyEztEI471jHznZ336OEcyX7gQuvHE8tOv5+oD1d7s3Xg1yuFp+Ynh+FfOi3hPCuaHA+7F6fLmzMDLVUBAllugst1C3U+L/paD7tqIa4ka+KNPCbSfwazmJrt4XNiivPR4hwH5g==\"\n    ]\n  },\n  { \"Content-Type\": \"application/json\" },\n)"
+      "code": "response = client.security.delegate_pki(\n  body: {\n    \"x509_certificate_chain\": [\n      \"MIIDeDCCAmCgAwIBAgIUBzj/nGGKxP2iXawsSquHmQjCJmMwDQYJKoZIhvcNAQELBQAwUzErMCkGA1UEAxMiRWxhc3RpY3NlYXJjaCBUZXN0IEludGVybWVkaWF0ZSBDQTEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMB4XDTIzMDcxODE5MjkwNloXDTQzMDcxMzE5MjkwNlowSjEiMCAGA1UEAxMZRWxhc3RpY3NlYXJjaCBUZXN0IENsaWVudDEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAllHL4pQkkfwAm/oLkxYYO+r950DEy1bjH+4viCHzNADLCTWO+lOZJVlNx7QEzJE3QGMdif9CCBBxQFMapA7oUFCLq84fPSQQu5AnvvbltVD9nwVtCs+9ZGDjMKsz98RhSLMFIkxdxi6HkQ3Lfa4ZSI4lvba4oo+T/GveazBDS+NgmKyq00EOXt3tWi1G9vEVItommzXWfv0agJWzVnLMldwkPqsw0W7zrpyT7FZS4iLbQADGceOW8fiauOGMkscu9zAnDR/SbWl/chYioQOdw6ndFLn1YIFPd37xL0WsdsldTpn0vH3YfzgLMffT/3P6YlwBegWzsx6FnM/93Ecb4wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBQKNRwjW+Ad/FN1Rpoqme/5+jrFWzAfBgNVHSMEGDAWgBRcya0c0x/PaI7MbmJVIylWgLqXNjANBgkqhkiG9w0BAQsFAAOCAQEACZ3PF7Uqu47lplXHP6YlzYL2jL0D28hpj5lGtdha4Muw1m/BjDb0Pu8l0NQ1z3AP6AVcvjNDkQq6Y5jeSz0bwQlealQpYfo7EMXjOidrft1GbqOMFmTBLpLA9SvwYGobSTXWTkJzonqVaTcf80HpMgM2uEhodwTcvz6v1WEfeT/HMjmdIsq4ImrOL9RNrcZG6nWfw0HR3JNOgrbfyEztEI471jHznZ336OEcyX7gQuvHE8tOv5+oD1d7s3Xg1yuFp+Ynh+FfOi3hPCuaHA+7F6fLmzMDLVUBAllugst1C3U+L/paD7tqIa4ka+KNPCbSfwazmJrt4XNiivPR4hwH5g==\"\n    ]\n  }\n)"
     },
     {
       "language": "PHP",
@@ -7975,6 +8971,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"x509_certificate_chain\":[\"MIIDeDCCAmCgAwIBAgIUBzj/nGGKxP2iXawsSquHmQjCJmMwDQYJKoZIhvcNAQELBQAwUzErMCkGA1UEAxMiRWxhc3RpY3NlYXJjaCBUZXN0IEludGVybWVkaWF0ZSBDQTEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMB4XDTIzMDcxODE5MjkwNloXDTQzMDcxMzE5MjkwNlowSjEiMCAGA1UEAxMZRWxhc3RpY3NlYXJjaCBUZXN0IENsaWVudDEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAllHL4pQkkfwAm/oLkxYYO+r950DEy1bjH+4viCHzNADLCTWO+lOZJVlNx7QEzJE3QGMdif9CCBBxQFMapA7oUFCLq84fPSQQu5AnvvbltVD9nwVtCs+9ZGDjMKsz98RhSLMFIkxdxi6HkQ3Lfa4ZSI4lvba4oo+T/GveazBDS+NgmKyq00EOXt3tWi1G9vEVItommzXWfv0agJWzVnLMldwkPqsw0W7zrpyT7FZS4iLbQADGceOW8fiauOGMkscu9zAnDR/SbWl/chYioQOdw6ndFLn1YIFPd37xL0WsdsldTpn0vH3YfzgLMffT/3P6YlwBegWzsx6FnM/93Ecb4wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBQKNRwjW+Ad/FN1Rpoqme/5+jrFWzAfBgNVHSMEGDAWgBRcya0c0x/PaI7MbmJVIylWgLqXNjANBgkqhkiG9w0BAQsFAAOCAQEACZ3PF7Uqu47lplXHP6YlzYL2jL0D28hpj5lGtdha4Muw1m/BjDb0Pu8l0NQ1z3AP6AVcvjNDkQq6Y5jeSz0bwQlealQpYfo7EMXjOidrft1GbqOMFmTBLpLA9SvwYGobSTXWTkJzonqVaTcf80HpMgM2uEhodwTcvz6v1WEfeT/HMjmdIsq4ImrOL9RNrcZG6nWfw0HR3JNOgrbfyEztEI471jHznZ336OEcyX7gQuvHE8tOv5+oD1d7s3Xg1yuFp+Ynh+FfOi3hPCuaHA+7F6fLmzMDLVUBAllugst1C3U+L/paD7tqIa4ka+KNPCbSfwazmJrt4XNiivPR4hwH5g==\"]}' \"$ELASTICSEARCH_URL/_security/delegate_pki\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .DelegatePkiAsync(d1 => d1\n        .X509CertificateChain(\"MIIDeDCCAmCgAwIBAgIUBzj/nGGKxP2iXawsSquHmQjCJmMwDQYJKoZIhvcNAQELBQAwUzErMCkGA1UEAxMiRWxhc3RpY3NlYXJjaCBUZXN0IEludGVybWVkaWF0ZSBDQTEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMB4XDTIzMDcxODE5MjkwNloXDTQzMDcxMzE5MjkwNlowSjEiMCAGA1UEAxMZRWxhc3RpY3NlYXJjaCBUZXN0IENsaWVudDEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAllHL4pQkkfwAm/oLkxYYO+r950DEy1bjH+4viCHzNADLCTWO+lOZJVlNx7QEzJE3QGMdif9CCBBxQFMapA7oUFCLq84fPSQQu5AnvvbltVD9nwVtCs+9ZGDjMKsz98RhSLMFIkxdxi6HkQ3Lfa4ZSI4lvba4oo+T/GveazBDS+NgmKyq00EOXt3tWi1G9vEVItommzXWfv0agJWzVnLMldwkPqsw0W7zrpyT7FZS4iLbQADGceOW8fiauOGMkscu9zAnDR/SbWl/chYioQOdw6ndFLn1YIFPd37xL0WsdsldTpn0vH3YfzgLMffT/3P6YlwBegWzsx6FnM/93Ecb4wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBQKNRwjW+Ad/FN1Rpoqme/5+jrFWzAfBgNVHSMEGDAWgBRcya0c0x/PaI7MbmJVIylWgLqXNjANBgkqhkiG9w0BAQsFAAOCAQEACZ3PF7Uqu47lplXHP6YlzYL2jL0D28hpj5lGtdha4Muw1m/BjDb0Pu8l0NQ1z3AP6AVcvjNDkQq6Y5jeSz0bwQlealQpYfo7EMXjOidrft1GbqOMFmTBLpLA9SvwYGobSTXWTkJzonqVaTcf80HpMgM2uEhodwTcvz6v1WEfeT/HMjmdIsq4ImrOL9RNrcZG6nWfw0HR3JNOgrbfyEztEI471jHznZ336OEcyX7gQuvHE8tOv5+oD1d7s3Xg1yuFp+Ynh+FfOi3hPCuaHA+7F6fLmzMDLVUBAllugst1C3U+L/paD7tqIa4ka+KNPCbSfwazmJrt4XNiivPR4hwH5g==\")\n    );"
     },
     {
       "language": "Java",
@@ -8003,6 +9003,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/user/logstash_system/_enable\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.EnableUserAsync(username: \"logstash_system\");"
+    },
+    {
       "language": "Java",
       "code": "client.security().enableUser(e -> e\n    .username(\"logstash_system\")\n);\n"
     }
@@ -8027,6 +9031,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"password\":\"l0ng-r4nd0m-p@ssw0rd\",\"roles\":[\"admin\",\"other_role1\"],\"full_name\":\"Jack Nicholson\",\"email\":\"jacknich@example.com\",\"metadata\":{\"intelligence\":7}}' \"$ELASTICSEARCH_URL/_security/user/jacknich\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutUserAsync(username: \"jacknich\", d1 => d1\n        .Email(\"jacknich@example.com\")\n        .FullName(\"Jack Nicholson\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"intelligence\", 7 }\n        })\n        .Password(\"l0ng-r4nd0m-p@ssw0rd\")\n        .Roles(\"admin\", \"other_role1\")\n    );"
     },
     {
       "language": "Java",
@@ -8055,6 +9063,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/api_key/yVGMr3QByxdh1MSaicYx/_clear_cache\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.ClearApiKeyCacheAsync(ids: new[] { \"yVGMr3QByxdh1MSaicYx\" });"
+    },
+    {
       "language": "Java",
       "code": "client.security().clearApiKeyCache(c -> c\n    .ids(\"yVGMr3QByxdh1MSaicYx\")\n);\n"
     }
@@ -8079,6 +9091,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/api_key?username=myuser&realm_name=native1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .GetApiKeyAsync(d1 => d1\n        .RealmName(\"native1\")\n        .Username(\"myuser\")\n    );"
     },
     {
       "language": "Java",
@@ -8107,6 +9123,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/service/elastic/fleet-server/credential/token/token1/_clear_cache\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.ClearCachedServiceTokensAsync(@namespace: \"elastic\", service: \"fleet-server\", name: new[] { \"token1\" });"
+    },
+    {
       "language": "Java",
       "code": "client.security().clearCachedServiceTokens(c -> c\n    .name(\"token1\")\n    .namespace(\"elastic\")\n    .service(\"fleet-server\")\n);\n"
     }
@@ -8131,6 +9151,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/profile/u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0/_enable\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security.EnableUserProfileAsync(uid: \"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\");"
     },
     {
       "language": "Java",
@@ -8159,6 +9183,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"ldap-example-user\"],\"enabled\":true,\"rules\":{\"all\":[{\"field\":{\"dn\":\"*,ou=subtree,dc=example,dc=com\"}},{\"field\":{\"realm.name\":\"ldap1\"}}]}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping7\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping7\", d1 => d1\n        .Enabled(true)\n        .Roles(\"ldap-example-user\")\n        .Rules(d2 => d2\n            .All(d3 => d3\n                .Field(d4 => d4\n                    .Dn(new[] { \"*,ou=subtree,dc=example,dc=com\" })\n                ), d3 => d3\n                .Field(new FieldRule())\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping7\")\n    .roles(\"ldap-example-user\")\n    .rules(r -> r\n        .all(List.of(RoleMappingRule.of(ro -> ro\n                .field(NamedValue.of(\"dn\",List.of(FieldValue.of(\"*,ou=subtree,dc=example,dc=com\"))\n                ))), RoleMappingRule.of(rol -> rol\n                .field(NamedValue.of(\"realm.name\",List.of(FieldValue.of(\"ldap1\"))\n                )))\n            )\n        )\n    )\n);\n"
     }
@@ -8183,6 +9211,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"role_templates\":[{\"template\":{\"source\":\"{{#tojson}}groups{{/tojson}}\"},\"format\":\"json\"}],\"rules\":{\"field\":{\"realm.name\":\"saml1\"}},\"enabled\":true}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping6\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping6\", d1 => d1\n        .Enabled(true)\n        .RoleTemplates(d2 => d2\n            .Format(TemplateFormat.Json)\n            .Template(d3 => d3\n                .Source(\"{{#tojson}}groups{{/tojson}}\")\n            )\n        )\n        .Rules(d2 => d2\n            .Field(new FieldRule())\n        )\n    );"
     },
     {
       "language": "Java",
@@ -8211,6 +9243,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"user\"],\"enabled\":true,\"rules\":{\"field\":{\"username\":\"*\"}},\"metadata\":{\"version\":1}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping1\", d1 => d1\n        .Enabled(true)\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"version\", 1 }\n        })\n        .Roles(\"user\")\n        .Rules(d2 => d2\n            .Field(d3 => d3\n                .Username(new[] { \"*\" })\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .metadata(\"version\", JsonData.fromJson(\"1\"))\n    .name(\"mapping1\")\n    .roles(\"user\")\n    .rules(r -> r\n        .field(NamedValue.of(\"username\",List.of(FieldValue.of(\"*\"))))\n    )\n);\n"
     }
@@ -8235,6 +9271,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"ldap-user\"],\"enabled\":true,\"rules\":{\"field\":{\"realm.name\":\"ldap1\"}}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping3\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping3\", d1 => d1\n        .Enabled(true)\n        .Roles(\"ldap-user\")\n        .Rules(d2 => d2\n            .Field(new FieldRule())\n        )\n    );"
     },
     {
       "language": "Java",
@@ -8263,6 +9303,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"user\",\"admin\"],\"enabled\":true,\"rules\":{\"field\":{\"username\":[\"esadmin01\",\"esadmin02\"]}}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping2\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping2\", d1 => d1\n        .Enabled(true)\n        .Roles(\"user\", \"admin\")\n        .Rules(d2 => d2\n            .Field(d3 => d3\n                .Username(new[] { \"esadmin01\", \"esadmin02\" })\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping2\")\n    .roles(List.of(\"user\",\"admin\"))\n    .rules(r -> r\n        .field(NamedValue.of(\"username\",List.of(FieldValue.of(\"esadmin01\"),FieldValue.of(\"esadmin02\"))))\n    )\n);\n"
     }
@@ -8287,6 +9331,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"rules\":{\"field\":{\"realm.name\":\"cloud-saml\"}},\"role_templates\":[{\"template\":{\"source\":\"saml_user\"}},{\"template\":{\"source\":\"_user_{{username}}\"}}],\"enabled\":true}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping9\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping9\", d1 => d1\n        .Enabled(true)\n        .RoleTemplates(d2 => d2\n            .Template(d3 => d3\n                .Source(\"saml_user\")\n            ), d2 => d2\n            .Template(d3 => d3\n                .Source(\"_user_{{username}}\")\n            )\n        )\n        .Rules(d2 => d2\n            .Field(new FieldRule())\n        )\n    );"
     },
     {
       "language": "Java",
@@ -8315,6 +9363,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"role_templates\":[{\"template\":{\"source\":\"{{#tojson}}groups{{/tojson}}\"},\"format\":\"json\"}],\"rules\":{\"field\":{\"realm.name\":\"saml1\"}},\"enabled\":true}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping5\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping5\", d1 => d1\n        .Enabled(true)\n        .RoleTemplates(d2 => d2\n            .Format(TemplateFormat.Json)\n            .Template(d3 => d3\n                .Source(\"{{#tojson}}groups{{/tojson}}\")\n            )\n        )\n        .Rules(d2 => d2\n            .Field(new FieldRule())\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping5\")\n    .roleTemplates(r -> r\n        .format(TemplateFormat.Json)\n        .template(t -> t\n            .source(s -> s\n                .scriptString(\"{{#tojson}}groups{{/tojson}}\")\n            )\n        )\n    )\n    .rules(ru -> ru\n        .field(NamedValue.of(\"realm.name\",List.of(FieldValue.of(\"saml1\"))))\n    )\n);\n"
     }
@@ -8339,6 +9391,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"superuser\"],\"enabled\":true,\"rules\":{\"any\":[{\"field\":{\"username\":\"esadmin\"}},{\"field\":{\"groups\":\"cn=admins,dc=example,dc=com\"}}]}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping4\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping4\", d1 => d1\n        .Enabled(true)\n        .Roles(\"superuser\")\n        .Rules(d2 => d2\n            .Any(d3 => d3\n                .Field(d4 => d4\n                    .Username(new[] { \"esadmin\" })\n                ), d3 => d3\n                .Field(d4 => d4\n                    .Groups(new[] { \"cn=admins,dc=example,dc=com\" })\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -8367,6 +9423,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"superuser\"],\"enabled\":true,\"rules\":{\"all\":[{\"any\":[{\"field\":{\"dn\":\"*,ou=admin,dc=example,dc=com\"}},{\"field\":{\"username\":[\"es-admin\",\"es-system\"]}}]},{\"field\":{\"groups\":\"cn=people,dc=example,dc=com\"}},{\"except\":{\"field\":{\"metadata.terminated_date\":null}}}]}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping8\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping8\", d1 => d1\n        .Enabled(true)\n        .Roles(\"superuser\")\n        .Rules(d2 => d2\n            .All(d3 => d3\n                .Any(d4 => d4\n                    .Field(d5 => d5\n                        .Dn(new[] { \"*,ou=admin,dc=example,dc=com\" })\n                    ), d4 => d4\n                    .Field(d5 => d5\n                        .Username(new[] { \"es-admin\", \"es-system\" })\n                    )\n                ), d3 => d3\n                .Field(d4 => d4\n                    .Groups(new[] { \"cn=people,dc=example,dc=com\" })\n                ), d3 => d3\n                .Except(d4 => d4\n                    .Field(new FieldRule())\n                )\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping8\")\n    .roles(\"superuser\")\n    .rules(r -> r\n        .all(List.of(RoleMappingRule.of(ro -> ro\n                    .any(List.of(RoleMappingRule.of(rol -> rol\n                            .field(NamedValue.of(\"dn\", List.of(FieldValue.of(\"*,ou=admin,\" +\n                                \"dc=example,dc=com\"))\n                            ))\n                        ), RoleMappingRule.of(role -> role\n                            .field(NamedValue.of(\"username\", List.of(FieldValue.of(\"es-admin\"),\n                                FieldValue.of(\"es-system\"))\n                            )))), RoleMappingRule.of(roleM -> roleM\n                            .field(NamedValue.of(\"groups\", List.of(FieldValue.of(\"cn=people,\" +\n                                \"dc=example,dc=com\"))\n                            )), RoleMappingRule.of(roleMa -> roleMa\n                            .except(e -> e\n                                .field(NamedValue.of(\"metadata.terminated_date\",\n                                    List.of(FieldValue.of(null))\n                                    )\n                                ))))\n                    )\n                )\n            )\n        )\n    )\n);\n"
     }
@@ -8391,6 +9451,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm\":\"saml1\"}' \"$ELASTICSEARCH_URL/_security/saml/prepare\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .SamlPrepareAuthenticationAsync(d1 => d1\n        .Realm(\"saml1\")\n    );"
     },
     {
       "language": "Java",
@@ -8419,6 +9483,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"acs\":\"https://kibana.org/api/security/saml/callback\"}' \"$ELASTICSEARCH_URL/_security/saml/prepare\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .SamlPrepareAuthenticationAsync(d1 => d1\n        .Acs(\"https://kibana.org/api/security/saml/callback\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().samlPrepareAuthentication(s -> s\n    .acs(\"https://kibana.org/api/security/saml/callback\")\n);\n"
     }
@@ -8443,6 +9511,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query_string\":\"SAMLRequest=nZFda4MwFIb%2FiuS%2BmviRpqFaClKQdbvo2g12M2KMraCJ9cRR9utnW4Wyi13sMie873MeznJ1aWrnS3VQGR0j4mLkKC1NUeljjA77zYyhVbIE0dR%2By7fmaHq7U%2BdegXWGpAZ%2B%2F4pR32luBFTAtWgUcCv56%2Fp5y30X87Yz1khTIycdgpUW9kY7WdsC9zxoXTvMvWuVV98YyMnSGH2SYE5pwALBIr9QKiwDGpW0oGVUznGeMyJZKFkQ4jBf5HnhUymjIhzCAL3KNFihbYx8TBYzzGaY7EnIyZwHzCWMfiDnbRIftkSjJr%2BFu0e9v%2B0EgOquRiiZjKpiVFp6j50T4WXoyNJ%2FEWC9fdqc1t%2F1%2B2F3aUpjzhPiXpqMz1%2FHSn4A&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=MsAYz2NFdovMG2mXf6TSpu5vlQQyEJAg%2B4KCwBqJTmrb3yGXKUtIgvjqf88eCAK32v3eN8vupjPC8LglYmke1ZnjK0%2FKxzkvSjTVA7mMQe2AQdKbkyC038zzRq%2FYHcjFDE%2Bz0qISwSHZY2NyLePmwU7SexEXnIz37jKC6NMEhus%3D\",\"realm\":\"saml1\"}' \"$ELASTICSEARCH_URL/_security/saml/invalidate\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .SamlInvalidateAsync(d1 => d1\n        .QueryString(\"SAMLRequest=nZFda4MwFIb%2FiuS%2BmviRpqFaClKQdbvo2g12M2KMraCJ9cRR9utnW4Wyi13sMie873MeznJ1aWrnS3VQGR0j4mLkKC1NUeljjA77zYyhVbIE0dR%2By7fmaHq7U%2BdegXWGpAZ%2B%2F4pR32luBFTAtWgUcCv56%2Fp5y30X87Yz1khTIycdgpUW9kY7WdsC9zxoXTvMvWuVV98YyMnSGH2SYE5pwALBIr9QKiwDGpW0oGVUznGeMyJZKFkQ4jBf5HnhUymjIhzCAL3KNFihbYx8TBYzzGaY7EnIyZwHzCWMfiDnbRIftkSjJr%2BFu0e9v%2B0EgOquRiiZjKpiVFp6j50T4WXoyNJ%2FEWC9fdqc1t%2F1%2B2F3aUpjzhPiXpqMz1%2FHSn4A&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=MsAYz2NFdovMG2mXf6TSpu5vlQQyEJAg%2B4KCwBqJTmrb3yGXKUtIgvjqf88eCAK32v3eN8vupjPC8LglYmke1ZnjK0%2FKxzkvSjTVA7mMQe2AQdKbkyC038zzRq%2FYHcjFDE%2Bz0qISwSHZY2NyLePmwU7SexEXnIz37jKC6NMEhus%3D\")\n        .Realm(\"saml1\")\n    );"
     },
     {
       "language": "Java",
@@ -8471,6 +9543,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grant_type\":\"client_credentials\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .GetTokenAsync(d1 => d1\n        .GrantType(AccessTokenGrantType.ClientCredentials)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().getToken(g -> g\n    .grantType(AccessTokenGrantType.ClientCredentials)\n);\n"
     }
@@ -8495,6 +9571,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grant_type\":\"password\",\"username\":\"test_admin\",\"password\":\"x-pack-test-password\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .GetTokenAsync(d1 => d1\n        .GrantType(AccessTokenGrantType.Password)\n        .Password(\"x-pack-test-password\")\n        .Username(\"test_admin\")\n    );"
     },
     {
       "language": "Java",
@@ -8523,6 +9603,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":{\"my_admin_role\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index1\",\"index2\"],\"privileges\":[\"all\"],\"field_security\":{\"grant\":[\"title\",\"body\"]},\"query\":\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\"}],\"applications\":[{\"application\":\"myapp\",\"privileges\":[\"admin\",\"read\"],\"resources\":[\"*\"]}],\"run_as\":[\"other_user\"],\"metadata\":{\"version\":1}},\"my_user_role\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index1\"],\"privileges\":[\"read\"],\"field_security\":{\"grant\":[\"title\",\"body\"]},\"query\":\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\"}],\"applications\":[{\"application\":\"myapp\",\"privileges\":[\"admin\",\"read\"],\"resources\":[\"*\"]}],\"run_as\":[\"other_user\"],\"metadata\":{\"version\":1}}}}' \"$ELASTICSEARCH_URL/_security/role\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .BulkPutRoleAsync(d1 => d1\n        .Roles(d2 => d2\n            .Add(\"my_admin_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\", \"index2\"])\n                    .Privileges(IndexPrivilege.All)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n            .Add(\"my_user_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\"])\n                    .Privileges(IndexPrivilege.Read)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().bulkPutRole(b -> b\n    .roles(Map.of(\"my_admin_role\", RoleDescriptor.of(r -> r\n            .cluster(\"all\")\n            .indices(i -> i\n                .fieldSecurity(f -> f\n                    .grant(List.of(\"title\",\"body\"))\n                )\n                .names(List.of(\"index1\",\"index2\"))\n                .privileges(\"all\")\n                .query(q -> q\n                    .match(m -> m\n                        .field(\"title\")\n                        .query(FieldValue.of(\"foo\"))\n                    )\n                )\n            )\n            .applications(a -> a\n                .application(\"myapp\")\n                .privileges(List.of(\"admin\",\"read\"))\n                .resources(\"*\")\n            )\n            .metadata(\"version\", JsonData.fromJson(\"1\"))\n            .runAs(\"other_user\")),\"my_user_role\", RoleDescriptor.of(ro -> ro\n            .cluster(\"all\")\n            .indices(i -> i\n                .fieldSecurity(f -> f\n                    .grant(List.of(\"title\",\"body\"))\n                )\n                .names(\"index1\")\n                .privileges(\"read\")\n                .query(q -> q\n                    .match(m -> m\n                        .field(\"title\")\n                        .query(FieldValue.of(\"foo\"))\n                    )\n                )\n            )\n            .applications(a -> a\n                .application(\"myapp\")\n                .privileges(List.of(\"admin\",\"read\"))\n                .resources(\"*\")\n            )\n            .metadata(\"version\", JsonData.fromJson(\"1\"))\n            .runAs(\"other_user\"))))\n);\n"
     }
@@ -8547,6 +9631,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"remote_indices\":[{\"clusters\":[\"my_remote\"],\"names\":[\"logs*\"],\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"]}],\"remote_cluster\":[{\"clusters\":[\"my_remote\"],\"privileges\":[\"monitor_stats\"]}]}' \"$ELASTICSEARCH_URL/_security/role/only_remote_access_role\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleAsync(name: \"only_remote_access_role\", d1 => d1\n        .RemoteCluster(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Privileges(RemoteClusterPrivilege.MonitorStats)\n        )\n        .RemoteIndices(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Names([\"logs*\"])\n            .Privileges(IndexPrivilege.Read, IndexPrivilege.ReadCrossCluster, IndexPrivilege.ViewIndexMetadata)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -8575,6 +9663,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":{\"my_admin_role\":{\"cluster\":[\"bad_cluster_privilege\"],\"indices\":[{\"names\":[\"index1\",\"index2\"],\"privileges\":[\"all\"],\"field_security\":{\"grant\":[\"title\",\"body\"]},\"query\":\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\"}],\"applications\":[{\"application\":\"myapp\",\"privileges\":[\"admin\",\"read\"],\"resources\":[\"*\"]}],\"run_as\":[\"other_user\"],\"metadata\":{\"version\":1}},\"my_user_role\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index1\"],\"privileges\":[\"read\"],\"field_security\":{\"grant\":[\"title\",\"body\"]},\"query\":\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\"}],\"applications\":[{\"application\":\"myapp\",\"privileges\":[\"admin\",\"read\"],\"resources\":[\"*\"]}],\"run_as\":[\"other_user\"],\"metadata\":{\"version\":1}}}}' \"$ELASTICSEARCH_URL/_security/role\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .BulkPutRoleAsync(d1 => d1\n        .Roles(d2 => d2\n            .Add(\"my_admin_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(new ClusterPrivilege(\"bad_cluster_privilege\"))\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\", \"index2\"])\n                    .Privileges(IndexPrivilege.All)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n            .Add(\"my_user_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\"])\n                    .Privileges(IndexPrivilege.Read)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().bulkPutRole(b -> b\n    .roles(Map.of(\"my_admin_role\", RoleDescriptor.of(r -> r\n            .cluster(\"bad_cluster_privilege\")\n            .indices(i -> i\n                .fieldSecurity(f -> f\n                    .grant(List.of(\"title\",\"body\"))\n                )\n                .names(List.of(\"index1\",\"index2\"))\n                .privileges(\"all\")\n                .query(q -> q\n                    .match(m -> m\n                        .field(\"title\")\n                        .query(FieldValue.of(\"foo\"))\n                    )\n                )\n            )\n            .applications(a -> a\n                .application(\"myapp\")\n                .privileges(List.of(\"admin\",\"read\"))\n                .resources(\"*\")\n            )\n            .metadata(\"version\", JsonData.fromJson(\"1\"))\n            .runAs(\"other_user\")),\"my_user_role\", RoleDescriptor.of(ro -> ro\n            .cluster(\"all\")\n            .indices(i -> i\n                .fieldSecurity(f -> f\n                    .grant(List.of(\"title\",\"body\"))\n                )\n                .names(\"index1\")\n                .privileges(\"read\")\n                .query(q -> q\n                    .match(m -> m\n                        .field(\"title\")\n                        .query(FieldValue.of(\"foo\"))\n                    )\n                )\n            )\n            .applications(a -> a\n                .application(\"myapp\")\n                .privileges(List.of(\"admin\",\"read\"))\n                .resources(\"*\")\n            )\n            .metadata(\"version\", JsonData.fromJson(\"1\"))\n            .runAs(\"other_user\"))))\n);\n"
     }
@@ -8599,6 +9691,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/role/my_admin_role\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .GetRoleAsync(d1 => d1\n        .Name(new[] { \"my_admin_role\" })\n    );"
     },
     {
       "language": "Java",
@@ -8627,6 +9723,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/role/my_admin_role\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.DeleteRoleAsync(name: \"my_admin_role\");"
+    },
+    {
       "language": "Java",
       "code": "client.security().deleteRole(d -> d\n    .name(\"my_admin_role\")\n);\n"
     }
@@ -8651,6 +9751,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"username\":\"myuser\",\"realm_name\":\"saml1\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateTokenAsync(d1 => d1\n        .RealmName(\"saml1\")\n        .Username(\"myuser\")\n    );"
     },
     {
       "language": "Java",
@@ -8679,6 +9783,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"username\":\"myuser\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateTokenAsync(d1 => d1\n        .Username(\"myuser\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().invalidateToken(i -> i\n    .username(\"myuser\")\n);\n"
     }
@@ -8703,6 +9811,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm_name\":\"saml1\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateTokenAsync(d1 => d1\n        .RealmName(\"saml1\")\n    );"
     },
     {
       "language": "Java",
@@ -8731,6 +9843,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"refresh_token\":\"vLBPvmAB6KvwvJZr27cS\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateTokenAsync(d1 => d1\n        .RefreshToken(\"vLBPvmAB6KvwvJZr27cS\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().invalidateToken(i -> i\n    .refreshToken(\"vLBPvmAB6KvwvJZr27cS\")\n);\n"
     }
@@ -8757,6 +9873,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"token\":\"dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .InvalidateTokenAsync(d1 => d1\n        .Token(\"dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().invalidateToken(i -> i\n    .token(\"dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==\")\n);\n"
     }
@@ -8764,7 +9884,7 @@
   "specification/security/query_user/examples/request/SecurityQueryUserRequestExample2.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.security.query_user(\n    query={\n        \"bool\": {\n            \"must\": [\n                {\n                    \"wildcard\": {\n                        \"email\": \"*example.com\"\n                    }\n                },\n                {\n                    \"term\": {\n                        \"enabled\": True\n                    }\n                }\n            ],\n            \"filter\": [\n                {\n                    \"wildcard\": {\n                        \"roles\": \"*other*\"\n                    }\n                }\n            ]\n        }\n    },\n    from=1,\n    size=2,\n    sort=[\n        {\n            \"username\": {\n                \"order\": \"desc\"\n            }\n        }\n    ],\n)"
+      "code": "resp = client.security.query_user(\n    query={\n        \"bool\": {\n            \"must\": [\n                {\n                    \"wildcard\": {\n                        \"email\": \"*example.com\"\n                    }\n                },\n                {\n                    \"term\": {\n                        \"enabled\": True\n                    }\n                }\n            ],\n            \"filter\": [\n                {\n                    \"wildcard\": {\n                        \"roles\": \"*other*\"\n                    }\n                }\n            ]\n        }\n    },\n    from_=1,\n    size=2,\n    sort=[\n        {\n            \"username\": {\n                \"order\": \"desc\"\n            }\n        }\n    ],\n)"
     },
     {
       "language": "JavaScript",
@@ -8781,6 +9901,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"bool\":{\"must\":[{\"wildcard\":{\"email\":\"*example.com\"}},{\"term\":{\"enabled\":true}}],\"filter\":[{\"wildcard\":{\"roles\":\"*other*\"}}]}},\"from\":1,\"size\":2,\"sort\":[{\"username\":{\"order\":\"desc\"}}]}' \"$ELASTICSEARCH_URL/_security/_query/user\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .QueryUserAsync(d1 => d1\n        .From(1)\n        .Query(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Wildcard(d5 => d5\n                        .Field(x => x.Roles)\n                        .Value(\"*other*\")\n                    )\n                )\n                .Must(d4 => d4\n                    .Wildcard(d5 => d5\n                        .Field(x => x.Email)\n                        .Value(\"*example.com\")\n                    ), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Enabled)\n                        .Value(true)\n                    )\n                )\n            )\n        )\n        .Size(2)\n        .Sort(d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Username)\n                .Order(SortOrder.Desc)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -8809,6 +9933,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"prefix\":{\"roles\":\"other\"}}}' \"$ELASTICSEARCH_URL/_security/_query/user?with_profile_uid=true\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .QueryUserAsync(d1 => d1\n        .WithProfileUid(true)\n        .Query(d2 => d2\n            .Prefix(d3 => d3\n                .Field(x => x.Roles)\n                .Value(\"other\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().queryUser(q -> q\n    .query(qu -> qu\n        .prefix(p -> p\n            .field(\"roles\")\n            .value(\"other\")\n        )\n    )\n    .withProfileUid(true)\n);\n"
     }
@@ -8833,6 +9961,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/profile/u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0/_data\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security.UpdateUserProfileDataAsync(uid: \"u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0\");"
     },
     {
       "language": "Java",
@@ -8861,6 +9993,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"role_descriptors\":{\"role-a\":{\"indices\":[{\"names\":[\"*\"],\"privileges\":[\"write\"]}]}},\"metadata\":{\"environment\":{\"level\":2,\"trusted\":true,\"tags\":[\"production\"]}}}' \"$ELASTICSEARCH_URL/_security/api_key/VuaCfGcBCdbkQm-e5aOx\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .UpdateApiKeyAsync(id: \"VuaCfGcBCdbkQm-e5aOx\", d1 => d1\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 2,\n              \"trusted\": true,\n              \"tags\": [\n                \"production\"\n              ]\n            }\n            \"\"\") }\n        })\n        .RoleDescriptors(d2 => d2\n            .Add(\"role-a\", d3 => d3\n                .Indices(d4 => d4\n                    .Names([\"*\"])\n                    .Privileges(IndexPrivilege.Write)\n                )\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().updateApiKey(u -> u\n    .id(\"VuaCfGcBCdbkQm-e5aOx\")\n    .metadata(\"environment\", JsonData.fromJson(\"{\\\"level\\\":2,\\\"trusted\\\":true,\\\"tags\\\":[\\\"production\\\"]}\"))\n    .roleDescriptors(\"role-a\", r -> r\n        .indices(i -> i\n            .names(\"*\")\n            .privileges(\"write\")\n        )\n    )\n);\n"
     }
@@ -8885,6 +10021,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"role_descriptors\":{}}' \"$ELASTICSEARCH_URL/_security/api_key/VuaCfGcBCdbkQm-e5aOx\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .UpdateApiKeyAsync(id: \"VuaCfGcBCdbkQm-e5aOx\", d1 => d1\n        .RoleDescriptors()\n    );"
     },
     {
       "language": "Java",
@@ -8913,6 +10053,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/service/elastic/fleet-server/credential/token/token42\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.DeleteServiceTokenAsync(@namespace: \"elastic\", service: \"fleet-server\", name: \"token42\");"
+    },
+    {
       "language": "Java",
       "code": "client.security().deleteServiceToken(d -> d\n    .name(\"token42\")\n    .namespace(\"elastic\")\n    .service(\"fleet-server\")\n);\n"
     }
@@ -8937,6 +10081,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"token\":\"46ToAxZVaXVVZTVKOVF5YU04ZFJVUDVSZlV3\",\"refresh_token\":\"mJdXLtmvTUSpoLwMvdBt_w\"}' \"$ELASTICSEARCH_URL/_security/saml/logout\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .SamlLogoutAsync(d1 => d1\n        .RefreshToken(\"mJdXLtmvTUSpoLwMvdBt_w\")\n        .Token(\"46ToAxZVaXVVZTVKOVF5YU04ZFJVUDVSZlV3\")\n    );"
     },
     {
       "language": "Java",
@@ -8965,6 +10113,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"redirect_uri\":\"https://oidc-kibana.elastic.co:5603/api/security/oidc/callback?code=jtI3Ntt8v3_XvcLzCFGq&state=4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I\",\"state\":\"4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I\",\"nonce\":\"WaBPH0KqPVdG5HHdSxPRjfoZbXMCicm5v1OiAj0DUFM\",\"realm\":\"oidc1\"}' \"$ELASTICSEARCH_URL/_security/oidc/authenticate\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .OidcAuthenticateAsync(d1 => d1\n        .Nonce(\"WaBPH0KqPVdG5HHdSxPRjfoZbXMCicm5v1OiAj0DUFM\")\n        .Realm(\"oidc1\")\n        .RedirectUri(\"https://oidc-kibana.elastic.co:5603/api/security/oidc/callback?code=jtI3Ntt8v3_XvcLzCFGq&state=4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I\")\n        .State(\"4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().oidcAuthenticate(o -> o\n    .nonce(\"WaBPH0KqPVdG5HHdSxPRjfoZbXMCicm5v1OiAj0DUFM\")\n    .realm(\"oidc1\")\n    .redirectUri(\"https://oidc-kibana.elastic.co:5603/api/security/oidc/callback?code=jtI3Ntt8v3_XvcLzCFGq&state=4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I\")\n    .state(\"4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I\")\n);\n"
     }
@@ -8989,6 +10141,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grant_type\":\"password\",\"username\":\"test_admin\",\"password\":\"x-pack-test-password\",\"run_as\":\"test_user\",\"api_key\":{\"name\":\"another-api-key\"}}' \"$ELASTICSEARCH_URL/_security/api_key/grant\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .GrantApiKeyAsync(d1 => d1\n        .ApiKey(d2 => d2\n            .Name(\"another-api-key\")\n        )\n        .GrantType(ApiKeyGrantType.Password)\n        .Password(\"x-pack-test-password\")\n        .RunAs(\"test_user\")\n        .Username(\"test_admin\")\n    );"
     },
     {
       "language": "Java",
@@ -9017,6 +10173,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grant_type\":\"password\",\"username\":\"test_admin\",\"password\":\"x-pack-test-password\",\"api_key\":{\"name\":\"my-api-key\",\"expiration\":\"1d\",\"role_descriptors\":{\"role-a\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index-a*\"],\"privileges\":[\"read\"]}]},\"role-b\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index-b*\"],\"privileges\":[\"all\"]}]}},\"metadata\":{\"application\":\"my-application\",\"environment\":{\"level\":1,\"trusted\":true,\"tags\":[\"dev\",\"staging\"]}}}}' \"$ELASTICSEARCH_URL/_security/api_key/grant\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .GrantApiKeyAsync(d1 => d1\n        .ApiKey(d2 => d2\n            .Expiration(\"1d\")\n            .Metadata(new Dictionary<string, object>()\n            {\n                { \"application\", \"my-application\" },\n                { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"level\": 1,\n                  \"trusted\": true,\n                  \"tags\": [\n                    \"dev\",\n                    \"staging\"\n                  ]\n                }\n                \"\"\") }\n            })\n            .Name(\"my-api-key\")\n            .RoleDescriptors([new Dictionary<string, RoleDescriptor>()\n            {\n                { \"role-a\", new()\n                {\n                    Cluster = [ClusterPrivilege.All],\n                    Indices = [new()\n                    {\n                        Names = [\"index-a*\"],\n                        Privileges = [IndexPrivilege.Read]\n                    }]\n                } },\n                { \"role-b\", new()\n                {\n                    Cluster = [ClusterPrivilege.All],\n                    Indices = [new()\n                    {\n                        Names = [\"index-b*\"],\n                        Privileges = [IndexPrivilege.All]\n                    }]\n                } }\n            }])\n        )\n        .GrantType(ApiKeyGrantType.Password)\n        .Password(\"x-pack-test-password\")\n        .Username(\"test_admin\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().grantApiKey(g -> g\n    .apiKey(a -> a\n        .name(\"my-api-key\")\n        .expiration(e -> e\n            .time(\"1d\")\n        )\n        .roleDescriptors(Map.of(\"role-b\", RoleDescriptor.of(r -> r\n                .cluster(\"all\")\n                .indices(i -> i\n                    .names(\"index-b*\")\n                    .privileges(\"all\")\n                )),\"role-a\", RoleDescriptor.of(r -> r\n                .cluster(\"all\")\n                .indices(i -> i\n                    .names(\"index-a*\")\n                    .privileges(\"read\")\n                ))))\n        .metadata(Map.of(\"environment\", JsonData.fromJson(\"{\\\"level\\\":1,\\\"trusted\\\":true,\\\"tags\\\":[\\\"dev\\\",\\\"staging\\\"]}\"),\"application\", JsonData.fromJson(\"\\\"my-application\\\"\")))\n    )\n    .grantType(ApiKeyGrantType.Password)\n    .password(\"x-pack-test-password\")\n    .username(\"test_admin\")\n);\n"
     }
@@ -9041,6 +10201,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/service/elastic/fleet-server\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .GetServiceAccountsAsync(d1 => d1\n        .Namespace(\"elastic\")\n        .Service(\"fleet-server\")\n    );"
     },
     {
       "language": "Java",
@@ -9069,6 +10233,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/role_mapping/mapping1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security.DeleteRoleMappingAsync(name: \"mapping1\");"
+    },
+    {
       "language": "Java",
       "code": "client.security().deleteRoleMapping(d -> d\n    .name(\"mapping1\")\n);\n"
     }
@@ -9093,6 +10261,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"remote_indices\":[{\"clusters\":[\"my_remote\"],\"names\":[\"logs*\"],\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"]}],\"remote_cluster\":[{\"clusters\":[\"my_remote\"],\"privileges\":[\"monitor_stats\"]}]}' \"$ELASTICSEARCH_URL/_security/role/only_remote_access_role\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleAsync(name: \"only_remote_access_role\", d1 => d1\n        .RemoteCluster(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Privileges(RemoteClusterPrivilege.MonitorStats)\n        )\n        .RemoteIndices(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Names([\"logs*\"])\n            .Privileges(IndexPrivilege.Read, IndexPrivilege.ReadCrossCluster, IndexPrivilege.ViewIndexMetadata)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9121,6 +10293,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"cluster\":[\"cluster:monitor/main\"],\"indices\":[{\"names\":[\"test\"],\"privileges\":[\"read\",\"indices:admin/get\"]}]}' \"$ELASTICSEARCH_URL/_security/role/cli_or_drivers_minimal\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleAsync(name: \"cli_or_drivers_minimal\", d1 => d1\n        .Cluster(new ClusterPrivilege(\"cluster:monitor/main\"))\n        .Indices(d2 => d2\n            .Names([\"test\"])\n            .Privileges(IndexPrivilege.Read, new IndexPrivilege(\"indices:admin/get\"))\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().putRole(p -> p\n    .cluster(\"cluster:monitor/main\")\n    .indices(i -> i\n        .names(\"test\")\n        .privileges(List.of(\"read\",\"indices:admin/get\"))\n    )\n    .name(\"cli_or_drivers_minimal\")\n);\n"
     }
@@ -9145,6 +10321,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"Grants full access to all management features within the cluster.\",\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index1\",\"index2\"],\"privileges\":[\"all\"],\"field_security\":{\"grant\":[\"title\",\"body\"]},\"query\":\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\"}],\"applications\":[{\"application\":\"myapp\",\"privileges\":[\"admin\",\"read\"],\"resources\":[\"*\"]}],\"run_as\":[\"other_user\"],\"metadata\":{\"version\":1}}' \"$ELASTICSEARCH_URL/_security/role/my_admin_role\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutRoleAsync(name: \"my_admin_role\", d1 => d1\n        .Applications(d2 => d2\n            .Application(\"myapp\")\n            .Privileges(\"admin\", \"read\")\n            .Resources(\"*\")\n        )\n        .Cluster(ClusterPrivilege.All)\n        .Description(\"Grants full access to all management features within the cluster.\")\n        .Indices(d2 => d2\n            .FieldSecurity(d3 => d3\n                .Grant(x => x.Title, x => x.Body)\n            )\n            .Names([\"index1\", \"index2\"])\n            .Privileges(IndexPrivilege.All)\n            .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n        )\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"version\", 1 }\n        })\n        .RunAs(\"other_user\")\n    );"
     },
     {
       "language": "Java",
@@ -9173,6 +10353,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"names\":[\"my_admin_role\",\"my_user_role\"]}' \"$ELASTICSEARCH_URL/_security/role\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .BulkDeleteRoleAsync(d1 => d1\n        .Names(\"my_admin_role\", \"my_user_role\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().bulkDeleteRole(b -> b\n    .names(List.of(\"my_admin_role\",\"my_user_role\"))\n);\n"
     }
@@ -9197,6 +10381,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"myapp\":{\"read\":{\"actions\":[\"data:read/*\",\"action:login\"],\"metadata\":{\"description\":\"Read access to myapp\"}}}}' \"$ELASTICSEARCH_URL/_security/privilege\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutPrivilegesAsync(d1 => d1\n        .Privileges(new Dictionary<string, IDictionary<string,PrivilegeActions>>()\n        {\n            { \"myapp\", new Dictionary<string, PrivilegeActions>()\n            {\n                { \"read\", new()\n                {\n                    Actions = [\"data:read/*\", \"action:login\"],\n                    Metadata = new Dictionary<string, object>()\n                    {\n                        { \"description\", \"Read access to myapp\" }\n                    }\n                } }\n            } }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -9225,6 +10413,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"app01\":{\"read\":{\"actions\":[\"action:login\",\"data:read/*\"]},\"write\":{\"actions\":[\"action:login\",\"data:write/*\"]}},\"app02\":{\"all\":{\"actions\":[\"*\"]}}}' \"$ELASTICSEARCH_URL/_security/privilege\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Security\n    .PutPrivilegesAsync(d1 => d1\n        .Privileges(new Dictionary<string, IDictionary<string,PrivilegeActions>>()\n        {\n            { \"app01\", new Dictionary<string, PrivilegeActions>()\n            {\n                { \"read\", new()\n                {\n                    Actions = [\"action:login\", \"data:read/*\"]\n                } },\n                { \"write\", new()\n                {\n                    Actions = [\"action:login\", \"data:write/*\"]\n                } }\n            } },\n            { \"app02\", new Dictionary<string, PrivilegeActions>()\n            {\n                { \"all\", new()\n                {\n                    Actions = [\"*\"]\n                } }\n            } }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.security().putPrivileges(p -> p\n    .privileges(Map.of(\"app02\", \"all\", pr -> pr\n        .actions(\"*\"),\"app01\", Map.of(\"read\", Actions.of(a -> a\n            .actions(List.of(\"action:login\",\"data:read/*\"))),\"write\", Actions.of(a -> a\n            .actions(List.of(\"action:login\",\"data:write/*\"))))))\n);\n"
     }
@@ -9249,6 +10441,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/enroll/kibana\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Security.EnrollKibanaAsync();"
     },
     {
       "language": "Java",
@@ -9277,6 +10473,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_nodes/usage\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Nodes.UsageAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.nodes().usage(u -> u);\n"
     }
@@ -9301,6 +10501,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_nodes/_all/jvm\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Nodes\n    .InfoAsync(d1 => d1\n        .Metric(\"jvm\")\n        .NodeId(\"_all\")\n    );"
     },
     {
       "language": "Java",
@@ -9329,6 +10533,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_nodes/hot_threads\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Nodes.HotThreadsAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.nodes().hotThreads(h -> h);\n"
     }
@@ -9353,6 +10561,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"secure_settings_password\":\"keystore-password\"}' \"$ELASTICSEARCH_URL/_nodes/reload_secure_settings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Nodes\n    .ReloadSecureSettingsAsync(d1 => d1\n        .SecureSettingsPassword(\"keystore-password\")\n    );"
     },
     {
       "language": "Java",
@@ -9381,6 +10593,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_nodes/stats/process?filter_path=**.max_file_descriptors\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Nodes\n    .StatsAsync(d1 => d1\n        .Metric(\"process\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "\n"
     }
@@ -9405,6 +10621,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/pipeline/my-pipeline-id\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Ingest\n    .GetPipelineAsync(d1 => d1\n        .Id(\"my-pipeline-id\")\n    );"
     },
     {
       "language": "Java",
@@ -9433,6 +10653,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"My optional pipeline description\",\"processors\":[{\"set\":{\"description\":\"My optional processor description\",\"field\":\"my-keyword-field\",\"value\":\"foo\"}}]}' \"$ELASTICSEARCH_URL/_ingest/pipeline/my-pipeline-id\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Ingest\n    .PutPipelineAsync(id: \"my-pipeline-id\", d1 => d1\n        .Description(\"My optional pipeline description\")\n        .Processors(d2 => d2\n            .Set(d3 => d3\n                .Description(\"My optional processor description\")\n                .Field(x => x.MyKeywordField)\n                .Value(\"foo\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ingest().putPipeline(p -> p\n    .description(\"My optional pipeline description\")\n    .id(\"my-pipeline-id\")\n    .processors(pr -> pr\n        .set(s -> s\n            .field(\"my-keyword-field\")\n            .value(JsonData.fromJson(\"\\\"foo\\\"\"))\n            .description(\"My optional processor description\")\n        )\n    )\n);\n"
     }
@@ -9444,7 +10668,7 @@
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.ingest.putPipeline({\n  id: \"my-pipeline-id\",\n  description: \"My optional pipeline description\",\n  processors: [\n    {\n      set: {\n        description: \"My optional processor description\",\n        field: \"my-keyword-field\",\n        value: \"foo\",\n      },\n    },\n  ],\n  meta: {\n    reason: \"set my-keyword-field to foo\",\n    serialization: {\n      class: \"MyPipeline\",\n      id: 10,\n    },\n  },\n});"
+      "code": "const response = await client.ingest.putPipeline({\n  id: \"my-pipeline-id\",\n  description: \"My optional pipeline description\",\n  processors: [\n    {\n      set: {\n        description: \"My optional processor description\",\n        field: \"my-keyword-field\",\n        value: \"foo\",\n      },\n    },\n  ],\n  _meta: {\n    reason: \"set my-keyword-field to foo\",\n    serialization: {\n      class: \"MyPipeline\",\n      id: 10,\n    },\n  },\n});"
     },
     {
       "language": "Ruby",
@@ -9457,6 +10681,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"My optional pipeline description\",\"processors\":[{\"set\":{\"description\":\"My optional processor description\",\"field\":\"my-keyword-field\",\"value\":\"foo\"}}],\"_meta\":{\"reason\":\"set my-keyword-field to foo\",\"serialization\":{\"class\":\"MyPipeline\",\"id\":10}}}' \"$ELASTICSEARCH_URL/_ingest/pipeline/my-pipeline-id\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Ingest\n    .PutPipelineAsync(id: \"my-pipeline-id\", d1 => d1\n        .Description(\"My optional pipeline description\")\n        .Meta(new Dictionary<string, object>()\n        {\n            { \"reason\", \"set my-keyword-field to foo\" },\n            { \"serialization\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"class\": \"MyPipeline\",\n              \"id\": 10\n            }\n            \"\"\") }\n        })\n        .Processors(d2 => d2\n            .Set(d3 => d3\n                .Description(\"My optional processor description\")\n                .Field(x => x.MyKeywordField)\n                .Value(\"foo\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9485,6 +10713,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"pipeline\":{\"description\":\"_description\",\"processors\":[{\"set\":{\"field\":\"field2\",\"value\":\"_value\"}}]},\"docs\":[{\"_index\":\"index\",\"_id\":\"id\",\"_source\":{\"foo\":\"bar\"}},{\"_index\":\"index\",\"_id\":\"id\",\"_source\":{\"foo\":\"rab\"}}]}' \"$ELASTICSEARCH_URL/_ingest/pipeline/_simulate\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Ingest\n    .SimulateAsync(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"id\")\n            .Index(\"index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"id\")\n            .Index(\"index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n        .Pipeline(d2 => d2\n            .Description(\"_description\")\n            .Processors(d3 => d3\n                .Set(d4 => d4\n                    .Field(x => x.Field2)\n                    .Value(\"_value\")\n                )\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ingest().simulate(s -> s\n    .docs(List.of(Document.of(d -> d\n            .id(\"id\")\n            .index(\"index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"bar\\\"}\"))),Document.of(d -> d\n            .id(\"id\")\n            .index(\"index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"rab\\\"}\")))))\n    .pipeline(p -> p\n        .description(\"_description\")\n        .processors(pr -> pr\n            .set(se -> se\n                .field(\"field2\")\n                .value(JsonData.fromJson(\"\\\"_value\\\"\"))\n            )\n        )\n    )\n);\n"
     }
@@ -9509,6 +10741,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/pipeline/my-pipeline-id\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Ingest.DeletePipelineAsync(id: \"my-pipeline-id\");"
     },
     {
       "language": "Java",
@@ -9537,6 +10773,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/geoip/stats\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Ingest.GeoIpStatsAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.ingest().geoIpStats();\n"
     }
@@ -9561,6 +10801,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"GeoIP2-Domain\",\"maxmind\":{\"account_id\":\"1234567\"}}' \"$ELASTICSEARCH_URL/_ingest/ip_location/database/my-database-1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Ingest\n    .PutIpLocationDatabaseAsync(id: \"my-database-1\", d1 => d1\n        .Configuration(d2 => d2\n            .Name(\"GeoIP2-Domain\")\n            .Maxmind(d3 => d3\n                .AccountId(\"1234567\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9589,6 +10833,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/ip_location/database/my-database-id\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Ingest.DeleteIpLocationDatabaseAsync(id: new[] { \"my-database-id\" });"
+    },
+    {
       "language": "Java",
       "code": "client.ingest().deleteIpLocationDatabase(d -> d\n    .id(\"my-database-id\")\n);\n"
     }
@@ -9613,6 +10861,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/ip_location/database/my-database-id\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Ingest\n    .GetIpLocationDatabaseAsync(d1 => d1\n        .Id(new[] { \"my-database-id\" })\n    );"
     },
     {
       "language": "Java",
@@ -9641,6 +10893,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/processor/grok\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Ingest.ProcessorGrokAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.ingest().processorGrok();\n"
     }
@@ -9648,23 +10904,27 @@
   "specification/simulate/ingest/examples/request/SimulateIngestRequestExample2.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.simulate.ingest(\n    docs=[\n        {\n            \"_index\": \"my-index\",\n            \"_id\": 123,\n            \"_source\": {\n                \"foo\": \"bar\"\n            }\n        },\n        {\n            \"_index\": \"my-index\",\n            \"_id\": 456,\n            \"_source\": {\n                \"foo\": \"rab\"\n            }\n        }\n    ],\n    pipeline_substitutions={\n        \"my-pipeline\": {\n            \"processors\": [\n                {\n                    \"uppercase\": {\n                        \"field\": \"foo\"\n                    }\n                }\n            ]\n        }\n    },\n)"
+      "code": "resp = client.simulate.ingest(\n    docs=[\n        {\n            \"_index\": \"my-index\",\n            \"_id\": \"123\",\n            \"_source\": {\n                \"foo\": \"bar\"\n            }\n        },\n        {\n            \"_index\": \"my-index\",\n            \"_id\": \"456\",\n            \"_source\": {\n                \"foo\": \"rab\"\n            }\n        }\n    ],\n    pipeline_substitutions={\n        \"my-pipeline\": {\n            \"processors\": [\n                {\n                    \"uppercase\": {\n                        \"field\": \"foo\"\n                    }\n                }\n            ]\n        }\n    },\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.simulate.ingest({\n  docs: [\n    {\n      _index: \"my-index\",\n      _id: 123,\n      _source: {\n        foo: \"bar\",\n      },\n    },\n    {\n      _index: \"my-index\",\n      _id: 456,\n      _source: {\n        foo: \"rab\",\n      },\n    },\n  ],\n  pipeline_substitutions: {\n    \"my-pipeline\": {\n      processors: [\n        {\n          uppercase: {\n            field: \"foo\",\n          },\n        },\n      ],\n    },\n  },\n});"
+      "code": "const response = await client.simulate.ingest({\n  docs: [\n    {\n      _index: \"my-index\",\n      _id: \"123\",\n      _source: {\n        foo: \"bar\",\n      },\n    },\n    {\n      _index: \"my-index\",\n      _id: \"456\",\n      _source: {\n        foo: \"rab\",\n      },\n    },\n  ],\n  pipeline_substitutions: {\n    \"my-pipeline\": {\n      processors: [\n        {\n          uppercase: {\n            field: \"foo\",\n          },\n        },\n      ],\n    },\n  },\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.simulate.ingest(\n  body: {\n    \"docs\": [\n      {\n        \"_index\": \"my-index\",\n        \"_id\": 123,\n        \"_source\": {\n          \"foo\": \"bar\"\n        }\n      },\n      {\n        \"_index\": \"my-index\",\n        \"_id\": 456,\n        \"_source\": {\n          \"foo\": \"rab\"\n        }\n      }\n    ],\n    \"pipeline_substitutions\": {\n      \"my-pipeline\": {\n        \"processors\": [\n          {\n            \"uppercase\": {\n              \"field\": \"foo\"\n            }\n          }\n        ]\n      }\n    }\n  }\n)"
+      "code": "response = client.simulate.ingest(\n  body: {\n    \"docs\": [\n      {\n        \"_index\": \"my-index\",\n        \"_id\": \"123\",\n        \"_source\": {\n          \"foo\": \"bar\"\n        }\n      },\n      {\n        \"_index\": \"my-index\",\n        \"_id\": \"456\",\n        \"_source\": {\n          \"foo\": \"rab\"\n        }\n      }\n    ],\n    \"pipeline_substitutions\": {\n      \"my-pipeline\": {\n        \"processors\": [\n          {\n            \"uppercase\": {\n              \"field\": \"foo\"\n            }\n          }\n        ]\n      }\n    }\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->simulate()->ingest([\n    \"body\" => [\n        \"docs\" => array(\n            [\n                \"_index\" => \"my-index\",\n                \"_id\" => 123,\n                \"_source\" => [\n                    \"foo\" => \"bar\",\n                ],\n            ],\n            [\n                \"_index\" => \"my-index\",\n                \"_id\" => 456,\n                \"_source\" => [\n                    \"foo\" => \"rab\",\n                ],\n            ],\n        ),\n        \"pipeline_substitutions\" => [\n            \"my-pipeline\" => [\n                \"processors\" => array(\n                    [\n                        \"uppercase\" => [\n                            \"field\" => \"foo\",\n                        ],\n                    ],\n                ),\n            ],\n        ],\n    ],\n]);"
+      "code": "$resp = $client->simulate()->ingest([\n    \"body\" => [\n        \"docs\" => array(\n            [\n                \"_index\" => \"my-index\",\n                \"_id\" => \"123\",\n                \"_source\" => [\n                    \"foo\" => \"bar\",\n                ],\n            ],\n            [\n                \"_index\" => \"my-index\",\n                \"_id\" => \"456\",\n                \"_source\" => [\n                    \"foo\" => \"rab\",\n                ],\n            ],\n        ),\n        \"pipeline_substitutions\" => [\n            \"my-pipeline\" => [\n                \"processors\" => array(\n                    [\n                        \"uppercase\" => [\n                            \"field\" => \"foo\",\n                        ],\n                    ],\n                ),\n            ],\n        ],\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"my-index\",\"_id\":123,\"_source\":{\"foo\":\"bar\"}},{\"_index\":\"my-index\",\"_id\":456,\"_source\":{\"foo\":\"rab\"}}],\"pipeline_substitutions\":{\"my-pipeline\":{\"processors\":[{\"uppercase\":{\"field\":\"foo\"}}]}}}' \"$ELASTICSEARCH_URL/_ingest/_simulate\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"my-index\",\"_id\":\"123\",\"_source\":{\"foo\":\"bar\"}},{\"_index\":\"my-index\",\"_id\":\"456\",\"_source\":{\"foo\":\"rab\"}}],\"pipeline_substitutions\":{\"my-pipeline\":{\"processors\":[{\"uppercase\":{\"field\":\"foo\"}}]}}}' \"$ELASTICSEARCH_URL/_ingest/_simulate\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"123\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"456\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n        .PipelineSubstitutions(d2 => d2\n            .Add(\"my-pipeline\", d3 => d3\n                .Processors(d4 => d4\n                    .Uppercase(d5 => d5\n                        .Field(x => x.Foo)\n                    )\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9693,6 +10953,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"my-index\",\"_id\":\"123\",\"_source\":{\"foo\":\"foo\"}},{\"_index\":\"my-index\",\"_id\":\"456\",\"_source\":{\"bar\":\"rab\"}}],\"component_template_substitutions\":{\"my-mappings_template\":{\"template\":{\"mappings\":{\"dynamic\":\"strict\",\"properties\":{\"foo\":{\"type\":\"keyword\"},\"bar\":{\"type\":\"keyword\"}}}}}}}' \"$ELASTICSEARCH_URL/_ingest/_simulate\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .ComponentTemplateSubstitutions(d2 => d2\n            .Add(\"my-mappings_template\", d3 => d3\n                .Template(d4 => d4\n                    .Mappings(d5 => d5\n                        .Dynamic(DynamicMapping.Strict)\n                        .Properties(d6 => d6\n                            .Keyword(x => x.Foo)\n                            .Keyword(x => x.Bar)\n                        )\n                    )\n                )\n            )\n        )\n        .Docs(d2 => d2\n            .Id(\"123\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"foo\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"456\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"bar\": \"rab\"\n            }\n            \"\"\"))\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.simulate().ingest(i -> i\n    .componentTemplateSubstitutions(\"my-mappings_template\", c -> c\n        .template(t -> t\n            .mappings(m -> m\n                .dynamic(DynamicMapping.Strict)\n                .properties(Map.of(\"bar\", Property.of(p -> p\n                        .keyword(k -> k\n                    )),\"foo\", Property.of(pr -> pr\n                        .keyword(k -> k\n                    ))))\n            )\n        )\n    )\n    .docs(List.of(Document.of(d -> d\n            .id(\"123\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"foo\\\"}\"))),Document.of(d -> d\n            .id(\"456\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"bar\\\":\\\"rab\\\"}\")))))\n);\n"
     }
@@ -9719,6 +10983,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_id\":\"id\",\"_index\":\"my-index\",\"_source\":{\"foo\":\"bar\"}},{\"_id\":\"id\",\"_index\":\"my-index\",\"_source\":{\"foo\":\"rab\"}}],\"pipeline_substitutions\":{\"my-pipeline\":{\"processors\":[{\"set\":{\"field\":\"field3\",\"value\":\"value3\"}}]}},\"component_template_substitutions\":{\"my-component-template\":{\"template\":{\"mappings\":{\"dynamic\":true,\"properties\":{\"field3\":{\"type\":\"keyword\"}}},\"settings\":{\"index\":{\"default_pipeline\":\"my-pipeline\"}}}}},\"index_template_substitutions\":{\"my-index-template\":{\"index_patterns\":[\"my-index-*\"],\"composed_of\":[\"component_template_1\",\"component_template_2\"]}},\"mapping_addition\":{\"dynamic\":\"strict\",\"properties\":{\"foo\":{\"type\":\"keyword\"}}}}' \"$ELASTICSEARCH_URL/_ingest/_simulate\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .ComponentTemplateSubstitutions(d2 => d2\n            .Add(\"my-component-template\", d3 => d3\n                .Template(d4 => d4\n                    .Mappings(d5 => d5\n                        .Dynamic(DynamicMapping.True)\n                        .Properties(d6 => d6\n                            .Keyword(x => x.Field3)\n                        )\n                    )\n                    .Settings(d5 => d5\n                        .Add(\"index\", d6 => d6\n                            .DefaultPipeline(\"my-pipeline\")\n                        )\n                    )\n                )\n            )\n        )\n        .Docs(d2 => d2\n            .Id(\"id\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"id\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n        .IndexTemplateSubstitutions(d2 => d2\n            .Add(\"my-index-template\", d3 => d3\n                .ComposedOf([\"component_template_1\", \"component_template_2\"])\n                .IndexPatterns(new[] { \"my-index-*\" })\n            )\n        )\n        .MappingAddition(d2 => d2\n            .Dynamic(DynamicMapping.Strict)\n            .Properties(d3 => d3\n                .Keyword(x => x.Foo)\n            )\n        )\n        .PipelineSubstitutions(d2 => d2\n            .Add(\"my-pipeline\", d3 => d3\n                .Processors(d4 => d4\n                    .Set(d5 => d5\n                        .Field(x => x.Field3)\n                        .Value(\"value3\")\n                    )\n                )\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.simulate().ingest(i -> i\n    .componentTemplateSubstitutions(\"my-component-template\", c -> c\n        .template(t -> t\n            .settings(\"index\", s -> s\n                .defaultPipeline(\"my-pipeline\")\n            )\n            .mappings(m -> m\n                .dynamic(DynamicMapping.True)\n                .properties(\"field3\", p -> p\n                    .keyword(k -> k)\n                )\n            )\n        )\n    )\n    .docs(List.of(Document.of(d -> d\n            .id(\"id\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"bar\\\"}\"))),Document.of(d -> d\n            .id(\"id\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"rab\\\"}\")))))\n    .indexTemplateSubstitutions(\"my-index-template\", in -> in\n        .indexPatterns(\"my-index-*\")\n        .composedOf(List.of(\"component_template_1\",\"component_template_2\"))\n    )\n    .mappingAddition(m -> m\n        .dynamic(DynamicMapping.Strict)\n        .properties(\"foo\", p -> p\n            .keyword(k -> k)\n        )\n    )\n    .pipelineSubstitutions(\"my-pipeline\", p -> p\n        .processors(pr -> pr\n            .set(s -> s\n                .field(\"field3\")\n                .value(JsonData.fromJson(\"\\\"value3\\\"\"))\n            )\n        )\n    )\n);\n"
     }
@@ -9726,23 +10994,27 @@
   "specification/simulate/ingest/examples/request/SimulateIngestRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.simulate.ingest(\n    docs=[\n        {\n            \"_id\": 123,\n            \"_index\": \"my-index\",\n            \"_source\": {\n                \"foo\": \"bar\"\n            }\n        },\n        {\n            \"_id\": 456,\n            \"_index\": \"my-index\",\n            \"_source\": {\n                \"foo\": \"rab\"\n            }\n        }\n    ],\n)"
+      "code": "resp = client.simulate.ingest(\n    docs=[\n        {\n            \"_id\": \"123\",\n            \"_index\": \"my-index\",\n            \"_source\": {\n                \"foo\": \"bar\"\n            }\n        },\n        {\n            \"_id\": \"456\",\n            \"_index\": \"my-index\",\n            \"_source\": {\n                \"foo\": \"rab\"\n            }\n        }\n    ],\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.simulate.ingest({\n  docs: [\n    {\n      _id: 123,\n      _index: \"my-index\",\n      _source: {\n        foo: \"bar\",\n      },\n    },\n    {\n      _id: 456,\n      _index: \"my-index\",\n      _source: {\n        foo: \"rab\",\n      },\n    },\n  ],\n});"
+      "code": "const response = await client.simulate.ingest({\n  docs: [\n    {\n      _id: \"123\",\n      _index: \"my-index\",\n      _source: {\n        foo: \"bar\",\n      },\n    },\n    {\n      _id: \"456\",\n      _index: \"my-index\",\n      _source: {\n        foo: \"rab\",\n      },\n    },\n  ],\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.simulate.ingest(\n  body: {\n    \"docs\": [\n      {\n        \"_id\": 123,\n        \"_index\": \"my-index\",\n        \"_source\": {\n          \"foo\": \"bar\"\n        }\n      },\n      {\n        \"_id\": 456,\n        \"_index\": \"my-index\",\n        \"_source\": {\n          \"foo\": \"rab\"\n        }\n      }\n    ]\n  }\n)"
+      "code": "response = client.simulate.ingest(\n  body: {\n    \"docs\": [\n      {\n        \"_id\": \"123\",\n        \"_index\": \"my-index\",\n        \"_source\": {\n          \"foo\": \"bar\"\n        }\n      },\n      {\n        \"_id\": \"456\",\n        \"_index\": \"my-index\",\n        \"_source\": {\n          \"foo\": \"rab\"\n        }\n      }\n    ]\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->simulate()->ingest([\n    \"body\" => [\n        \"docs\" => array(\n            [\n                \"_id\" => 123,\n                \"_index\" => \"my-index\",\n                \"_source\" => [\n                    \"foo\" => \"bar\",\n                ],\n            ],\n            [\n                \"_id\" => 456,\n                \"_index\" => \"my-index\",\n                \"_source\" => [\n                    \"foo\" => \"rab\",\n                ],\n            ],\n        ),\n    ],\n]);"
+      "code": "$resp = $client->simulate()->ingest([\n    \"body\" => [\n        \"docs\" => array(\n            [\n                \"_id\" => \"123\",\n                \"_index\" => \"my-index\",\n                \"_source\" => [\n                    \"foo\" => \"bar\",\n                ],\n            ],\n            [\n                \"_id\" => \"456\",\n                \"_index\" => \"my-index\",\n                \"_source\" => [\n                    \"foo\" => \"rab\",\n                ],\n            ],\n        ),\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_id\":123,\"_index\":\"my-index\",\"_source\":{\"foo\":\"bar\"}},{\"_id\":456,\"_index\":\"my-index\",\"_source\":{\"foo\":\"rab\"}}]}' \"$ELASTICSEARCH_URL/_ingest/_simulate\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_id\":\"123\",\"_index\":\"my-index\",\"_source\":{\"foo\":\"bar\"}},{\"_id\":\"456\",\"_index\":\"my-index\",\"_source\":{\"foo\":\"rab\"}}]}' \"$ELASTICSEARCH_URL/_ingest/_simulate\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"123\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"456\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9771,6 +11043,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/stats\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SnapshotLifecycleManagement.GetStatsAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.slm().getStats(g -> g);\n"
     }
@@ -9795,6 +11071,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/status\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.SnapshotLifecycleManagement.GetStatusAsync();"
     },
     {
       "language": "Java",
@@ -9823,6 +11103,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/policy/daily-snapshots\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SnapshotLifecycleManagement.DeleteLifecycleAsync(policyId: \"daily-snapshots\");"
+    },
+    {
       "language": "Java",
       "code": "client.slm().deleteLifecycle(d -> d\n    .policyId(\"daily-snapshots\")\n);\n"
     }
@@ -9847,6 +11131,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/start\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.SnapshotLifecycleManagement.StartAsync();"
     },
     {
       "language": "Java",
@@ -9875,6 +11163,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/policy/daily-snapshots?human\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SnapshotLifecycleManagement\n    .GetLifecycleAsync(d1 => d1\n        .PolicyId(new[] { \"daily-snapshots\" })\n    );"
+    },
+    {
       "language": "Java",
       "code": "\n"
     }
@@ -9899,6 +11191,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"schedule\":\"0 30 1 * * ?\",\"name\":\"<daily-snap-{now/d}>\",\"repository\":\"my_repository\",\"config\":{\"indices\":[\"data-*\",\"important\"],\"ignore_unavailable\":false,\"include_global_state\":false},\"retention\":{\"expire_after\":\"30d\",\"min_count\":5,\"max_count\":50}}' \"$ELASTICSEARCH_URL/_slm/policy/daily-snapshots\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.SnapshotLifecycleManagement\n    .PutLifecycleAsync(policyId: \"daily-snapshots\", d1 => d1\n        .Config(d2 => d2\n            .IgnoreUnavailable(false)\n            .IncludeGlobalState(false)\n            .Indices(new[] { \"data-*\", \"important\" })\n        )\n        .Name(\"<daily-snap-{now/d}>\")\n        .Repository(\"my_repository\")\n        .Retention(d2 => d2\n            .ExpireAfter(\"30d\")\n            .MaxCount(50)\n            .MinCount(5)\n        )\n        .Schedule(\"0 30 1 * * ?\")\n    );"
     },
     {
       "language": "Java",
@@ -9927,6 +11223,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"schedule\":\"1h\",\"name\":\"<hourly-snap-{now/d}>\",\"repository\":\"my_repository\",\"config\":{\"indices\":[\"data-*\",\"important\"]}}' \"$ELASTICSEARCH_URL/_slm/policy/hourly-snapshots\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SnapshotLifecycleManagement\n    .PutLifecycleAsync(policyId: \"hourly-snapshots\", d1 => d1\n        .Config(d2 => d2\n            .Indices(new[] { \"data-*\", \"important\" })\n        )\n        .Name(\"<hourly-snap-{now/d}>\")\n        .Repository(\"my_repository\")\n        .Schedule(\"1h\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.slm().putLifecycle(p -> p\n    .config(c -> c\n        .indices(List.of(\"data-*\",\"important\"))\n    )\n    .name(\"<hourly-snap-{now/d}>\")\n    .policyId(\"hourly-snapshots\")\n    .repository(\"my_repository\")\n    .schedule(\"1h\")\n);\n"
     }
@@ -9951,6 +11251,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/_execute_retention\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.SnapshotLifecycleManagement.ExecuteRetentionAsync();"
     },
     {
       "language": "Java",
@@ -9979,6 +11283,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/policy/daily-snapshots/_execute\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SnapshotLifecycleManagement.ExecuteLifecycleAsync(policyId: \"daily-snapshots\");"
+    },
+    {
       "language": "Java",
       "code": "client.slm().executeLifecycle(e -> e\n    .policyId(\"daily-snapshots\")\n);\n"
     }
@@ -10005,6 +11313,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_features/_reset\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Features.ResetFeaturesAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.features().resetFeatures(r -> r);\n"
     }
@@ -10029,6 +11341,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_features\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Features.GetFeaturesAsync();"
     },
     {
       "language": "Java",
@@ -10083,6 +11399,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_synonyms/my-synonyms-set/test-1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Synonyms.GetSynonymRuleAsync(setId: \"my-synonyms-set\", ruleId: \"test-1\");"
+    },
+    {
       "language": "Java",
       "code": "client.synonyms().getSynonymRule(g -> g\n    .ruleId(\"test-1\")\n    .setId(\"my-synonyms-set\")\n);\n"
     }
@@ -10107,6 +11427,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"synonyms\":\"hello, hi, howdy\"}' \"$ELASTICSEARCH_URL/_synonyms/my-synonyms-set/test-1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Synonyms\n    .PutSynonymRuleAsync(setId: \"my-synonyms-set\", ruleId: \"test-1\", d1 => d1\n        .Synonyms(\"hello, hi, howdy\")\n    );"
     },
     {
       "language": "Java",
@@ -10135,6 +11459,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_synonyms/my-synonyms-set/test-1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Synonyms.DeleteSynonymRuleAsync(setId: \"my-synonyms-set\", ruleId: \"test-1\");"
+    },
+    {
       "language": "Java",
       "code": "client.synonyms().deleteSynonymRule(d -> d\n    .ruleId(\"test-1\")\n    .setId(\"my-synonyms-set\")\n);\n"
     }
@@ -10159,6 +11487,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_synonyms/my-synonyms-set\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Synonyms.DeleteSynonymAsync(id: \"my-synonyms-set\");"
     },
     {
       "language": "Java",
@@ -10187,6 +11519,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_synonyms/my-synonyms-set\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Synonyms.GetSynonymAsync(id: \"my-synonyms-set\");"
+    },
+    {
       "language": "Java",
       "code": "client.synonyms().getSynonym(g -> g\n    .id(\"my-synonyms-set\")\n);\n"
     }
@@ -10211,6 +11547,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_synonyms\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Synonyms.GetSynonymsSetsAsync();"
     },
     {
       "language": "Java",
@@ -10259,6 +11599,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_dangling\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.DanglingIndices.ListDanglingIndicesAsync();"
     },
     {
       "language": "Java",
@@ -10339,6 +11683,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"duration\":\"10d\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/_forecast\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .ForecastAsync(jobId: \"low_request_rate\", d1 => d1\n        .Duration(\"10d\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().forecast(f -> f\n    .duration(d -> d\n        .time(\"10d\")\n    )\n    .jobId(\"low_request_rate\")\n);\n"
     }
@@ -10363,6 +11711,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/loganalytics/_stop\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.StopDataFrameAnalyticsAsync(id: \"loganalytics\");"
     },
     {
       "language": "Java",
@@ -10391,6 +11743,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/farequote/model_snapshots/1491948163\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteModelSnapshotAsync(jobId: \"farequote\", snapshotId: \"1491948163\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().deleteModelSnapshot(d -> d\n    .jobId(\"farequote\")\n    .snapshotId(\"1491948163\")\n);\n"
     }
@@ -10415,6 +11771,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-high_sum_total_sales/_stats\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetDatafeedStatsAsync(d1 => d1\n        .DatafeedId(new[] { \"datafeed-high_sum_total_sales\" })\n    );"
     },
     {
       "language": "Java",
@@ -10443,6 +11803,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-total-requests\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteDatafeedAsync(datafeedId: \"datafeed-total-requests\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().deleteDatafeed(d -> d\n    .datafeedId(\"datafeed-total-requests\")\n);\n"
     }
@@ -10467,6 +11831,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages/jobs/total-requests\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteCalendarJobAsync(calendarId: \"planned-outages\", jobId: new[] { \"total-requests\" });"
     },
     {
       "language": "Java",
@@ -10495,6 +11863,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-high_sum_total_sales\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetDatafeedsAsync(d1 => d1\n        .DatafeedId(new[] { \"datafeed-high_sum_total_sales\" })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().getDatafeeds(g -> g\n    .datafeedId(\"datafeed-high_sum_total_sales\")\n);\n"
     }
@@ -10519,6 +11891,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/my_model_for_search/deployment/_stop\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.StopTrainedModelDeploymentAsync(modelId: \"my_model_for_search\");"
     },
     {
       "language": "Java",
@@ -10547,6 +11923,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"timeout\":\"30s\"}' \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-low_request_rate/_stop\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .StopDatafeedAsync(datafeedId: \"datafeed-low_request_rate\", d1 => d1\n        .Timeout(\"30s\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().stopDatafeed(s -> s\n    .datafeedId(\"datafeed-low_request_rate\")\n    .timeout(t -> t\n        .time(\"30s\")\n    )\n);\n"
     }
@@ -10571,6 +11951,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages/events\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.GetCalendarEventsAsync(calendarId: \"planned-outages\");"
     },
     {
       "language": "Java",
@@ -10599,6 +11983,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"text\":\"The fool doth think he is wise, but the wise man knows himself to be a fool.\"}]}' \"$ELASTICSEARCH_URL/_ml/trained_models/lang_ident_model_1/_infer\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .InferTrainedModelAsync(modelId: \"lang_ident_model_1\", d1 => d1\n        .Docs([new Dictionary<string, object>()\n        {\n            { \"text\", \"The fool doth think he is wise, but the wise man knows himself to be a fool.\" }\n        }])\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().inferTrainedModel(i -> i\n    .docs(Map.of(\"text\", JsonData.fromJson(\"\\\"The fool doth think he is wise, but the wise man knows himself to be a fool.\\\"\")))\n    .modelId(\"lang_ident_model_1\")\n);\n"
     }
@@ -10623,6 +12011,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":[\"kibana_sample_data_logs\"],\"query\":{\"bool\":{\"must\":[{\"match_all\":{}}]}},\"job_id\":\"test-job\"}' \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-test-job?pretty\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .PutDatafeedAsync(datafeedId: \"datafeed-test-job\", d1 => d1\n        .Indices(new[] { \"kibana_sample_data_logs\" })\n        .JobId(\"test-job\")\n        .Query(d2 => d2\n            .Bool(d3 => d3\n                .Must(d4 => d4\n                    .MatchAll()\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -10677,6 +12069,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/model_snapshots/1828371/_upgrade?timeout=45m&wait_for_completion=true\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .UpgradeJobSnapshotAsync(jobId: \"low_request_rate\", snapshotId: \"1828371\", d1 => d1\n        .Timeout(\"45m\")\n        .WaitForCompletion(true)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().upgradeJobSnapshot(u -> u\n    .jobId(\"low_request_rate\")\n    .snapshotId(\"1828371\")\n    .timeout(t -> t\n        .offset(45)\n    )\n    .waitForCompletion(true)\n);\n"
     }
@@ -10701,6 +12097,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/high_sum_total_sales\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetJobsAsync(d1 => d1\n        .JobId(new[] { \"high_sum_total_sales\" })\n    );"
     },
     {
       "language": "Java",
@@ -10729,6 +12129,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/model_snapshots/_all/_upgrade/_stats\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.GetModelSnapshotUpgradeStatsAsync(jobId: \"low_request_rate\", snapshotId: \"_all\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().getModelSnapshotUpgradeStats(g -> g\n    .jobId(\"low_request_rate\")\n    .snapshotId(\"_all\")\n);\n"
     }
@@ -10753,6 +12157,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"Snapshot 1\",\"retain\":true}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/it_ops_new_logs/model_snapshots/1491852978/_update\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .UpdateModelSnapshotAsync(jobId: \"it_ops_new_logs\", snapshotId: \"1491852978\", d1 => d1\n        .Description(\"Snapshot 1\")\n        .Retain(true)\n    );"
     },
     {
       "language": "Java",
@@ -10781,6 +12189,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages/jobs/total-requests\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.PutCalendarJobAsync(calendarId: \"planned-outages\", jobId: new[] { \"total-requests\" });"
+    },
+    {
       "language": "Java",
       "code": "client.ml().putCalendarJob(p -> p\n    .calendarId(\"planned-outages\")\n    .jobId(\"total-requests\")\n);\n"
     }
@@ -10805,6 +12217,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"analysis_config\":{\"bucket_span\":\"5m\",\"detectors\":[{\"function\":\"sum\",\"field_name\":\"bytes\",\"by_field_name\":\"status\",\"partition_field_name\":\"app\"}],\"influencers\":[\"source_ip\",\"dest_ip\"]},\"overall_cardinality\":{\"status\":10,\"app\":50},\"max_bucket_cardinality\":{\"source_ip\":300,\"dest_ip\":30}}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/_estimate_model_memory\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .EstimateModelMemoryAsync(d1 => d1\n        .AnalysisConfig(d2 => d2\n            .BucketSpan(\"5m\")\n            .Detectors(d3 => d3\n                .ByFieldName(x => x.Status)\n                .FieldName(x => x.Bytes)\n                .Function(\"sum\")\n                .PartitionFieldName(x => x.App)\n            )\n            .Influencers(x => x.SourceIp, x => x.DestIp)\n        )\n        .MaxBucketCardinality(new Dictionary<Field, long>()\n        {\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.SourceIp), 300L },\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.DestIp), 30L }\n        })\n        .OverallCardinality(new Dictionary<Field, long>()\n        {\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Status), 10L },\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.App), 50L }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -10833,6 +12249,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"page\":{\"size\":1}}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/esxi_log/results/categories\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetCategoriesAsync(new GetCategoriesRequest()\n    {\n        JobId = \"esxi_log\",\n        Page = new()\n        {\n            Size = 1\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.ml().getCategories(g -> g\n    .jobId(\"esxi_log\")\n    .page(p -> p\n        .size(1)\n    )\n);\n"
     }
@@ -10857,6 +12277,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"events\":[{\"description\":\"event 1\",\"start_time\":1513641600000,\"end_time\":1513728000000},{\"description\":\"event 2\",\"start_time\":1513814400000,\"end_time\":1513900800000},{\"description\":\"event 3\",\"start_time\":1514160000000,\"end_time\":1514246400000}]}' \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages/events\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .PostCalendarEventsAsync(calendarId: \"planned-outages\", d1 => d1\n        .Events(d2 => d2\n            .Description(\"event 1\")\n            .EndTime(DateTimeOffset.Parse(\"2017-12-20T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .StartTime(DateTimeOffset.Parse(\"2017-12-19T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)), d2 => d2\n            .Description(\"event 2\")\n            .EndTime(DateTimeOffset.Parse(\"2017-12-22T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .StartTime(DateTimeOffset.Parse(\"2017-12-21T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)), d2 => d2\n            .Description(\"event 3\")\n            .EndTime(DateTimeOffset.Parse(\"2017-12-26T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .StartTime(DateTimeOffset.Parse(\"2017-12-25T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -10885,6 +12309,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"geo.src\":\"US\"}}}' \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-test-job/_update\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .UpdateDatafeedAsync(datafeedId: \"datafeed-test-job\", d1 => d1\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.Geo.Src)\n                .Value(\"US\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().updateDatafeed(u -> u\n    .datafeedId(\"datafeed-test-job\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"geo.src\")\n            .value(FieldValue.of(\"US\"))\n        )\n    )\n);\n"
     }
@@ -10909,6 +12337,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"analysis_config\":{\"bucket_span\":\"15m\",\"detectors\":[{\"detector_description\":\"Sum of bytes\",\"function\":\"sum\",\"field_name\":\"bytes\"}]},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},\"analysis_limits\":{\"model_memory_limit\":\"11MB\"},\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"results_index_name\":\"test-job1\",\"datafeed_config\":{\"indices\":[\"kibana_sample_data_logs\"],\"query\":{\"bool\":{\"must\":[{\"match_all\":{}}]}},\"runtime_mappings\":{\"hour_of_day\":{\"type\":\"long\",\"script\":{\"source\":\"emit(doc['\"'\"'timestamp'\"'\"'].value.getHour());\"}}},\"datafeed_id\":\"datafeed-test-job1\"}}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/job-01\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .PutJobAsync(jobId: \"job-01\", d1 => d1\n        .AnalysisConfig(d2 => d2\n            .BucketSpan(\"15m\")\n            .Detectors(d3 => d3\n                .DetectorDescription(\"Sum of bytes\")\n                .FieldName(x => x.Bytes)\n                .Function(\"sum\")\n            )\n        )\n        .AnalysisLimits(d2 => d2\n            .ModelMemoryLimit(new ByteSize(\"11MB\"))\n        )\n        .DataDescription(d2 => d2\n            .TimeField(x => x.Timestamp)\n            .TimeFormat(\"epoch_ms\")\n        )\n        .DatafeedConfig(d2 => d2\n            .DatafeedId(\"datafeed-test-job1\")\n            .Indices(new[] { \"kibana_sample_data_logs\" })\n            .Query(d3 => d3\n                .Bool(d4 => d4\n                    .Must(d5 => d5\n                        .MatchAll()\n                    )\n                )\n            )\n            .RuntimeMappings(d3 => d3\n                .Add(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.HourOfDay), d4 => d4\n                    .Script(d5 => d5\n                        .Source(\"emit(doc['timestamp'].value.getHour());\")\n                    )\n                    .Type(RuntimeFieldType.Long)\n                )\n            )\n        )\n        .ModelPlotConfig(d2 => d2\n            .AnnotationsEnabled(true)\n            .Enabled(true)\n        )\n        .ResultsIndexName(\"test-job1\")\n    );"
     },
     {
       "language": "Java",
@@ -10937,6 +12369,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"house_price_predictions\",\"query\":{\"term\":{\"ml.is_training\":{\"value\":true}}},\"evaluation\":{\"regression\":{\"actual_field\":\"price\",\"predicted_field\":\"ml.price_prediction\",\"metrics\":{\"r_squared\":{},\"mse\":{},\"msle\":{},\"huber\":{}}}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/_evaluate\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .Regression(d3 => d3\n                .ActualField(x => x.Price)\n                .Metrics(d4 => d4\n                    .Huber()\n                    .Mse(new Dictionary<string, object>() { })\n                    .Msle()\n                    .RSquared(new Dictionary<string, object>() { })\n                )\n                .PredictedField(x => x.Ml.PricePrediction)\n            )\n        )\n        .Index(\"house_price_predictions\")\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.Ml.IsTraining)\n                .Value(true)\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().evaluateDataFrame(e -> e\n    .evaluation(ev -> ev\n        .regression(r -> r\n            .actualField(\"price\")\n            .predictedField(\"ml.price_prediction\")\n            .metrics(m -> m\n                .msle(ms -> ms)\n                .huber(h -> h)\n            )\n        )\n    )\n    .index(\"house_price_predictions\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"ml.is_training\")\n            .value(FieldValue.of(true))\n        )\n    )\n);\n"
     }
@@ -10961,6 +12397,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"house_price_predictions\",\"query\":{\"bool\":{\"filter\":[{\"term\":{\"ml.is_training\":false}}]}},\"evaluation\":{\"regression\":{\"actual_field\":\"price\",\"predicted_field\":\"ml.price_prediction\",\"metrics\":{\"r_squared\":{},\"mse\":{},\"msle\":{\"offset\":10},\"huber\":{\"delta\":1.5}}}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/_evaluate\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .Regression(d3 => d3\n                .ActualField(x => x.Price)\n                .Metrics(d4 => d4\n                    .Huber(d5 => d5\n                        .Delta(1.5d)\n                    )\n                    .Mse(new Dictionary<string, object>() { })\n                    .Msle(d5 => d5\n                        .Offset(10d)\n                    )\n                    .RSquared(new Dictionary<string, object>() { })\n                )\n                .PredictedField(x => x.Ml.PricePrediction)\n            )\n        )\n        .Index(\"house_price_predictions\")\n        .Query(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Ml.IsTraining)\n                        .Value(false)\n                    )\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -10989,6 +12429,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"my_analytics_dest_index\",\"evaluation\":{\"outlier_detection\":{\"actual_field\":\"is_outlier\",\"predicted_probability_field\":\"ml.outlier_score\"}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/_evaluate\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .OutlierDetection(d3 => d3\n                .ActualField(x => x.IsOutlier)\n                .PredictedProbabilityField(x => x.Ml.OutlierScore)\n            )\n        )\n        .Index(\"my_analytics_dest_index\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().evaluateDataFrame(e -> e\n    .evaluation(ev -> ev\n        .outlierDetection(o -> o\n            .actualField(\"is_outlier\")\n            .predictedProbabilityField(\"ml.outlier_score\")\n        )\n    )\n    .index(\"my_analytics_dest_index\")\n);\n"
     }
@@ -11013,6 +12457,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"animal_classification\",\"evaluation\":{\"classification\":{\"actual_field\":\"animal_class\",\"metrics\":{\"auc_roc\":{\"class_name\":\"dog\"}}}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/_evaluate\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .Classification(d3 => d3\n                .ActualField(x => x.AnimalClass)\n                .Metrics(d4 => d4\n                    .AucRoc(d5 => d5\n                        .ClassName(\"dog\")\n                    )\n                )\n            )\n        )\n        .Index(\"animal_classification\")\n    );"
     },
     {
       "language": "Java",
@@ -11041,6 +12489,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"animal_classification\",\"evaluation\":{\"classification\":{\"actual_field\":\"animal_class\",\"predicted_field\":\"ml.animal_class_prediction\",\"metrics\":{\"multiclass_confusion_matrix\":{}}}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/_evaluate\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .Classification(d3 => d3\n                .ActualField(x => x.AnimalClass)\n                .Metrics(d4 => d4\n                    .MulticlassConfusionMatrix(new Dictionary<string, object>() { })\n                )\n                .PredictedField(x => x.Ml.AnimalClassPrediction)\n            )\n        )\n        .Index(\"animal_classification\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().evaluateDataFrame(e -> e\n    .evaluation(ev -> ev\n        .classification(c -> c\n            .actualField(\"animal_class\")\n            .predictedField(\"ml.animal_class_prediction\")\n            .metrics(m -> m)\n        )\n    )\n    .index(\"animal_classification\")\n);\n"
     }
@@ -11065,6 +12517,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/total-requests/_forecast/_all\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .DeleteForecastAsync(new DeleteForecastRequest()\n    {\n        ForecastId = \"_all\",\n        JobId = \"total-requests\"\n    });"
     },
     {
       "language": "Java",
@@ -11093,6 +12549,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.GetTrainedModelsAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.ml().getTrainedModels(g -> g);\n"
     }
@@ -11117,6 +12577,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/_stats\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.GetTrainedModelsStatsAsync();"
     },
     {
       "language": "Java",
@@ -11145,6 +12609,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"sort\":\"influencer_score\",\"desc\":true}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/high_sum_total_sales/results/influencers\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.GetInfluencersAsync(jobId: \"high_sum_total_sales\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().getInfluencers(g -> g\n    .jobId(\"high_sum_total_sales\")\n);\n"
     }
@@ -11169,6 +12637,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/total-requests/_reset\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.ResetJobAsync(jobId: \"total-requests\");"
     },
     {
       "language": "Java",
@@ -11197,6 +12669,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/weblog-outliers/_stats\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetDataFrameAnalyticsStatsAsync(d1 => d1\n        .Id(\"weblog-outliers\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().getDataFrameAnalyticsStats(g -> g\n    .id(\"weblog-outliers\")\n);\n"
     }
@@ -11221,6 +12697,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.PutCalendarAsync(calendarId: \"planned-outages\");"
     },
     {
       "language": "Java",
@@ -11249,6 +12729,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/filters/safe_domains\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteFilterAsync(filterId: \"safe_domains\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().deleteFilter(d -> d\n    .filterId(\"safe_domains\")\n);\n"
     }
@@ -11273,6 +12757,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"Updated list of domains\",\"add_items\":[\"*.myorg.com\"],\"remove_items\":[\"wikipedia.org\"]}' \"$ELASTICSEARCH_URL/_ml/filters/safe_domains/_update\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .UpdateFilterAsync(filterId: \"safe_domains\", d1 => d1\n        .AddItems(\"*.myorg.com\")\n        .Description(\"Updated list of domains\")\n        .RemoveItems(\"wikipedia.org\")\n    );"
     },
     {
       "language": "Java",
@@ -11301,6 +12789,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/_delete_expired_data?timeout=1h\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteExpiredDataAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.ml().deleteExpiredData(d -> d\n    .timeout(t -> t\n        .offset(1)\n    )\n);\n"
     }
@@ -11325,6 +12817,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/deployment/cache/_clear\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.ClearTrainedModelDeploymentCacheAsync(modelId: \"elastic__distilbert-base-uncased-finetuned-conll03-english\");"
     },
     {
       "language": "Java",
@@ -11353,6 +12849,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteCalendarAsync(calendarId: \"planned-outages\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().deleteCalendar(d -> d\n    .calendarId(\"planned-outages\")\n);\n"
     }
@@ -11377,6 +12877,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/filters/safe_domains\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetFiltersAsync(d1 => d1\n        .FilterId(new[] { \"safe_domains\" })\n    );"
     },
     {
       "language": "Java",
@@ -11405,6 +12909,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/flight-delay-prediction-1574775339910/model_aliases/flight_delay_model\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.PutTrainedModelAliasAsync(modelId: \"flight-delay-prediction-1574775339910\", modelAlias: \"flight_delay_model\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().putTrainedModelAlias(p -> p\n    .modelAlias(\"flight_delay_model\")\n    .modelId(\"flight-delay-prediction-1574775339910\")\n);\n"
     }
@@ -11429,6 +12937,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"number_of_allocations\":4}' \"$ELASTICSEARCH_URL/_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/deployment/_update\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .UpdateTrainedModelDeploymentAsync(modelId: \"elastic__distilbert-base-uncased-finetuned-conll03-english\", d1 => d1\n        .NumberOfAllocations(4)\n    );"
     },
     {
       "language": "Java",
@@ -11457,6 +12969,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/info\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.InfoAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.ml().info();\n"
     }
@@ -11481,6 +12997,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/total-requests\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteJobAsync(jobId: \"total-requests\");"
     },
     {
       "language": "Java",
@@ -11509,6 +13029,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"anomaly_score\":80,\"start\":\"1454530200001\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/results/buckets\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetBucketsAsync(new GetBucketsRequest()\n    {\n        JobId = \"low_request_rate\",\n        AnomalyScore = 80d,\n        Start = DateTimeOffset.Parse(\"2016-02-03T20:10:00.0010000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.ml().getBuckets(g -> g\n    .anomalyScore(80.0D)\n    .jobId(\"low_request_rate\")\n    .start(DateTime.of(\"1454530200001\"))\n);\n"
     }
@@ -11533,6 +13057,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/deployment/_start?wait_for=started&timeout=1m\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .StartTrainedModelDeploymentAsync(modelId: \"elastic__distilbert-base-uncased-finetuned-conll03-english\", d1 => d1\n        .Timeout(\"1m\")\n        .WaitFor(DeploymentAllocationState.Started)\n    );"
     },
     {
       "language": "Java",
@@ -11561,6 +13089,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages/events/LS8LJGEBMTCMA-qz49st\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteCalendarEventAsync(calendarId: \"planned-outages\", eventId: \"LS8LJGEBMTCMA-qz49st\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().deleteCalendarEvent(d -> d\n    .calendarId(\"planned-outages\")\n    .eventId(\"LS8LJGEBMTCMA-qz49st\")\n);\n"
     }
@@ -11585,6 +13117,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"sort\":\"record_score\",\"desc\":true,\"start\":\"1454944100000\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/results/records\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetRecordsAsync(jobId: \"low_request_rate\", d1 => d1\n        .Desc(true)\n        .Sort(x => x.RecordScore)\n        .Start(DateTimeOffset.Parse(\"2016-02-08T15:08:20.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n    );"
     },
     {
       "language": "Java",
@@ -11613,6 +13149,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/memory/_stats?human\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.GetMemoryStatsAsync();"
+    },
+    {
       "language": "Java",
       "code": "\n"
     }
@@ -11637,6 +13177,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"start\":\"2019-04-07T18:22:16Z\"}' \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-low_request_rate/_start\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .StartDatafeedAsync(datafeedId: \"datafeed-low_request_rate\", d1 => d1\n        .Start(DateTimeOffset.Parse(\"2019-04-07T18:22:16.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n    );"
     },
     {
       "language": "Java",
@@ -11665,6 +13209,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"houses_sold_last_10_yrs\"},\"analysis\":{\"regression\":{\"dependent_variable\":\"price\"}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/_explain\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .ExplainDataFrameAnalyticsAsync(d1 => d1\n        .Analysis(d2 => d2\n            .Regression(d3 => d3\n                .DependentVariable(\"price\")\n            )\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"houses_sold_last_10_yrs\" })\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().explainDataFrameAnalytics(e -> e\n    .analysis(a -> a\n        .regression(r -> r\n            .dependentVariable(\"price\")\n        )\n    )\n    .source(s -> s\n        .index(\"houses_sold_last_10_yrs\")\n    )\n);\n"
     }
@@ -11689,6 +13237,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"calc_interim\":true}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/_flush\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .FlushJobAsync(jobId: \"low_request_rate\", d1 => d1\n        .CalcInterim(true)\n    );"
     },
     {
       "language": "Java",
@@ -11717,6 +13269,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"start\":\"1575402236000\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/high_sum_total_sales/model_snapshots\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetModelSnapshotsAsync(new GetModelSnapshotsRequest()\n    {\n        JobId = \"high_sum_total_sales\",\n        Start = DateTimeOffset.Parse(\"2019-12-03T19:43:56.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.ml().getModelSnapshots(g -> g\n    .jobId(\"high_sum_total_sales\")\n    .start(DateTime.of(\"1575402236000\"))\n);\n"
     }
@@ -11741,6 +13297,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/set_upgrade_mode?enabled=true\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .SetUpgradeModeAsync(d1 => d1\n        .Enabled(true)\n    );"
     },
     {
       "language": "Java",
@@ -11769,6 +13329,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"model_memory_limit\":\"200mb\"}' \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/loganalytics/_update\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .UpdateDataFrameAnalyticsAsync(id: \"loganalytics\", d1 => d1\n        .ModelMemoryLimit(\"200mb\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().updateDataFrameAnalytics(u -> u\n    .id(\"loganalytics\")\n    .modelMemoryLimit(\"200mb\")\n);\n"
     }
@@ -11795,6 +13359,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/regression-job-one-1574775307356\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteTrainedModelAsync(modelId: \"regression-job-one-1574775307356\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().deleteTrainedModel(d -> d\n    .modelId(\"regression-job-one-1574775307356\")\n);\n"
     }
@@ -11819,6 +13387,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"overall_score\":80,\"start\":\"1403532000000\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/job-*/results/overall_buckets\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetOverallBucketsAsync(jobId: \"job-*\", d1 => d1\n        .OverallScore(80d)\n        .Start(DateTimeOffset.Parse(\"2014-06-23T14:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n    );"
     },
     {
       "language": "Java",
@@ -11873,6 +13445,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"vocabulary\":[\"[PAD]\",\"[unused0]\"]}' \"$ELASTICSEARCH_URL/_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/vocabulary\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .PutTrainedModelVocabularyAsync(modelId: \"elastic__distilbert-base-uncased-finetuned-conll03-english\", d1 => d1\n        .Vocabulary(\"[PAD]\", \"[unused0]\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().putTrainedModelVocabulary(p -> p\n    .modelId(\"elastic__distilbert-base-uncased-finetuned-conll03-english\")\n    .vocabulary(List.of(\"[PAD]\",\"[unused0]\"))\n);\n"
     }
@@ -11897,6 +13473,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/loganalytics\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetDataFrameAnalyticsAsync(d1 => d1\n        .Id(\"loganalytics\")\n    );"
     },
     {
       "language": "Java",
@@ -11925,6 +13505,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/flight-delay-prediction-1574775339910/model_aliases/flight_delay_model\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteTrainedModelAliasAsync(modelId: \"flight-delay-prediction-1574775339910\", modelAlias: \"flight_delay_model\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().deleteTrainedModelAlias(d -> d\n    .modelAlias(\"flight_delay_model\")\n    .modelId(\"flight-delay-prediction-1574775339910\")\n);\n"
     }
@@ -11949,6 +13533,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"delete_intervening_results\":true}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/model_snapshots/1637092688/_revert\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .RevertModelSnapshotAsync(jobId: \"low_request_rate\", snapshotId: \"1637092688\", d1 => d1\n        .DeleteInterveningResults(true)\n    );"
     },
     {
       "language": "Java",
@@ -11977,6 +13565,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/_close\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.CloseJobAsync(jobId: \"low_request_rate\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().closeJob(c -> c\n    .jobId(\"low_request_rate\")\n);\n"
     }
@@ -12001,6 +13593,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"definition\":\"...\",\"total_definition_length\":265632637,\"total_parts\":64}' \"$ELASTICSEARCH_URL/_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/definition/0\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .PutTrainedModelDefinitionPartAsync(modelId: \"elastic__distilbert-base-uncased-finetuned-conll03-english\", part: 0, d1 => d1\n        .Definition(\"...\")\n        .TotalDefinitionLength(265632637L)\n        .TotalParts(64)\n    );"
     }
   ],
   "specification/ml/put_data_frame_analytics/examples/request/MlPutDataFrameAnalyticsExample1.yaml": [
@@ -12023,6 +13619,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":[\"kibana_sample_data_flights\"],\"query\":{\"range\":{\"DistanceKilometers\":{\"gt\":0}}},\"_source\":{\"includes\":[],\"excludes\":[\"FlightDelay\",\"FlightDelayType\"]}},\"dest\":{\"index\":\"df-flight-delays\",\"results_field\":\"ml-results\"},\"analysis\":{\"regression\":{\"dependent_variable\":\"FlightDelayMin\",\"training_percent\":90}},\"analyzed_fields\":{\"includes\":[],\"excludes\":[\"FlightNum\"]},\"model_memory_limit\":\"100mb\"}' \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/model-flight-delays-pre\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .PutDataFrameAnalyticsAsync(id: \"model-flight-delays-pre\", d1 => d1\n        .Analysis(d2 => d2\n            .Regression(d3 => d3\n                .DependentVariable(\"FlightDelayMin\")\n                .TrainingPercent(new Percentage(90f))\n            )\n        )\n        .AnalyzedFields(d2 => d2\n            .Excludes(\"FlightNum\")\n            .Includes()\n        )\n        .Dest(d2 => d2\n            .Index(\"df-flight-delays\")\n            .ResultsField(x => x.MlResults)\n        )\n        .ModelMemoryLimit(\"100mb\")\n        .Source(d2 => d2\n            .Indices(new[] { \"kibana_sample_data_flights\" })\n            .Query(d3 => d3\n                .Range(new UntypedRangeQuery()\n                {\n                    Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.DistanceKilometers),\n                    Gt = 0\n                })\n            )\n            .Source(d3 => d3\n                .Excludes(\"FlightDelay\", \"FlightDelayType\")\n                .Includes()\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -12051,6 +13651,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/loganalytics\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.DeleteDataFrameAnalyticsAsync(id: \"loganalytics\");"
+    },
+    {
       "language": "Java",
       "code": "client.ml().deleteDataFrameAnalytics(d -> d\n    .id(\"loganalytics\")\n);\n"
     }
@@ -12075,6 +13679,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"config\":{\"source\":{\"index\":\"houses_sold_last_10_yrs\"},\"analysis\":{\"regression\":{\"dependent_variable\":\"price\"}}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/_preview\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .PreviewDataFrameAnalyticsAsync(d1 => d1\n        .Config(d2 => d2\n            .Analysis(d3 => d3\n                .Regression(d4 => d4\n                    .DependentVariable(\"price\")\n                )\n            )\n            .Source(d3 => d3\n                .Indices(new[] { \"houses_sold_last_10_yrs\" })\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -12103,6 +13711,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"A list of safe domains\",\"items\":[\"*.google.com\",\"wikipedia.org\"]}' \"$ELASTICSEARCH_URL/_ml/filters/safe_domains\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .PutFilterAsync(filterId: \"safe_domains\", d1 => d1\n        .Description(\"A list of safe domains\")\n        .Items(\"*.google.com\", \"wikipedia.org\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().putFilter(p -> p\n    .description(\"A list of safe domains\")\n    .filterId(\"safe_domains\")\n    .items(List.of(\"*.google.com\",\"wikipedia.org\"))\n);\n"
     }
@@ -12127,6 +13739,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/loganalytics/_start\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning.StartDataFrameAnalyticsAsync(id: \"loganalytics\");"
     },
     {
       "language": "Java",
@@ -12155,6 +13771,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetCalendarsAsync(d1 => d1\n        .CalendarId(\"planned-outages\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().getCalendars(g -> g\n    .calendarId(\"planned-outages\")\n);\n"
     }
@@ -12179,6 +13799,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/_stats\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .GetJobStatsAsync(d1 => d1\n        .JobId(\"low_request_rate\")\n    );"
     },
     {
       "language": "Java",
@@ -12207,6 +13831,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"timeout\":\"35m\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/job-01/_open\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.MachineLearning\n    .OpenJobAsync(jobId: \"job-01\", d1 => d1\n        .Timeout(\"35m\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ml().openJob(o -> o\n    .jobId(\"job-01\")\n    .timeout(t -> t\n        .time(\"35m\")\n    )\n);\n"
     }
@@ -12233,6 +13861,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grok_pattern\":\"Hello %{WORD:first_name} %{WORD:last_name}\",\"text\":[\"Hello John Doe\",\"this does not match\"]}' \"$ELASTICSEARCH_URL/_text_structure/test_grok_pattern\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.TextStructure\n    .TestGrokPatternAsync(d1 => d1\n        .GrokPattern(\"Hello %{WORD:first_name} %{WORD:last_name}\")\n        .Text(\"Hello John Doe\", \"this does not match\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.textStructure().testGrokPattern(t -> t\n    .grokPattern(\"Hello %{WORD:first_name} %{WORD:last_name}\")\n    .text(List.of(\"Hello John Doe\",\"this does not match\"))\n);\n"
     }
@@ -12256,7 +13888,7 @@
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '[{\"name\":\"Leviathan Wakes\",\"author\":\"James S.A. Corey\",\"release_date\":\"2011-06-02\",\"page_count\":561},{\"name\":\"Hyperion\",\"author\":\"Dan Simmons\",\"release_date\":\"1989-05-26\",\"page_count\":482},{\"name\":\"Dune\",\"author\":\"Frank Herbert\",\"release_date\":\"1965-06-01\",\"page_count\":604},{\"name\":\"Dune Messiah\",\"author\":\"Frank Herbert\",\"release_date\":\"1969-10-15\",\"page_count\":331},{\"name\":\"Children of Dune\",\"author\":\"Frank Herbert\",\"release_date\":\"1976-04-21\",\"page_count\":408},{\"name\":\"God Emperor of Dune\",\"author\":\"Frank Herbert\",\"release_date\":\"1981-05-28\",\"page_count\":454},{\"name\":\"Consider Phlebas\",\"author\":\"Iain M. Banks\",\"release_date\":\"1987-04-23\",\"page_count\":471},{\"name\":\"Pandora'\"'\"'s Star\",\"author\":\"Peter F. Hamilton\",\"release_date\":\"2004-03-02\",\"page_count\":768},{\"name\":\"Revelation Space\",\"author\":\"Alastair Reynolds\",\"release_date\":\"2000-03-15\",\"page_count\":585},{\"name\":\"A Fire Upon the Deep\",\"author\":\"Vernor Vinge\",\"release_date\":\"1992-06-01\",\"page_count\":613},{\"name\":\"Ender'\"'\"'s Game\",\"author\":\"Orson Scott Card\",\"release_date\":\"1985-06-01\",\"page_count\":324},{\"name\":\"1984\",\"author\":\"George Orwell\",\"release_date\":\"1985-06-01\",\"page_count\":328},{\"name\":\"Fahrenheit 451\",\"author\":\"Ray Bradbury\",\"release_date\":\"1953-10-15\",\"page_count\":227},{\"name\":\"Brave New World\",\"author\":\"Aldous Huxley\",\"release_date\":\"1932-06-01\",\"page_count\":268},{\"name\":\"Foundation\",\"author\":\"Isaac Asimov\",\"release_date\":\"1951-06-01\",\"page_count\":224},{\"name\":\"The Giver\",\"author\":\"Lois Lowry\",\"release_date\":\"1993-04-26\",\"page_count\":208},{\"name\":\"Slaughterhouse-Five\",\"author\":\"Kurt Vonnegut\",\"release_date\":\"1969-06-01\",\"page_count\":275},{\"name\":\"The Hitchhiker'\"'\"'s Guide to the Galaxy\",\"author\":\"Douglas Adams\",\"release_date\":\"1979-10-12\",\"page_count\":180},{\"name\":\"Snow Crash\",\"author\":\"Neal Stephenson\",\"release_date\":\"1992-06-01\",\"page_count\":470},{\"name\":\"Neuromancer\",\"author\":\"William Gibson\",\"release_date\":\"1984-07-01\",\"page_count\":271},{\"name\":\"The Handmaid'\"'\"'s Tale\",\"author\":\"Margaret Atwood\",\"release_date\":\"1985-06-01\",\"page_count\":311},{\"name\":\"Starship Troopers\",\"author\":\"Robert A. Heinlein\",\"release_date\":\"1959-12-01\",\"page_count\":335},{\"name\":\"The Left Hand of Darkness\",\"author\":\"Ursula K. Le Guin\",\"release_date\":\"1969-06-01\",\"page_count\":304},{\"name\":\"The Moon is a Harsh Mistress\",\"author\":\"Robert A. Heinlein\",\"release_date\":\"1966-04-01\",\"page_count\":288}]' \"$ELASTICSEARCH_URL/_text_structure/find_structure\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/x-ndjson\" -d $'{\"name\":\"Leviathan Wakes\",\"author\":\"James S.A. Corey\",\"release_date\":\"2011-06-02\",\"page_count\":561}\\n{\"name\":\"Hyperion\",\"author\":\"Dan Simmons\",\"release_date\":\"1989-05-26\",\"page_count\":482}\\n{\"name\":\"Dune\",\"author\":\"Frank Herbert\",\"release_date\":\"1965-06-01\",\"page_count\":604}\\n{\"name\":\"Dune Messiah\",\"author\":\"Frank Herbert\",\"release_date\":\"1969-10-15\",\"page_count\":331}\\n{\"name\":\"Children of Dune\",\"author\":\"Frank Herbert\",\"release_date\":\"1976-04-21\",\"page_count\":408}\\n{\"name\":\"God Emperor of Dune\",\"author\":\"Frank Herbert\",\"release_date\":\"1981-05-28\",\"page_count\":454}\\n{\"name\":\"Consider Phlebas\",\"author\":\"Iain M. Banks\",\"release_date\":\"1987-04-23\",\"page_count\":471}\\n{\"name\":\"Pandora'\"'\"$'s Star\",\"author\":\"Peter F. Hamilton\",\"release_date\":\"2004-03-02\",\"page_count\":768}\\n{\"name\":\"Revelation Space\",\"author\":\"Alastair Reynolds\",\"release_date\":\"2000-03-15\",\"page_count\":585}\\n{\"name\":\"A Fire Upon the Deep\",\"author\":\"Vernor Vinge\",\"release_date\":\"1992-06-01\",\"page_count\":613}\\n{\"name\":\"Ender'\"'\"$'s Game\",\"author\":\"Orson Scott Card\",\"release_date\":\"1985-06-01\",\"page_count\":324}\\n{\"name\":\"1984\",\"author\":\"George Orwell\",\"release_date\":\"1985-06-01\",\"page_count\":328}\\n{\"name\":\"Fahrenheit 451\",\"author\":\"Ray Bradbury\",\"release_date\":\"1953-10-15\",\"page_count\":227}\\n{\"name\":\"Brave New World\",\"author\":\"Aldous Huxley\",\"release_date\":\"1932-06-01\",\"page_count\":268}\\n{\"name\":\"Foundation\",\"author\":\"Isaac Asimov\",\"release_date\":\"1951-06-01\",\"page_count\":224}\\n{\"name\":\"The Giver\",\"author\":\"Lois Lowry\",\"release_date\":\"1993-04-26\",\"page_count\":208}\\n{\"name\":\"Slaughterhouse-Five\",\"author\":\"Kurt Vonnegut\",\"release_date\":\"1969-06-01\",\"page_count\":275}\\n{\"name\":\"The Hitchhiker'\"'\"$'s Guide to the Galaxy\",\"author\":\"Douglas Adams\",\"release_date\":\"1979-10-12\",\"page_count\":180}\\n{\"name\":\"Snow Crash\",\"author\":\"Neal Stephenson\",\"release_date\":\"1992-06-01\",\"page_count\":470}\\n{\"name\":\"Neuromancer\",\"author\":\"William Gibson\",\"release_date\":\"1984-07-01\",\"page_count\":271}\\n{\"name\":\"The Handmaid'\"'\"$'s Tale\",\"author\":\"Margaret Atwood\",\"release_date\":\"1985-06-01\",\"page_count\":311}\\n{\"name\":\"Starship Troopers\",\"author\":\"Robert A. Heinlein\",\"release_date\":\"1959-12-01\",\"page_count\":335}\\n{\"name\":\"The Left Hand of Darkness\",\"author\":\"Ursula K. Le Guin\",\"release_date\":\"1969-06-01\",\"page_count\":304}\\n{\"name\":\"The Moon is a Harsh Mistress\",\"author\":\"Robert A. Heinlein\",\"release_date\":\"1966-04-01\",\"page_count\":288}\\n' \"$ELASTICSEARCH_URL/_text_structure/find_structure\""
     }
   ],
   "specification/text_structure/find_field_structure/examples/request/FindFieldStructureRequestExample1.yaml": [
@@ -12279,6 +13911,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_text_structure/find_field_structure?index=test-logs&field=message\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.TextStructure\n    .FindFieldStructureAsync(d1 => d1\n        .Field(x => x.Message)\n        .Index(\"test-logs\")\n    );"
     },
     {
       "language": "Java",
@@ -12307,6 +13943,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"messages\":[\"[2024-03-05T10:52:36,256][INFO ][o.a.l.u.VectorUtilPanamaProvider] [laptop] Java vector incubator API enabled; uses preferredBitSize=128\",\"[2024-03-05T10:52:41,038][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [repository-url]\",\"[2024-03-05T10:52:41,042][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [rest-root]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-core]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-redact]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [ingest-user-agent]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-monitoring]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [repository-s3]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-analytics]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-ent-search]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-autoscaling]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [lang-painless]]\",\"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [lang-expression]\",\"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-eql]\",\"[2024-03-05T10:52:43,291][INFO ][o.e.e.NodeEnvironment    ] [laptop] heap size [16gb], compressed ordinary object pointers [true]\",\"[2024-03-05T10:52:46,098][INFO ][o.e.x.s.Security         ] [laptop] Security is enabled\",\"[2024-03-05T10:52:47,227][INFO ][o.e.x.p.ProfilingPlugin  ] [laptop] Profiling is enabled\",\"[2024-03-05T10:52:47,259][INFO ][o.e.x.p.ProfilingPlugin  ] [laptop] profiling index templates will not be installed or reinstalled\",\"[2024-03-05T10:52:47,755][INFO ][o.e.i.r.RecoverySettings ] [laptop] using rate limit [40mb] with [default=40mb, read=0b, write=0b, max=0b]\",\"[2024-03-05T10:52:47,787][INFO ][o.e.d.DiscoveryModule    ] [laptop] using discovery type [multi-node] and seed hosts providers [settings]\",\"[2024-03-05T10:52:49,188][INFO ][o.e.n.Node               ] [laptop] initialized\",\"[2024-03-05T10:52:49,199][INFO ][o.e.n.Node               ] [laptop] starting ...\"]}' \"$ELASTICSEARCH_URL/_text_structure/find_message_structure\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.TextStructure\n    .FindMessageStructureAsync(d1 => d1\n        .Messages(\"[2024-03-05T10:52:36,256][INFO ][o.a.l.u.VectorUtilPanamaProvider] [laptop] Java vector incubator API enabled; uses preferredBitSize=128\", \"[2024-03-05T10:52:41,038][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [repository-url]\", \"[2024-03-05T10:52:41,042][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [rest-root]\", \"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-core]\", \"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-redact]\", \"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [ingest-user-agent]\", \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-monitoring]\", \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [repository-s3]\", \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-analytics]\", \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-ent-search]\", \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-autoscaling]\", \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [lang-painless]]\", \"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [lang-expression]\", \"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-eql]\", \"[2024-03-05T10:52:43,291][INFO ][o.e.e.NodeEnvironment    ] [laptop] heap size [16gb], compressed ordinary object pointers [true]\", \"[2024-03-05T10:52:46,098][INFO ][o.e.x.s.Security         ] [laptop] Security is enabled\", \"[2024-03-05T10:52:47,227][INFO ][o.e.x.p.ProfilingPlugin  ] [laptop] Profiling is enabled\", \"[2024-03-05T10:52:47,259][INFO ][o.e.x.p.ProfilingPlugin  ] [laptop] profiling index templates will not be installed or reinstalled\", \"[2024-03-05T10:52:47,755][INFO ][o.e.i.r.RecoverySettings ] [laptop] using rate limit [40mb] with [default=40mb, read=0b, write=0b, max=0b]\", \"[2024-03-05T10:52:47,787][INFO ][o.e.d.DiscoveryModule    ] [laptop] using discovery type [multi-node] and seed hosts providers [settings]\", \"[2024-03-05T10:52:49,188][INFO ][o.e.n.Node               ] [laptop] initialized\", \"[2024-03-05T10:52:49,199][INFO ][o.e.n.Node               ] [laptop] starting ...\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.textStructure().findMessageStructure(f -> f\n    .messages(List.of(\"[2024-03-05T10:52:36,256][INFO ][o.a.l.u.VectorUtilPanamaProvider] [laptop] Java vector incubator API enabled; uses preferredBitSize=128\",\"[2024-03-05T10:52:41,038][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [repository-url]\",\"[2024-03-05T10:52:41,042][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [rest-root]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-core]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-redact]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [ingest-user-agent]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-monitoring]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [repository-s3]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-analytics]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-ent-search]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-autoscaling]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [lang-painless]]\",\"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [lang-expression]\",\"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-eql]\",\"[2024-03-05T10:52:43,291][INFO ][o.e.e.NodeEnvironment    ] [laptop] heap size [16gb], compressed ordinary object pointers [true]\",\"[2024-03-05T10:52:46,098][INFO ][o.e.x.s.Security         ] [laptop] Security is enabled\",\"[2024-03-05T10:52:47,227][INFO ][o.e.x.p.ProfilingPlugin  ] [laptop] Profiling is enabled\",\"[2024-03-05T10:52:47,259][INFO ][o.e.x.p.ProfilingPlugin  ] [laptop] profiling index templates will not be installed or reinstalled\",\"[2024-03-05T10:52:47,755][INFO ][o.e.i.r.RecoverySettings ] [laptop] using rate limit [40mb] with [default=40mb, read=0b, write=0b, max=0b]\",\"[2024-03-05T10:52:47,787][INFO ][o.e.d.DiscoveryModule    ] [laptop] using discovery type [multi-node] and seed hosts providers [settings]\",\"[2024-03-05T10:52:49,188][INFO ][o.e.n.Node               ] [laptop] initialized\",\"[2024-03-05T10:52:49,199][INFO ][o.e.n.Node               ] [laptop] starting ...\"))\n);\n"
     }
@@ -12322,7 +13962,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.rollup.get_rollup_index_caps(\n  index: \"sensor_rollup\"\n)"
+      "code": "response = client.perform_request(\n  \"GET\",\n  \"/sensor_rollup/_rollup/data\",\n  {},\n)"
     },
     {
       "language": "PHP",
@@ -12331,6 +13971,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/sensor_rollup/_rollup/data\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Rollup.GetRollupIndexCapsAsync(index: new[] { \"sensor_rollup\" });"
     },
     {
       "language": "Java",
@@ -12348,7 +13992,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.rollup.get_jobs(\n  id: \"sensor\"\n)"
+      "code": "response = client.perform_request(\n  \"GET\",\n  \"/_rollup/job/sensor\",\n  {},\n)"
     },
     {
       "language": "PHP",
@@ -12357,6 +14001,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_rollup/job/sensor\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Rollup\n    .GetJobsAsync(d1 => d1\n        .Id(\"sensor\")\n    );"
     },
     {
       "language": "Java",
@@ -12374,7 +14022,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.rollup.stop_job(\n  id: \"sensor\",\n  wait_for_completion: \"true\",\n  timeout: \"10s\"\n)"
+      "code": "response = client.perform_request(\n  \"POST\",\n  \"/_rollup/job/sensor/_stop\",\n  {\n    \"wait_for_completion\": \"true\",\n    \"timeout\": \"10s\"\n  },\n)"
     },
     {
       "language": "PHP",
@@ -12383,6 +14031,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_rollup/job/sensor/_stop?wait_for_completion=true&timeout=10s\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Rollup\n    .StopJobAsync(id: \"sensor\", d1 => d1\n        .Timeout(\"10s\")\n        .WaitForCompletion(true)\n    );"
     },
     {
       "language": "Java",
@@ -12400,7 +14052,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.rollup.get_rollup_caps(\n  id: \"sensor-*\"\n)"
+      "code": "response = client.perform_request(\n  \"GET\",\n  \"/_rollup/data/sensor-*\",\n  {},\n)"
     },
     {
       "language": "PHP",
@@ -12409,6 +14061,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_rollup/data/sensor-*\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Rollup\n    .GetRollupCapsAsync(d1 => d1\n        .Id(\"sensor-*\")\n    );"
     },
     {
       "language": "Java",
@@ -12426,7 +14082,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.rollup.rollup_search(\n  index: \"sensor_rollup\",\n  body: {\n    \"size\": 0,\n    \"aggregations\": {\n      \"max_temperature\": {\n        \"max\": {\n          \"field\": \"temperature\"\n        }\n      }\n    }\n  }\n)"
+      "code": "response = client.perform_request(\n  \"GET\",\n  \"/sensor_rollup/_rollup_search\",\n  {},\n  {\n    \"size\": 0,\n    \"aggregations\": {\n      \"max_temperature\": {\n        \"max\": {\n          \"field\": \"temperature\"\n        }\n      }\n    }\n  },\n  { \"Content-Type\": \"application/json\" },\n)"
     },
     {
       "language": "PHP",
@@ -12435,6 +14091,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"size\":0,\"aggregations\":{\"max_temperature\":{\"max\":{\"field\":\"temperature\"}}}}' \"$ELASTICSEARCH_URL/sensor_rollup/_rollup_search\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Rollup\n    .RollupSearchAsync<MyDocument>(indices: new[] { \"sensor_rollup\" }, d1 => d1\n        .Aggregations(d2 => d2\n            .Add(\"max_temperature\", d3 => d3\n                .Max(d4 => d4\n                    .Field(x => x.Temperature)\n                )\n            )\n        )\n        .Size(0)\n    );"
     },
     {
       "language": "Java",
@@ -12452,7 +14112,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.rollup.put_job(\n  id: \"sensor\",\n  body: {\n    \"index_pattern\": \"sensor-*\",\n    \"rollup_index\": \"sensor_rollup\",\n    \"cron\": \"*/30 * * * * ?\",\n    \"page_size\": 1000,\n    \"groups\": {\n      \"date_histogram\": {\n        \"field\": \"timestamp\",\n        \"fixed_interval\": \"1h\",\n        \"delay\": \"7d\"\n      },\n      \"terms\": {\n        \"fields\": [\n          \"node\"\n        ]\n      }\n    },\n    \"metrics\": [\n      {\n        \"field\": \"temperature\",\n        \"metrics\": [\n          \"min\",\n          \"max\",\n          \"sum\"\n        ]\n      },\n      {\n        \"field\": \"voltage\",\n        \"metrics\": [\n          \"avg\"\n        ]\n      }\n    ]\n  }\n)"
+      "code": "response = client.perform_request(\n  \"PUT\",\n  \"/_rollup/job/sensor\",\n  {},\n  {\n    \"index_pattern\": \"sensor-*\",\n    \"rollup_index\": \"sensor_rollup\",\n    \"cron\": \"*/30 * * * * ?\",\n    \"page_size\": 1000,\n    \"groups\": {\n      \"date_histogram\": {\n        \"field\": \"timestamp\",\n        \"fixed_interval\": \"1h\",\n        \"delay\": \"7d\"\n      },\n      \"terms\": {\n        \"fields\": [\n          \"node\"\n        ]\n      }\n    },\n    \"metrics\": [\n      {\n        \"field\": \"temperature\",\n        \"metrics\": [\n          \"min\",\n          \"max\",\n          \"sum\"\n        ]\n      },\n      {\n        \"field\": \"voltage\",\n        \"metrics\": [\n          \"avg\"\n        ]\n      }\n    ]\n  },\n  { \"Content-Type\": \"application/json\" },\n)"
     },
     {
       "language": "PHP",
@@ -12461,6 +14121,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_pattern\":\"sensor-*\",\"rollup_index\":\"sensor_rollup\",\"cron\":\"*/30 * * * * ?\",\"page_size\":1000,\"groups\":{\"date_histogram\":{\"field\":\"timestamp\",\"fixed_interval\":\"1h\",\"delay\":\"7d\"},\"terms\":{\"fields\":[\"node\"]}},\"metrics\":[{\"field\":\"temperature\",\"metrics\":[\"min\",\"max\",\"sum\"]},{\"field\":\"voltage\",\"metrics\":[\"avg\"]}]}' \"$ELASTICSEARCH_URL/_rollup/job/sensor\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Rollup\n    .PutJobAsync(id: \"sensor\", d1 => d1\n        .Cron(\"*/30 * * * * ?\")\n        .Groups(d2 => d2\n            .DateHistogram(d3 => d3\n                .Delay(\"7d\")\n                .Field(x => x.Timestamp)\n                .FixedInterval(\"1h\")\n            )\n            .Terms(d3 => d3\n                .Fields(x => x.Node)\n            )\n        )\n        .IndexPattern(\"sensor-*\")\n        .Metrics(d2 => d2\n            .Field(x => x.Temperature)\n            .Metrics(Metric.Min, Metric.Max, Metric.Sum), d2 => d2\n            .Field(x => x.Voltage)\n            .Metrics(Metric.Avg)\n        )\n        .PageSize(1000)\n        .RollupIndex(\"sensor_rollup\")\n    );"
     },
     {
       "language": "Java",
@@ -12478,7 +14142,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.rollup.delete_job(\n  id: \"sensor\"\n)"
+      "code": "response = client.perform_request(\n  \"DELETE\",\n  \"/_rollup/job/sensor\",\n  {},\n)"
     },
     {
       "language": "PHP",
@@ -12487,6 +14151,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_rollup/job/sensor\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Rollup.DeleteJobAsync(id: \"sensor\");"
     },
     {
       "language": "Java",
@@ -12504,7 +14172,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.rollup.start_job(\n  id: \"sensor\"\n)"
+      "code": "response = client.perform_request(\n  \"POST\",\n  \"/_rollup/job/sensor/_start\",\n  {},\n)"
     },
     {
       "language": "PHP",
@@ -12513,6 +14181,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_rollup/job/sensor/_start\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Rollup.StartJobAsync(id: \"sensor\");"
     },
     {
       "language": "Java",
@@ -13250,11 +14922,11 @@
   "specification/connector/last_sync/examples/request/ConnectorUpdateLastSyncRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.perform_request(\n    \"PUT\",\n    \"/_connector/my-connector/_last_sync\",\n    headers={\"Content-Type\": \"application/json\"},\n    body={\n        \"last_access_control_sync_error\": \"Houston, we have a problem!\",\n        \"last_access_control_sync_scheduled_at\": \"2023-11-09T15:13:08.231Z\",\n        \"last_access_control_sync_status\": \"pending\",\n        \"last_deleted_document_count\": 42,\n        \"last_incremental_sync_scheduled_at\": \"2023-11-09T15:13:08.231Z\",\n        \"last_indexed_document_count\": 42,\n        \"last_sync_error\": \"Houston, we have a problem!\",\n        \"last_sync_scheduled_at\": \"2024-11-09T15:13:08.231Z\",\n        \"last_sync_status\": \"completed\",\n        \"last_synced\": \"2024-11-09T15:13:08.231Z\"\n    },\n)"
+      "code": "resp = client.connector.last_sync(\n    connector_id=\"my-connector\",\n    last_access_control_sync_error=\"Houston, we have a problem!\",\n    last_access_control_sync_scheduled_at=\"2023-11-09T15:13:08.231Z\",\n    last_access_control_sync_status=\"pending\",\n    last_deleted_document_count=42,\n    last_incremental_sync_scheduled_at=\"2023-11-09T15:13:08.231Z\",\n    last_indexed_document_count=42,\n    last_sync_error=\"Houston, we have a problem!\",\n    last_sync_scheduled_at=\"2024-11-09T15:13:08.231Z\",\n    last_sync_status=\"completed\",\n    last_synced=\"2024-11-09T15:13:08.231Z\",\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.transport.request({\n  method: \"PUT\",\n  path: \"/_connector/my-connector/_last_sync\",\n  body: {\n    last_access_control_sync_error: \"Houston, we have a problem!\",\n    last_access_control_sync_scheduled_at: \"2023-11-09T15:13:08.231Z\",\n    last_access_control_sync_status: \"pending\",\n    last_deleted_document_count: 42,\n    last_incremental_sync_scheduled_at: \"2023-11-09T15:13:08.231Z\",\n    last_indexed_document_count: 42,\n    last_sync_error: \"Houston, we have a problem!\",\n    last_sync_scheduled_at: \"2024-11-09T15:13:08.231Z\",\n    last_sync_status: \"completed\",\n    last_synced: \"2024-11-09T15:13:08.231Z\",\n  },\n});"
+      "code": "const response = await client.connector.lastSync({\n  connector_id: \"my-connector\",\n  last_access_control_sync_error: \"Houston, we have a problem!\",\n  last_access_control_sync_scheduled_at: \"2023-11-09T15:13:08.231Z\",\n  last_access_control_sync_status: \"pending\",\n  last_deleted_document_count: 42,\n  last_incremental_sync_scheduled_at: \"2023-11-09T15:13:08.231Z\",\n  last_indexed_document_count: 42,\n  last_sync_error: \"Houston, we have a problem!\",\n  last_sync_scheduled_at: \"2024-11-09T15:13:08.231Z\",\n  last_sync_status: \"completed\",\n  last_synced: \"2024-11-09T15:13:08.231Z\",\n});"
     },
     {
       "language": "Ruby",
@@ -13343,6 +15015,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"mistral\",\"service_settings\":{\"api_key\":\"Mistral-API-Key\",\"model\":\"mistral-embed\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/mistral-embeddings-test\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"mistral-embeddings-test\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"mistral\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Mistral-API-Key\",\n              \"model\": \"mistral-embed\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"mistral-embeddings-test\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"mistral\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Mistral-API-Key\\\",\\\"model\\\":\\\"mistral-embed\\\"}\"))\n    )\n);\n"
     }
@@ -13367,6 +15043,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"model\":\"gpt-4o\",\"messages\":[{\"role\":\"user\",\"content\":\"What is Elastic?\"}]}' \"$ELASTICSEARCH_URL/_inference/chat_completion/openai-completion/_stream\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .ChatCompletionUnifiedAsync(inferenceId: \"openai-completion\", d1 => d1\n        .ChatCompletionRequest(d2 => d2\n            .Messages(d3 => d3\n                .Content(\"What is Elastic?\")\n                .Role(\"user\")\n            )\n            .Model(\"gpt-4o\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -13395,6 +15075,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What'\"'\"'s the price of a scarf?\"}]}],\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_current_price\",\"description\":\"Get the current price of a item\",\"parameters\":{\"type\":\"object\",\"properties\":{\"item\":{\"id\":\"123\"}}}}}],\"tool_choice\":{\"type\":\"function\",\"function\":{\"name\":\"get_current_price\"}}}' \"$ELASTICSEARCH_URL/_inference/chat_completion/openai-completion/_stream\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .ChatCompletionUnifiedAsync(inferenceId: \"openai-completion\", d1 => d1\n        .ChatCompletionRequest(d2 => d2\n            .Messages(d3 => d3\n                .Content(new ContentObject[] { new()\n                {\n                    Text = \"What's the price of a scarf?\",\n                    Type = \"text\"\n                } })\n                .Role(\"user\")\n            )\n            .ToolChoice(new CompletionToolChoice()\n            {\n                Function = new()\n                {\n                    Name = \"get_current_price\"\n                },\n                Type = \"function\"\n            })\n            .Tools(d3 => d3\n                .Function(d4 => d4\n                    .Description(\"Get the current price of a item\")\n                    .Name(\"get_current_price\")\n                    .Parameters(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                    {\n                      \"type\": \"object\",\n                      \"properties\": {\n                        \"item\": {\n                          \"id\": \"123\"\n                        }\n                      }\n                    }\n                    \"\"\"))\n                )\n                .Type(\"function\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.inference().chatCompletionUnified(c -> c\n  .inferenceId(\"openai-completion\")\n  .chatCompletionRequest(ch -> ch\n      .messages(m -> m\n          .content(co -> co\n              .string(\"What's the price of a scarf?\")\n          )\n          .role(\"user\")\n      )\n      .toolChoice(t -> t\n          .object(o -> o\n              .type(\"function\")\n              .function(f -> f\n                  .name(\"get_current_price\")\n              )\n          )\n      )\n      .tools(to -> to\n          .type(\"function\")\n          .function(f -> f\n              .description(\"Get the current price of a item\")\n              .name(\"get_current_price\")\n              .parameters(JsonData.fromJson(\"{\\\"type\\\":\\\"object\\\",\\\"properties\\\":{\\\"item\\\":{\\\"id\\\":\\\"123\\\"}}}\"))\n          )\n      )\n  )\n);\n"
     }
@@ -13421,6 +15105,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"messages\":[{\"role\":\"assistant\",\"content\":\"Let'\"'\"'s find out what the weather is\",\"tool_calls\":[{\"id\":\"call_KcAjWtAww20AihPHphUh46Gd\",\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"arguments\":\"{\\\"location\\\":\\\"Boston, MA\\\"}\"}}]},{\"role\":\"tool\",\"content\":\"The weather is cold\",\"tool_call_id\":\"call_KcAjWtAww20AihPHphUh46Gd\"}]}' \"$ELASTICSEARCH_URL/_inference/chat_completion/openai-completion/_stream\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .ChatCompletionUnifiedAsync(inferenceId: \"openai-completion\", d1 => d1\n        .ChatCompletionRequest(d2 => d2\n            .Messages(d3 => d3\n                .Content(\"Let's find out what the weather is\")\n                .Role(\"assistant\")\n                .ToolCalls(d4 => d4\n                    .Function(d5 => d5\n                        .Arguments(\"{\\\"location\\\":\\\"Boston, MA\\\"}\")\n                        .Name(\"get_current_weather\")\n                    )\n                    .Id(\"call_KcAjWtAww20AihPHphUh46Gd\")\n                    .Type(\"function\")\n                ), d3 => d3\n                .Content(\"The weather is cold\")\n                .Role(\"tool\")\n                .ToolCallId(\"call_KcAjWtAww20AihPHphUh46Gd\")\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.inference().chatCompletionUnified(c -> c\n  .inferenceId(\"openai-completion\")\n  .chatCompletionRequest(ch -> ch\n      .messages(List.of(Message.of(m -> m\n              .content(co -> co\n                  .string(\"Let's find out what the weather is\")\n              )\n              .role(\"assistant\")\n              .toolCalls(t -> t\n                  .id(\"call_KcAjWtAww20AihPHphUh46Gd\")\n                  .function(f -> f\n                      .arguments(\"{\\\"location\\\":\\\"Boston, MA\\\"}\")\n                      .name(\"get_current_weather\")\n                  )\n                  .type(\"function\")\n              )),Message.of(me -> me\n              .content(co -> co\n                  .string(\"The weather is cold\")\n              )\n              .role(\"tool\")\n              .toolCallId(\"call_KcAjWtAww20AihPHphUh46Gd\"))))\n  )\n);\n"
     }
@@ -13428,23 +15116,27 @@
   "specification/inference/text_embedding/examples/request/TextEmbeddingRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.inference.text_embedding(\n    inference_id=\"my-cohere-endpoint\",\n    input=\"The sky above the port was the color of television tuned to a dead channel.\",\n    task_settings={\n        \"input_type\": \"ingest\"\n    },\n)"
+      "code": "resp = client.inference.text_embedding(\n    inference_id=\"my-cohere-endpoint\",\n    input=\"The sky above the port was the color of television tuned to a dead channel.\",\n    input_type=\"ingest\",\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.inference.textEmbedding({\n  inference_id: \"my-cohere-endpoint\",\n  input:\n    \"The sky above the port was the color of television tuned to a dead channel.\",\n  task_settings: {\n    input_type: \"ingest\",\n  },\n});"
+      "code": "const response = await client.inference.textEmbedding({\n  inference_id: \"my-cohere-endpoint\",\n  input:\n    \"The sky above the port was the color of television tuned to a dead channel.\",\n  input_type: \"ingest\",\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.inference.text_embedding(\n  inference_id: \"my-cohere-endpoint\",\n  body: {\n    \"input\": \"The sky above the port was the color of television tuned to a dead channel.\",\n    \"task_settings\": {\n      \"input_type\": \"ingest\"\n    }\n  }\n)"
+      "code": "response = client.inference.text_embedding(\n  inference_id: \"my-cohere-endpoint\",\n  body: {\n    \"input\": \"The sky above the port was the color of television tuned to a dead channel.\",\n    \"input_type\": \"ingest\"\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->inference()->textEmbedding([\n    \"inference_id\" => \"my-cohere-endpoint\",\n    \"body\" => [\n        \"input\" => \"The sky above the port was the color of television tuned to a dead channel.\",\n        \"task_settings\" => [\n            \"input_type\" => \"ingest\",\n        ],\n    ],\n]);"
+      "code": "$resp = $client->inference()->textEmbedding([\n    \"inference_id\" => \"my-cohere-endpoint\",\n    \"body\" => [\n        \"input\" => \"The sky above the port was the color of television tuned to a dead channel.\",\n        \"input_type\" => \"ingest\",\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"The sky above the port was the color of television tuned to a dead channel.\",\"task_settings\":{\"input_type\":\"ingest\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/my-cohere-endpoint\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"The sky above the port was the color of television tuned to a dead channel.\",\"input_type\":\"ingest\"}' \"$ELASTICSEARCH_URL/_inference/text_embedding/my-cohere-endpoint\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .TextEmbeddingAsync(inferenceId: \"my-cohere-endpoint\", d1 => d1\n        .Input(\"The sky above the port was the color of television tuned to a dead channel.\")\n        .InputType(\"ingest\")\n    );"
     },
     {
       "language": "Java",
@@ -13473,6 +15165,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"jinaai\",\"service_settings\":{\"model_id\":\"jina-embeddings-v3\",\"api_key\":\"JinaAi-Api-key\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/jinaai-embeddings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"jinaai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"jinaai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"jina-embeddings-v3\",\n              \"api_key\": \"JinaAi-Api-key\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"jinaai-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"jinaai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"model_id\\\":\\\"jina-embeddings-v3\\\",\\\"api_key\\\":\\\"JinaAi-Api-key\\\"}\"))\n    )\n);\n"
     }
@@ -13499,6 +15195,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"jinaai\",\"service_settings\":{\"api_key\":\"JinaAI-Api-key\",\"model_id\":\"jina-reranker-v2-base-multilingual\"},\"task_settings\":{\"top_n\":10,\"return_documents\":true}}' \"$ELASTICSEARCH_URL/_inference/rerank/jinaai-rerank\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"jinaai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"jinaai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"JinaAI-Api-key\",\n              \"model_id\": \"jina-reranker-v2-base-multilingual\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"top_n\": 10,\n              \"return_documents\": true\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"jinaai-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"jinaai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"JinaAI-Api-key\\\",\\\"model_id\\\":\\\"jina-reranker-v2-base-multilingual\\\"}\"))\n        .taskSettings(JsonData.fromJson(\"{\\\"top_n\\\":10,\\\"return_documents\\\":true}\"))\n    )\n);\n"
     }
@@ -13523,6 +15223,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service_settings\":{\"api_key\":\"<API_KEY>\"}}' \"$ELASTICSEARCH_URL/_inference/my-inference-endpoint/_update\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .UpdateAsync(new UpdateInferenceRequest()\n    {\n        InferenceId = \"my-inference-endpoint\",\n        InferenceConfig = new()\n        {\n            Service = null,\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"\\u003CAPI_KEY\\u003E\"\n            }\n            \"\"\")\n        }\n    });"
     }
   ],
   "specification/inference/put_elser/examples/request/PutElserRequestExample1.yaml": [
@@ -13545,6 +15249,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elser\",\"service_settings\":{\"num_allocations\":1,\"num_threads\":1}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elser\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"num_allocations\": 1,\n              \"num_threads\": 1\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -13573,6 +15281,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elser\",\"service_settings\":{\"adaptive_allocations\":{\"enabled\":true,\"min_number_of_allocations\":3,\"max_number_of_allocations\":10},\"num_threads\":1}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elser\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 3,\n                \"max_number_of_allocations\": 10\n              },\n              \"num_threads\": 1\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"my-elser-model\")\n    .taskType(TaskType.SparseEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"elser\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"adaptive_allocations\\\":{\\\"enabled\\\":true,\\\"min_number_of_allocations\\\":3,\\\"max_number_of_allocations\\\":10},\\\"num_threads\\\":1}\"))\n    )\n);\n"
     }
@@ -13597,6 +15309,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .DeleteAsync(new DeleteInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding\n    });"
     },
     {
       "language": "Java",
@@ -13625,6 +15341,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"cohere\",\"service_settings\":{\"api_key\":\"Cohere-Api-key\",\"model_id\":\"embed-english-light-v3.0\",\"embedding_type\":\"byte\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/cohere-embeddings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"cohere-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Cohere-Api-key\",\n              \"model_id\": \"embed-english-light-v3.0\",\n              \"embedding_type\": \"byte\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"cohere-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"cohere\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Cohere-Api-key\\\",\\\"model_id\\\":\\\"embed-english-light-v3.0\\\",\\\"embedding_type\\\":\\\"byte\\\"}\"))\n    )\n);\n"
     }
@@ -13649,6 +15369,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"cohere\",\"service_settings\":{\"api_key\":\"Cohere-API-key\",\"model_id\":\"rerank-english-v3.0\"},\"task_settings\":{\"top_n\":10,\"return_documents\":true}}' \"$ELASTICSEARCH_URL/_inference/rerank/cohere-rerank\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"cohere-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Cohere-API-key\",\n              \"model_id\": \"rerank-english-v3.0\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"top_n\": 10,\n              \"return_documents\": true\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -13677,6 +15401,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"googleaistudio\",\"service_settings\":{\"api_key\":\"api-key\",\"model_id\":\"model-id\"}}' \"$ELASTICSEARCH_URL/_inference/completion/google_ai_studio_completion\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_ai_studio_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googleaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"api-key\",\n              \"model_id\": \"model-id\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"google_ai_studio_completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"googleaistudio\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"api-key\\\",\\\"model_id\\\":\\\"model-id\\\"}\"))\n    )\n);\n"
     }
@@ -13701,6 +15429,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"cohere\",\"service_settings\":{\"model_id\":\"rerank-english-v3.0\",\"api_key\":\"{{COHERE_API_KEY}}\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/my-rerank-model\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-rerank-model\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"rerank-english-v3.0\",\n              \"api_key\": \"{{COHERE_API_KEY}}\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -13729,6 +15461,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"voyageai\",\"service_settings\":{\"model_id\":\"rerank-2\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/voyageai-rerank\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"voyageai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"voyageai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"rerank-2\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"voyageai-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"voyageai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"model_id\\\":\\\"rerank-2\\\"}\"))\n    )\n);\n"
     }
@@ -13753,6 +15489,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"voyageai\",\"service_settings\":{\"model_id\":\"voyage-3-large\",\"dimensions\":512}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/openai-embeddings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"voyageai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"voyage-3-large\",\n              \"dimensions\": 512\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -13781,6 +15521,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"watsonxai\",\"service_settings\":{\"api_key\":\"Watsonx-API-Key\",\"url\":\"Wastonx-URL\",\"model_id\":\"ibm/slate-30m-english-rtrvr\",\"project_id\":\"IBM-Cloud-ID\",\"api_version\":\"2024-03-14\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/watsonx-embeddings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"watsonx-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"watsonxai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Watsonx-API-Key\",\n              \"url\": \"Wastonx-URL\",\n              \"model_id\": \"ibm/slate-30m-english-rtrvr\",\n              \"project_id\": \"IBM-Cloud-ID\",\n              \"api_version\": \"2024-03-14\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"watsonx-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"watsonxai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Watsonx-API-Key\\\",\\\"url\\\":\\\"Wastonx-URL\\\",\\\"model_id\\\":\\\"ibm/slate-30m-english-rtrvr\\\",\\\"project_id\\\":\\\"IBM-Cloud-ID\\\",\\\"api_version\\\":\\\"2024-03-14\\\"}\"))\n    )\n);\n"
     }
@@ -13805,6 +15549,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"What is Elastic?\"}' \"$ELASTICSEARCH_URL/_inference/completion/openai_chat_completions\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .CompletionAsync(inferenceId: \"openai_chat_completions\", d1 => d1\n        .Input(\"What is Elastic?\")\n    );"
     },
     {
       "language": "Java",
@@ -13833,6 +15581,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .GetAsync(d1 => d1\n        .InferenceId(\"my-elser-model\")\n        .TaskType(TaskType.SparseEmbedding)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.inference().get(g -> g\n    .inferenceId(\"my-elser-model\")\n    .taskType(TaskType.SparseEmbedding)\n);\n"
     }
@@ -13857,6 +15609,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"anthropic\",\"service_settings\":{\"api_key\":\"Anthropic-Api-Key\",\"model_id\":\"Model-ID\"},\"task_settings\":{\"max_tokens\":1024}}' \"$ELASTICSEARCH_URL/_inference/completion/anthropic_completion\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"anthropic_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"anthropic\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Anthropic-Api-Key\",\n              \"model_id\": \"Model-ID\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"max_tokens\": 1024\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -13885,6 +15641,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"The sky above the port was the color of television tuned to a dead channel.\"}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .SparseEmbeddingAsync(inferenceId: \"my-elser-model\", d1 => d1\n        .Input(\"The sky above the port was the color of television tuned to a dead channel.\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.inference().sparseEmbedding(s -> s\n    .inferenceId(\"my-elser-model\")\n    .input(\"The sky above the port was the color of television tuned to a dead channel.\")\n);\n"
     }
@@ -13909,6 +15669,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"googlevertexai\",\"service_settings\":{\"service_account_json\":\"service-account-json\",\"project_id\":\"project-id\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/google_vertex_ai_rerank\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_vertex_ai_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"service_account_json\": \"service-account-json\",\n              \"project_id\": \"project-id\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -13937,6 +15701,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"googlevertexai\",\"service_settings\":{\"service_account_json\":\"service-account-json\",\"model_id\":\"model-id\",\"location\":\"location\",\"project_id\":\"project-id\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/google_vertex_ai_embeddingss\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_vertex_ai_embeddingss\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"service_account_json\": \"service-account-json\",\n              \"model_id\": \"model-id\",\n              \"location\": \"location\",\n              \"project_id\": \"project-id\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"google_vertex_ai_embeddingss\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"googlevertexai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"service_account_json\\\":\\\"service-account-json\\\",\\\"model_id\\\":\\\"model-id\\\",\\\"location\\\":\\\"location\\\",\\\"project_id\\\":\\\"project-id\\\"}\"))\n    )\n);\n"
     }
@@ -13961,6 +15729,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"hugging_face\",\"service_settings\":{\"api_key\":\"hugging-face-access-token\",\"url\":\"url-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/hugging-face-embeddings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"hugging-face-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"hugging_face\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"hugging-face-access-token\",\n              \"url\": \"url-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -13989,6 +15761,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"hugging_face\",\"service_settings\":{\"api_key\":\"hugging-face-access-token\",\"url\":\"url-endpoint\"},\"task_settings\":{\"return_documents\":true,\"top_n\":3}}' \"$ELASTICSEARCH_URL/_inference/rerank/hugging-face-rerank\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"hugging-face-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"hugging_face\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"hugging-face-access-token\",\n              \"url\": \"url-endpoint\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"return_documents\": true,\n              \"top_n\": 3\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"hugging-face-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"hugging_face\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"hugging-face-access-token\\\",\\\"url\\\":\\\"url-endpoint\\\"}\"))\n        .taskSettings(JsonData.fromJson(\"{\\\"return_documents\\\":true,\\\"top_n\\\":3}\"))\n    )\n);\n"
     }
@@ -14015,11 +15791,45 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazonbedrock\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"provider\":\"amazontitan\",\"model\":\"amazon.titan-embed-text-v2:0\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/amazon_bedrock_embeddings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_bedrock_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"amazonbedrock\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"provider\": \"amazontitan\",\n              \"model\": \"amazon.titan-embed-text-v2:0\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"amazon_bedrock_embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"amazonbedrock\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"access_key\\\":\\\"AWS-access-key\\\",\\\"secret_key\\\":\\\"AWS-secret-key\\\",\\\"region\\\":\\\"us-east-1\\\",\\\"provider\\\":\\\"amazontitan\\\",\\\"model\\\":\\\"amazon.titan-embed-text-v2:0\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_amazonbedrock/examples/request/PutAmazonBedrockRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"amazon_bedrock_completion\",\n    inference_config={\n        \"service\": \"amazonbedrock\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"provider\": \"amazontitan\",\n            \"model\": \"amazon.titan-text-premier-v1:0\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"amazon_bedrock_completion\",\n  inference_config: {\n    service: \"amazonbedrock\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      provider: \"amazontitan\",\n      model: \"amazon.titan-text-premier-v1:0\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"amazon_bedrock_completion\",\n  body: {\n    \"service\": \"amazonbedrock\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"provider\": \"amazontitan\",\n      \"model\": \"amazon.titan-text-premier-v1:0\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"amazon_bedrock_completion\",\n    \"body\" => [\n        \"service\" => \"amazonbedrock\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"provider\" => \"amazontitan\",\n            \"model\" => \"amazon.titan-text-premier-v1:0\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazonbedrock\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"provider\":\"amazontitan\",\"model\":\"amazon.titan-text-premier-v1:0\"}}' \"$ELASTICSEARCH_URL/_inference/completion/amazon_bedrock_completion\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_bedrock_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"amazonbedrock\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"provider\": \"amazontitan\",\n              \"model\": \"amazon.titan-text-premier-v1:0\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"openai-completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"openai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"OpenAI-API-Key\\\",\\\"model_id\\\":\\\"gpt-3.5-turbo\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_openai/examples/request/PutOpenAiRequestExample2.yaml": [
     {
       "language": "Python",
       "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"openai-completion\",\n    inference_config={\n        \"service\": \"openai\",\n        \"service_settings\": {\n            \"api_key\": \"OpenAI-API-Key\",\n            \"model_id\": \"gpt-3.5-turbo\"\n        }\n    },\n)"
@@ -14041,30 +15851,8 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"openai\",\"service_settings\":{\"api_key\":\"OpenAI-API-Key\",\"model_id\":\"gpt-3.5-turbo\"}}' \"$ELASTICSEARCH_URL/_inference/completion/openai-completion\""
     },
     {
-      "language": "Java",
-      "code": "client.inference().put(p -> p\n    .inferenceId(\"openai-completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"openai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"OpenAI-API-Key\\\",\\\"model_id\\\":\\\"gpt-3.5-turbo\\\"}\"))\n    )\n);\n"
-    }
-  ],
-  "specification/inference/put_openai/examples/request/PutOpenAiRequestExample2.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"amazon_bedrock_completion\",\n    inference_config={\n        \"service\": \"amazonbedrock\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"provider\": \"amazontitan\",\n            \"model\": \"amazon.titan-text-premier-v1:0\"\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"amazon_bedrock_completion\",\n  inference_config: {\n    service: \"amazonbedrock\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      provider: \"amazontitan\",\n      model: \"amazon.titan-text-premier-v1:0\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"amazon_bedrock_completion\",\n  body: {\n    \"service\": \"amazonbedrock\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"provider\": \"amazontitan\",\n      \"model\": \"amazon.titan-text-premier-v1:0\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"amazon_bedrock_completion\",\n    \"body\" => [\n        \"service\" => \"amazonbedrock\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"provider\" => \"amazontitan\",\n            \"model\" => \"amazon.titan-text-premier-v1:0\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazonbedrock\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"provider\":\"amazontitan\",\"model\":\"amazon.titan-text-premier-v1:0\"}}' \"$ELASTICSEARCH_URL/_inference/completion/amazon_bedrock_completion\""
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"openai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"OpenAI-API-Key\",\n              \"model_id\": \"gpt-3.5-turbo\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -14093,6 +15881,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"openai\",\"service_settings\":{\"api_key\":\"OpenAI-API-Key\",\"model_id\":\"text-embedding-3-small\",\"dimensions\":128}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/openai-embeddings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"openai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"OpenAI-API-Key\",\n              \"model_id\": \"text-embedding-3-small\",\n              \"dimensions\": 128\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"openai-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"openai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"OpenAI-API-Key\\\",\\\"model_id\\\":\\\"text-embedding-3-small\\\",\\\"dimensions\\\":128}\"))\n    )\n);\n"
     }
@@ -14117,6 +15909,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":[\"luke\",\"like\",\"leia\",\"chewy\",\"r2d2\",\"star\",\"wars\"],\"query\":\"star wars main character\"}' \"$ELASTICSEARCH_URL/_inference/rerank/cohere_rerank\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .RerankAsync(inferenceId: \"cohere_rerank\", d1 => d1\n        .Input(\"luke\", \"like\", \"leia\", \"chewy\", \"r2d2\", \"star\", \"wars\")\n        .Query(\"star wars main character\")\n    );"
     },
     {
       "language": "Java",
@@ -14145,6 +15941,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":[\"luke\",\"like\",\"leia\",\"chewy\",\"r2d2\",\"star\",\"wars\"],\"query\":\"star wars main character\",\"return_documents\":false,\"top_n\":2}' \"$ELASTICSEARCH_URL/_inference/rerank/bge-reranker-base-mkn\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"bge-reranker-base-mkn\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = null,\n            ServiceSettings = null\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().rerank(r -> r\n    .inferenceId(\"bge-reranker-base-mkn\")\n    .input(List.of(\"luke\",\"like\",\"leia\",\"chewy\",\"r2d2\",\"star\",\"wars\"))\n    .query(\"star wars main character\")\n);\n"
     }
@@ -14169,6 +15969,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":[\"luke\",\"like\",\"leia\",\"chewy\",\"r2d2\",\"star\",\"wars\"],\"query\":\"star wars main character\",\"return_documents\":true,\"top_n\":3}' \"$ELASTICSEARCH_URL/_inference/rerank/bge-reranker-base-mkn\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .RerankAsync(inferenceId: \"bge-reranker-base-mkn\", d1 => d1\n        .Input(\"luke\", \"like\", \"leia\", \"chewy\", \"r2d2\", \"star\", \"wars\")\n        .Query(\"star wars main character\")\n    );"
     },
     {
       "language": "Java",
@@ -14197,6 +16001,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"alibabacloud-ai-search\",\"service_settings\":{\"api_key\":\"AlibabaCloud-API-Key\",\"service_id\":\"ops-text-embedding-001\",\"host\":\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\"workspace\":\"default\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/alibabacloud_ai_search_embeddings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-text-embedding-001\",\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"alibabacloud_ai_search_embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"alibabacloud-ai-search\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"AlibabaCloud-API-Key\\\",\\\"service_id\\\":\\\"ops-text-embedding-001\\\",\\\"host\\\":\\\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\\\",\\\"workspace\\\":\\\"default\\\"}\"))\n    )\n);\n"
     }
@@ -14221,6 +16029,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"alibabacloud-ai-search\",\"service_settings\":{\"api_key\":\"AlibabaCloud-API-Key\",\"service_id\":\"ops-text-sparse-embedding-001\",\"host\":\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\"workspace\":\"default\"}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/alibabacloud_ai_search_sparse\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_sparse\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-text-sparse-embedding-001\",\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -14249,6 +16061,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"alibabacloud-ai-search\",\"service_settings\":{\"api_key\":\"AlibabaCloud-API-Key\",\"service_id\":\"ops-bge-reranker-larger\",\"host\":\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\"workspace\":\"default\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/alibabacloud_ai_search_rerank\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-bge-reranker-larger\",\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"alibabacloud_ai_search_rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"alibabacloud-ai-search\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"AlibabaCloud-API-Key\\\",\\\"service_id\\\":\\\"ops-bge-reranker-larger\\\",\\\"host\\\":\\\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\\\",\\\"workspace\\\":\\\"default\\\"}\"))\n    )\n);\n"
     }
@@ -14273,6 +16089,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"alibabacloud-ai-search\",\"service_settings\":{\"host\":\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\"api_key\":\"AlibabaCloud-API-Key\",\"service_id\":\"ops-qwen-turbo\",\"workspace\":\"default\"}}' \"$ELASTICSEARCH_URL/_inference/completion/alibabacloud_ai_search_completion\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-qwen-turbo\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -14301,6 +16121,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"azureopenai\",\"service_settings\":{\"api_key\":\"Api-Key\",\"resource_name\":\"Resource-name\",\"deployment_id\":\"Deployment-id\",\"api_version\":\"2024-02-01\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/azure_openai_embeddings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_openai_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"azureopenai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Api-Key\",\n              \"resource_name\": \"Resource-name\",\n              \"deployment_id\": \"Deployment-id\",\n              \"api_version\": \"2024-02-01\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"azure_openai_embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"azureopenai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Api-Key\\\",\\\"resource_name\\\":\\\"Resource-name\\\",\\\"deployment_id\\\":\\\"Deployment-id\\\",\\\"api_version\\\":\\\"2024-02-01\\\"}\"))\n    )\n);\n"
     }
@@ -14325,6 +16149,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"azureopenai\",\"service_settings\":{\"api_key\":\"Api-Key\",\"resource_name\":\"Resource-name\",\"deployment_id\":\"Deployment-id\",\"api_version\":\"2024-02-01\"}}' \"$ELASTICSEARCH_URL/_inference/completion/azure_openai_completion\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_openai_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"azureopenai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Api-Key\",\n              \"resource_name\": \"Resource-name\",\n              \"deployment_id\": \"Deployment-id\",\n              \"api_version\": \"2024-02-01\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -14353,6 +16181,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"What is Elastic?\"}' \"$ELASTICSEARCH_URL/_inference/completion/openai-completion/_stream\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .StreamCompletionAsync(inferenceId: \"openai-completion\", d1 => d1\n        .Input(\"What is Elastic?\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.inference().streamCompletion(s -> s\n    .inferenceId(\"openai-completion\")\n    .input(\"What is Elastic?\")\n);\n"
     }
@@ -14377,6 +16209,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"adaptive_allocations\":{\"enabled\":true,\"min_number_of_allocations\":3,\"max_number_of_allocations\":10},\"num_threads\":1,\"model_id\":\".multilingual-e5-small\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/my-e5-model\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-e5-model\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 3,\n                \"max_number_of_allocations\": 10\n              },\n              \"num_threads\": 1,\n              \"model_id\": \".multilingual-e5-small\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -14405,6 +16241,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"num_allocations\":1,\"num_threads\":1,\"model_id\":\"msmarco-MiniLM-L12-cos-v5\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/my-msmarco-minilm-model\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-msmarco-minilm-model\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"num_allocations\": 1,\n              \"num_threads\": 1,\n              \"model_id\": \"msmarco-MiniLM-L12-cos-v5\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"my-msmarco-minilm-model\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"elasticsearch\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"num_allocations\\\":1,\\\"num_threads\\\":1,\\\"model_id\\\":\\\"msmarco-MiniLM-L12-cos-v5\\\"}\"))\n    )\n);\n"
     }
@@ -14429,6 +16269,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"num_allocations\":1,\"num_threads\":1,\"model_id\":\".multilingual-e5-small\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/my-e5-model\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-e5-model\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"num_allocations\": 1,\n              \"num_threads\": 1,\n              \"model_id\": \".multilingual-e5-small\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -14457,6 +16301,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"model_id\":\".rerank-v1\",\"num_threads\":1,\"adaptive_allocations\":{\"enabled\":true,\"min_number_of_allocations\":1,\"max_number_of_allocations\":4}}}' \"$ELASTICSEARCH_URL/_inference/rerank/my-elastic-rerank\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elastic-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \".rerank-v1\",\n              \"num_threads\": 1,\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 1,\n                \"max_number_of_allocations\": 4\n              }\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"my-elastic-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"elasticsearch\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"model_id\\\":\\\".rerank-v1\\\",\\\"num_threads\\\":1,\\\"adaptive_allocations\\\":{\\\"enabled\\\":true,\\\"min_number_of_allocations\\\":1,\\\"max_number_of_allocations\\\":4}}\"))\n    )\n);\n"
     }
@@ -14481,6 +16329,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"adaptive_allocations\":{\"enabled\":true,\"min_number_of_allocations\":1,\"max_number_of_allocations\":4},\"num_threads\":1,\"model_id\":\".elser_model_2\"}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 1,\n                \"max_number_of_allocations\": 4\n              },\n              \"num_threads\": 1,\n              \"model_id\": \".elser_model_2\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -14509,6 +16361,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"deployment_id\":\".elser_model_2\"}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/use_existing_deployment\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"use_existing_deployment\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"deployment_id\": \".elser_model_2\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"use_existing_deployment\")\n    .taskType(TaskType.SparseEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"elasticsearch\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"deployment_id\\\":\\\".elser_model_2\\\"}\"))\n    )\n);\n"
     }
@@ -14533,6 +16389,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"azureaistudio\",\"service_settings\":{\"api_key\":\"Azure-AI-Studio-API-key\",\"target\":\"Target-URI\",\"provider\":\"databricks\",\"endpoint_type\":\"realtime\"}}' \"$ELASTICSEARCH_URL/_inference/completion/azure_ai_studio_completion\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_ai_studio_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"azureaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Azure-AI-Studio-API-key\",\n              \"target\": \"Target-URI\",\n              \"provider\": \"databricks\",\n              \"endpoint_type\": \"realtime\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -14561,6 +16421,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"azureaistudio\",\"service_settings\":{\"api_key\":\"Azure-AI-Studio-API-key\",\"target\":\"Target-Uri\",\"provider\":\"openai\",\"endpoint_type\":\"token\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/azure_ai_studio_embeddings\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_ai_studio_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"azureaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Azure-AI-Studio-API-key\",\n              \"target\": \"Target-Uri\",\n              \"provider\": \"openai\",\n              \"endpoint_type\": \"token\"\n            }\n            \"\"\")\n        }\n    });"
+    },
+    {
       "language": "Java",
       "code": "client.inference().put(p -> p\n    .inferenceId(\"azure_ai_studio_embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"azureaistudio\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Azure-AI-Studio-API-key\\\",\\\"target\\\":\\\"Target-Uri\\\",\\\"provider\\\":\\\"openai\\\",\\\"endpoint_type\\\":\\\"token\\\"}\"))\n    )\n);\n"
     }
@@ -14568,7 +16432,7 @@
   "specification/query_rules/list_rulesets/examples/request/QueryRulesetListRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.query_rules.list_rulesets(\n    from=\"0\",\n    size=\"3\",\n)"
+      "code": "resp = client.query_rules.list_rulesets(\n    from_=\"0\",\n    size=\"3\",\n)"
     },
     {
       "language": "JavaScript",
@@ -14585,6 +16449,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query_rules/?from=0&size=3\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.QueryRules\n    .ListRulesetsAsync(d1 => d1\n        .From(0)\n        .Size(3)\n    );"
     },
     {
       "language": "Java",
@@ -14613,6 +16481,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"rules\":[{\"rule_id\":\"my-rule1\",\"type\":\"pinned\",\"criteria\":[{\"type\":\"contains\",\"metadata\":\"user_query\",\"values\":[\"pugs\",\"puggles\"]},{\"type\":\"exact\",\"metadata\":\"user_country\",\"values\":[\"us\"]}],\"actions\":{\"ids\":[\"id1\",\"id2\"]}},{\"rule_id\":\"my-rule2\",\"type\":\"pinned\",\"criteria\":[{\"type\":\"fuzzy\",\"metadata\":\"user_query\",\"values\":[\"rescue dogs\"]}],\"actions\":{\"docs\":[{\"_index\":\"index1\",\"_id\":\"id3\"},{\"_index\":\"index2\",\"_id\":\"id4\"}]}}]}' \"$ELASTICSEARCH_URL/_query_rules/my-ruleset\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.QueryRules\n    .PutRulesetAsync(rulesetId: \"my-ruleset\", d1 => d1\n        .Rules(d2 => d2\n            .Actions(d3 => d3\n                .Ids([\"id1\", \"id2\"])\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Contains)\n                .Values([\"pugs\", \"puggles\"]), d3 => d3\n                .Metadata(\"user_country\")\n                .Type(QueryRuleCriteriaType.Exact)\n                .Values([\"us\"])\n            )\n            .RuleId(\"my-rule1\")\n            .Type(QueryRuleType.Pinned), d2 => d2\n            .Actions(d3 => d3\n                .Docs(d4 => d4\n                    .Id(\"id3\")\n                    .Index(\"index1\"), d4 => d4\n                    .Id(\"id4\")\n                    .Index(\"index2\")\n                )\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Fuzzy)\n                .Values([\"rescue dogs\"])\n            )\n            .RuleId(\"my-rule2\")\n            .Type(QueryRuleType.Pinned)\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.queryRules().putRuleset(p -> p\n    .rules(List.of(QueryRule.queryRuleOf(q -> q\n            .ruleId(\"my-rule1\")\n            .type(QueryRuleType.Pinned)\n            .criteria(List.of(QueryRuleCriteria.of(qu -> qu\n                    .type(QueryRuleCriteriaType.Contains)\n                    .metadata(\"user_query\")\n                    .values(List.of(JsonData.fromJson(\"\\\"pugs\\\"\"),JsonData.fromJson(\"\\\"puggles\\\"\")))),QueryRuleCriteria.of(qu -> qu\n                    .type(QueryRuleCriteriaType.Exact)\n                    .metadata(\"user_country\")\n                    .values(JsonData.fromJson(\"\\\"us\\\"\")))))\n            .actions(a -> a\n                .ids(List.of(\"id1\",\"id2\"))\n            )),QueryRule.queryRuleOf(q -> q\n            .ruleId(\"my-rule2\")\n            .type(QueryRuleType.Pinned)\n            .criteria(c -> c\n                .type(QueryRuleCriteriaType.Fuzzy)\n                .metadata(\"user_query\")\n                .values(JsonData.fromJson(\"\\\"rescue dogs\\\"\"))\n            )\n            .actions(a -> a\n                .docs(List.of(PinnedDoc.of(pi -> pi\n                        .id(\"id3\")\n                        .index(\"index1\")),PinnedDoc.of(pi -> pi\n                        .id(\"id4\")\n                        .index(\"index2\"))))\n            ))))\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
@@ -14637,6 +16509,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"match_criteria\":{\"query_string\":\"puggles\"}}' \"$ELASTICSEARCH_URL/_query_rules/my-ruleset/_test\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.QueryRules\n    .TestAsync(rulesetId: \"my-ruleset\", d1 => d1\n        .MatchCriteria(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"puggles\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -14665,6 +16541,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query_rules/my-ruleset/_rule/my-rule1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.QueryRules.DeleteRuleAsync(rulesetId: \"my-ruleset\", ruleId: \"my-rule1\");"
+    },
+    {
       "language": "Java",
       "code": "client.queryRules().deleteRule(d -> d\n    .ruleId(\"my-rule1\")\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
@@ -14689,6 +16569,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query_rules/my-ruleset/_rule/my-rule1\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.QueryRules.GetRuleAsync(rulesetId: \"my-ruleset\", ruleId: \"my-rule1\");"
     },
     {
       "language": "Java",
@@ -14717,6 +16601,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query_rules/my-ruleset/\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.QueryRules.GetRulesetAsync(rulesetId: \"my-ruleset\");"
+    },
+    {
       "language": "Java",
       "code": "client.queryRules().getRuleset(g -> g\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
@@ -14741,6 +16629,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query_rules/my-ruleset/\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.QueryRules.DeleteRulesetAsync(rulesetId: \"my-ruleset\");"
     },
     {
       "language": "Java",
@@ -14769,6 +16661,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"rules\":[{\"rule_id\":\"my-rule1\",\"type\":\"pinned\",\"criteria\":[{\"type\":\"contains\",\"metadata\":\"user_query\",\"values\":[\"pugs\",\"puggles\"]},{\"type\":\"exact\",\"metadata\":\"user_country\",\"values\":[\"us\"]}],\"actions\":{\"ids\":[\"id1\",\"id2\"]}},{\"rule_id\":\"my-rule2\",\"type\":\"pinned\",\"criteria\":[{\"type\":\"fuzzy\",\"metadata\":\"user_query\",\"values\":[\"rescue dogs\"]}],\"actions\":{\"docs\":[{\"_index\":\"index1\",\"_id\":\"id3\"},{\"_index\":\"index2\",\"_id\":\"id4\"}]}}]}' \"$ELASTICSEARCH_URL/_query_rules/my-ruleset\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.QueryRules\n    .PutRulesetAsync(rulesetId: \"my-ruleset\", d1 => d1\n        .Rules(d2 => d2\n            .Actions(d3 => d3\n                .Ids([\"id1\", \"id2\"])\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Contains)\n                .Values([\"pugs\", \"puggles\"]), d3 => d3\n                .Metadata(\"user_country\")\n                .Type(QueryRuleCriteriaType.Exact)\n                .Values([\"us\"])\n            )\n            .RuleId(\"my-rule1\")\n            .Type(QueryRuleType.Pinned), d2 => d2\n            .Actions(d3 => d3\n                .Docs(d4 => d4\n                    .Id(\"id3\")\n                    .Index(\"index1\"), d4 => d4\n                    .Id(\"id4\")\n                    .Index(\"index2\")\n                )\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Fuzzy)\n                .Values([\"rescue dogs\"])\n            )\n            .RuleId(\"my-rule2\")\n            .Type(QueryRuleType.Pinned)\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.queryRules().putRuleset(p -> p\n    .rules(List.of(QueryRule.queryRuleOf(q -> q\n            .ruleId(\"my-rule1\")\n            .type(QueryRuleType.Pinned)\n            .criteria(List.of(QueryRuleCriteria.of(qu -> qu\n                    .type(QueryRuleCriteriaType.Contains)\n                    .metadata(\"user_query\")\n                    .values(List.of(JsonData.fromJson(\"\\\"pugs\\\"\"),JsonData.fromJson(\"\\\"puggles\\\"\")))),QueryRuleCriteria.of(qu -> qu\n                    .type(QueryRuleCriteriaType.Exact)\n                    .metadata(\"user_country\")\n                    .values(JsonData.fromJson(\"\\\"us\\\"\")))))\n            .actions(a -> a\n                .ids(List.of(\"id1\",\"id2\"))\n            )),QueryRule.queryRuleOf(q -> q\n            .ruleId(\"my-rule2\")\n            .type(QueryRuleType.Pinned)\n            .criteria(c -> c\n                .type(QueryRuleCriteriaType.Fuzzy)\n                .metadata(\"user_query\")\n                .values(JsonData.fromJson(\"\\\"rescue dogs\\\"\"))\n            )\n            .actions(a -> a\n                .docs(List.of(PinnedDoc.of(pi -> pi\n                        .id(\"id3\")\n                        .index(\"index1\")),PinnedDoc.of(pi -> pi\n                        .id(\"id4\")\n                        .index(\"index2\"))))\n            ))))\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
@@ -14793,6 +16689,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_enrich/policy/my-policy\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Enrich.DeletePolicyAsync(name: \"my-policy\");"
     },
     {
       "language": "Java",
@@ -14821,6 +16721,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_enrich/policy/my-policy/_execute?wait_for_completion=false\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Enrich\n    .ExecutePolicyAsync(name: \"my-policy\", d1 => d1\n        .WaitForCompletion(false)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.enrich().executePolicy(e -> e\n    .name(\"my-policy\")\n    .waitForCompletion(false)\n);\n"
     }
@@ -14845,6 +16749,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_enrich/policy/my-policy\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Enrich\n    .GetPolicyAsync(d1 => d1\n        .Name(new[] { \"my-policy\" })\n    );"
     },
     {
       "language": "Java",
@@ -14873,6 +16781,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"geo_match\":{\"indices\":\"postal_codes\",\"match_field\":\"location\",\"enrich_fields\":[\"location\",\"postal_code\"]}}' \"$ELASTICSEARCH_URL/_enrich/policy/postal_policy\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Enrich\n    .PutPolicyAsync(name: \"postal_policy\", d1 => d1\n        .GeoMatch(d2 => d2\n            .EnrichFields(x => x.Location, x => x.PostalCode)\n            .Indices(new[] { \"postal_codes\" })\n            .MatchField(x => x.Location)\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.enrich().putPolicy(p -> p\n    .geoMatch(g -> g\n        .enrichFields(List.of(\"location\",\"postal_code\"))\n        .indices(\"postal_codes\")\n        .matchField(\"location\")\n    )\n    .name(\"postal_policy\")\n);\n"
     }
@@ -14897,6 +16809,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_enrich/_stats\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Enrich.StatsAsync();"
     },
     {
       "language": "Java",
@@ -14925,6 +16841,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"sort\":[{\"date\":{\"order\":\"asc\"}}],\"aggs\":{\"sale_date\":{\"date_histogram\":{\"field\":\"date\",\"calendar_interval\":\"1d\"}}}}' \"$ELASTICSEARCH_URL/sales*/_async_search?size=0\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.AsyncSearch\n    .SubmitAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"sales*\" })\n        .Aggregations(d2 => d2\n            .Add(\"sale_date\", d3 => d3\n                .DateHistogram(d4 => d4\n                    .CalendarInterval(CalendarInterval.Day)\n                    .Field(x => x.Date)\n                )\n            )\n        )\n        .Sort(d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Date)\n                .Order(SortOrder.Asc)\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.asyncSearch().submit(s -> s\n    .aggregations(\"sale_date\", a -> a\n        .dateHistogram(d -> d\n            .calendarInterval(CalendarInterval.Day)\n            .field(\"date\")\n        )\n    )\n    .index(\"sales*\")\n    .size(0)\n    .sort(so -> so\n        .field(f -> f\n            .field(\"date\")\n            .order(SortOrder.Asc)\n        )\n    )\n,Void.class);\n"
     }
@@ -14949,6 +16869,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.AsyncSearch.DeleteAsync(id: \"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\");"
     },
     {
       "language": "Java",
@@ -14977,6 +16901,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.AsyncSearch.GetAsync<MyDocument>(id: \"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\");"
+    },
+    {
       "language": "Java",
       "code": "client.asyncSearch().get(g -> g\n    .id(\"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\")\n);\n"
     }
@@ -15001,6 +16929,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_async_search/status/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.AsyncSearch.StatusAsync(id: \"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\");"
     },
     {
       "language": "Java",
@@ -15029,6 +16961,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_eql/search/status/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Eql.GetStatusAsync(id: \"FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\");"
+    },
+    {
       "language": "Java",
       "code": "client.eql().getStatus(g -> g\n    .id(\"FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\")\n);\n"
     }
@@ -15053,6 +16989,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_eql/search/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Eql.DeleteAsync(id: \"FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\");"
     },
     {
       "language": "Java",
@@ -15081,6 +17021,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_eql/search/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=?wait_for_completion_timeout=2s\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Eql\n    .GetAsync<MyDocument>(id: \"FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\", d1 => d1\n        .WaitForCompletionTimeout(\"2s\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.eql().get(g -> g\n    .id(\"FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\")\n    .waitForCompletionTimeout(w -> w\n        .offset(2)\n    )\n);\n"
     }
@@ -15105,6 +17049,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"\\n    process where (process.name == \\\"cmd.exe\\\" and process.pid != 2013)\\n  \"}' \"$ELASTICSEARCH_URL/my-data-stream/_eql/search\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Eql\n    .SearchAsync<MyDocument, MyDocument>(indices: new[] { \"my-data-stream\" }, d1 => d1\n        .Query(\"\\n    process where (process.name == \\\"cmd.exe\\\" and process.pid != 2013)\\n  \")\n    );"
     },
     {
       "language": "Java",
@@ -15133,6 +17081,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"\\n    sequence by process.pid\\n      [ file where file.name == \\\"cmd.exe\\\" and process.pid != 2013 ]\\n      [ process where stringContains(process.executable, \\\"regsvr32\\\") ]\\n  \"}' \"$ELASTICSEARCH_URL/my-data-stream/_eql/search\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Eql\n    .SearchAsync<MyDocument, MyDocument>(indices: new[] { \"my-data-stream\" }, d1 => d1\n        .Query(\"\\n    sequence by process.pid\\n      [ file where file.name == \\\"cmd.exe\\\" and process.pid != 2013 ]\\n      [ process where stringContains(process.executable, \\\"regsvr32\\\") ]\\n  \")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.eql().search(s -> s\n    .index(\"my-data-stream\")\n    .query(\" sequence by process.pid [ file where file.name == \\\"cmd.exe\\\" and process.pid != 2013 ][ process where stringContains(process.executable, \\\"regsvr32\\\") ] \")\n);\n"
     }
@@ -15157,6 +17109,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query/async/FkpMRkJGS1gzVDRlM3g4ZzMyRGlLbkEaTXlJZHdNT09TU2VTZVBoNDM3cFZMUToxMDM=/stop\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Esql.AsyncQueryStopAsync(id: \"FkpMRkJGS1gzVDRlM3g4ZzMyRGlLbkEaTXlJZHdNT09TU2VTZVBoNDM3cFZMUToxMDM=\");"
     }
   ],
   "specification/esql/async_query/examples/request/AsyncQueryRequestExample1.yaml": [
@@ -15179,6 +17135,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"\\n    FROM library,remote-*:library\\n    | EVAL year = DATE_TRUNC(1 YEARS, release_date)\\n    | STATS MAX(page_count) BY year\\n    | SORT year\\n    | LIMIT 5\\n  \",\"wait_for_completion_timeout\":\"2s\",\"include_ccs_metadata\":true}' \"$ELASTICSEARCH_URL/_query/async\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Esql\n    .AsyncQueryAsync(d1 => d1\n        .IncludeCcsMetadata(true)\n        .Query(\"\\n    FROM library,remote-*:library\\n    | EVAL year = DATE_TRUNC(1 YEARS, release_date)\\n    | STATS MAX(page_count) BY year\\n    | SORT year\\n    | LIMIT 5\\n  \")\n        .WaitForCompletionTimeout(\"2s\")\n    );"
     }
   ],
   "specification/esql/async_query_get/examples/request/EsqlAsyncQueryGetExample1.yaml": [
@@ -15201,6 +17161,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query/async/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=?wait_for_completion_timeout=30s\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Esql\n    .AsyncQueryGetAsync(id: \"FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\", d1 => d1\n        .WaitForCompletionTimeout(\"30s\")\n    );"
     }
   ],
   "specification/esql/query/examples/request/QueryRequestExample1.yaml": [
@@ -15223,6 +17187,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"\\n    FROM library,remote-*:library\\n    | EVAL year = DATE_TRUNC(1 YEARS, release_date)\\n    | STATS MAX(page_count) BY year\\n    | SORT year\\n    | LIMIT 5\\n  \",\"include_ccs_metadata\":true}' \"$ELASTICSEARCH_URL/_query\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Esql\n    .QueryAsync(d1 => d1\n        .IncludeCcsMetadata(true)\n        .Query(\"\\n    FROM library,remote-*:library\\n    | EVAL year = DATE_TRUNC(1 YEARS, release_date)\\n    | STATS MAX(page_count) BY year\\n    | SORT year\\n    | LIMIT 5\\n  \")\n    );"
     },
     {
       "language": "Java",
@@ -15249,6 +17217,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query/async/FmdMX2pIang3UWhLRU5QS0lqdlppYncaMUpYQ05oSkpTc3kwZ21EdC1tbFJXQToxOTI=\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Esql.AsyncQueryDeleteAsync(id: \"FmdMX2pIang3UWhLRU5QS0lqdlppYncaMUpYQ05oSkpTc3kwZ21EdC1tbFJXQToxOTI=\");"
     }
   ],
   "specification/autoscaling/put_autoscaling_policy/examples/request/PutAutoscalingPolicyRequestExample1.yaml": [
@@ -15262,7 +17234,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.autoscaling.put_autoscaling_policy(\n  name: \"<name>\",\n  body: {\n    \"roles\": [],\n    \"deciders\": {\n      \"fixed\": {}\n    }\n  }\n)"
+      "code": "response = client.perform_request(\n  \"PUT\",\n  \"/_autoscaling/policy/&lt;name&gt;\",\n  {},\n  {\n    \"roles\": [],\n    \"deciders\": {\n      \"fixed\": {}\n    }\n  },\n  { \"Content-Type\": \"application/json\" },\n)"
     },
     {
       "language": "PHP",
@@ -15288,7 +17260,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.autoscaling.put_autoscaling_policy(\n  name: \"my_autoscaling_policy\",\n  body: {\n    \"roles\": [\n      \"data_hot\"\n    ],\n    \"deciders\": {\n      \"fixed\": {}\n    }\n  }\n)"
+      "code": "response = client.perform_request(\n  \"PUT\",\n  \"/_autoscaling/policy/my_autoscaling_policy\",\n  {},\n  {\n    \"roles\": [\n      \"data_hot\"\n    ],\n    \"deciders\": {\n      \"fixed\": {}\n    }\n  },\n  { \"Content-Type\": \"application/json\" },\n)"
     },
     {
       "language": "PHP",
@@ -15314,7 +17286,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.autoscaling.delete_autoscaling_policy(\n  name: \"*\"\n)"
+      "code": "response = client.perform_request(\n  \"DELETE\",\n  \"/_autoscaling/policy/*\",\n  {},\n)"
     },
     {
       "language": "PHP",
@@ -15340,7 +17312,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.autoscaling.get_autoscaling_policy(\n  name: \"my_autoscaling_policy\"\n)"
+      "code": "response = client.perform_request(\n  \"GET\",\n  \"/_autoscaling/policy/my_autoscaling_policy\",\n  {},\n)"
     },
     {
       "language": "PHP",
@@ -15366,7 +17338,7 @@
     },
     {
       "language": "Ruby",
-      "code": "response = client.autoscaling.get_autoscaling_capacity"
+      "code": "response = client.perform_request(\n  \"GET\",\n  \"/_autoscaling/capacity\",\n  {},\n)"
     },
     {
       "language": "PHP",
@@ -15403,6 +17375,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"params\":{\"query_string\":\"my first query\",\"text_fields\":[{\"name\":\"title\",\"boost\":5},{\"name\":\"description\",\"boost\":1}]}}' \"$ELASTICSEARCH_URL/_application/search_application/my-app/_render_query\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SearchApplication\n    .RenderQueryAsync(name: \"my-app\", d1 => d1\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"my first query\" },\n            { \"text_fields\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            [\n              {\n                \"name\": \"title\",\n                \"boost\": 5\n              },\n              {\n                \"name\": \"description\",\n                \"boost\": 1\n              }\n            ]\n            \"\"\") }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.searchApplication().renderQuery(r -> r\n    .name(\"my-app\")\n    .params(Map.of(\"text_fields\", JsonData.fromJson(\"[{\\\"name\\\":\\\"title\\\",\\\"boost\\\":5},{\\\"name\\\":\\\"description\\\",\\\"boost\\\":1}]\"),\"query_string\", JsonData.fromJson(\"\\\"my first query\\\"\")))\n);\n"
     }
@@ -15427,6 +17403,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/search_application/my-app/\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.SearchApplication.DeleteAsync(name: \"my-app\");"
     },
     {
       "language": "Java",
@@ -15481,6 +17461,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/search_application/my-app/\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SearchApplication.GetAsync(name: \"my-app\");"
+    },
+    {
       "language": "Java",
       "code": "client.searchApplication().get(g -> g\n    .name(\"my-app\")\n);\n"
     }
@@ -15505,6 +17489,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"session\":{\"id\":\"1797ca95-91c9-4e2e-b1bd-9c38e6f386a9\"},\"user\":{\"id\":\"5f26f01a-bbee-4202-9298-81261067abbd\"},\"search\":{\"query\":\"search term\",\"results\":{\"items\":[{\"document\":{\"id\":\"123\",\"index\":\"products\"}}],\"total_results\":10},\"sort\":{\"name\":\"relevance\"},\"search_application\":\"website\"},\"document\":{\"id\":\"123\",\"index\":\"products\"}}' \"$ELASTICSEARCH_URL/_application/analytics/my_analytics_collection/event/search_click\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.SearchApplication\n    .PostBehavioralAnalyticsEventAsync(collectionName: \"my_analytics_collection\", eventType: EventType.SearchClick, d1 => d1\n        .Payload(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n        {\n          \"session\": {\n            \"id\": \"1797ca95-91c9-4e2e-b1bd-9c38e6f386a9\"\n          },\n          \"user\": {\n            \"id\": \"5f26f01a-bbee-4202-9298-81261067abbd\"\n          },\n          \"search\": {\n            \"query\": \"search term\",\n            \"results\": {\n              \"items\": [\n                {\n                  \"document\": {\n                    \"id\": \"123\",\n                    \"index\": \"products\"\n                  }\n                }\n              ],\n              \"total_results\": 10\n            },\n            \"sort\": {\n              \"name\": \"relevance\"\n            },\n            \"search_application\": \"website\"\n          },\n          \"document\": {\n            \"id\": \"123\",\n            \"index\": \"products\"\n          }\n        }\n        \"\"\"))\n    );"
     },
     {
       "language": "Java",
@@ -15533,6 +17521,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/analytics/my*\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SearchApplication\n    .GetBehavioralAnalyticsAsync(d1 => d1\n        .Name([\"my*\"])\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.searchApplication().getBehavioralAnalytics(g -> g\n    .name(\"my*\")\n);\n"
     }
@@ -15557,6 +17549,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/analytics/my_analytics_collection/\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.SearchApplication.DeleteBehavioralAnalyticsAsync(name: \"my_analytics_collection\");"
     },
     {
       "language": "Java",
@@ -15585,6 +17581,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/analytics/my_analytics_collection\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SearchApplication.PutBehavioralAnalyticsAsync(name: \"my_analytics_collection\");"
+    },
+    {
       "language": "Java",
       "code": "client.searchApplication().putBehavioralAnalytics(p -> p\n    .name(\"my_analytics_collection\")\n);\n"
     }
@@ -15611,6 +17611,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"params\":{\"query_string\":\"my first query\",\"text_fields\":[{\"name\":\"title\",\"boost\":5},{\"name\":\"description\",\"boost\":1}]}}' \"$ELASTICSEARCH_URL/_application/search_application/my-app/_search\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.SearchApplication\n    .SearchAsync<MyDocument>(name: \"my-app\", d1 => d1\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"my first query\" },\n            { \"text_fields\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            [\n              {\n                \"name\": \"title\",\n                \"boost\": 5\n              },\n              {\n                \"name\": \"description\",\n                \"boost\": 1\n              }\n            ]\n            \"\"\") }\n        })\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.searchApplication().search(s -> s\n    .name(\"my-app\")\n    .params(Map.of(\"text_fields\", JsonData.fromJson(\"[{\\\"name\\\":\\\"title\\\",\\\"boost\\\":5},{\\\"name\\\":\\\"description\\\",\\\"boost\\\":1}]\"),\"query_string\", JsonData.fromJson(\"\\\"my first query\\\"\")))\n);\n"
     }
@@ -15618,7 +17622,7 @@
   "specification/search_application/list/examples/request/SearchApplicationsListRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.search_application.list(\n    from=\"0\",\n    size=\"3\",\n    q=\"app*\",\n)"
+      "code": "resp = client.search_application.list(\n    from_=\"0\",\n    size=\"3\",\n    q=\"app*\",\n)"
     },
     {
       "language": "JavaScript",
@@ -15635,6 +17639,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/search_application?from=0&size=3&q=app*\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.SearchApplication\n    .ListAsync(d1 => d1\n        .From(0)\n        .QueryLuceneSyntax(\"app*\")\n        .Size(3)\n    );"
     },
     {
       "language": "Java",
@@ -15741,6 +17749,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce-customer-transform/_start\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement.StartTransformAsync(transformId: \"ecommerce-customer-transform\");"
+    },
+    {
       "language": "Java",
       "code": "client.transform().startTransform(s -> s\n    .transformId(\"ecommerce-customer-transform\")\n);\n"
     }
@@ -15765,6 +17777,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce_transform/_schedule_now\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement.ScheduleNowTransformAsync(transformId: \"ecommerce_transform\");"
     },
     {
       "language": "Java",
@@ -15793,6 +17809,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform?size=10\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement\n    .GetTransformAsync(d1 => d1\n        .Size(10)\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.transform().getTransform(g -> g\n    .size(10)\n);\n"
     }
@@ -15817,6 +17837,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/_upgrade\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement.UpgradeTransformsAsync();"
     },
     {
       "language": "Java",
@@ -15845,6 +17869,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"kibana_sample_data_ecommerce\"},\"pivot\":{\"group_by\":{\"customer_id\":{\"terms\":{\"field\":\"customer_id\",\"missing_bucket\":true}}},\"aggregations\":{\"max_price\":{\"max\":{\"field\":\"taxful_total_price\"}}}}}' \"$ELASTICSEARCH_URL/_transform/_preview\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement\n    .PreviewTransformAsync<MyDocument, MyDocument>(d1 => d1\n        .Pivot(d2 => d2\n            .Aggregations(d3 => d3\n                .Add(\"max_price\", d4 => d4\n                    .Max(d5 => d5\n                        .Field(x => x.TaxfulTotalPrice)\n                    )\n                )\n            )\n            .GroupBy(d3 => d3\n                .Add(\"customer_id\", d4 => d4\n                    .Terms(d5 => d5\n                        .Field(x => x.CustomerId)\n                        .MissingBucket(true)\n                    )\n                )\n            )\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"kibana_sample_data_ecommerce\" })\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.transform().previewTransform(p -> p\n    .pivot(pi -> pi\n        .aggregations(\"max_price\", a -> a\n            .max(m -> m\n                .field(\"taxful_total_price\")\n            )\n        )\n        .groupBy(\"customer_id\", g -> g\n            .terms(t -> t\n                .field(\"customer_id\")\n                .missingBucket(true)\n            )\n        )\n    )\n    .source(s -> s\n        .index(\"kibana_sample_data_ecommerce\")\n    )\n);\n"
     }
@@ -15869,6 +17897,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"kibana_sample_data_ecommerce\"},\"latest\":{\"unique_key\":[\"customer_id\"],\"sort\":\"order_date\"},\"description\":\"Latest order for each customer\",\"dest\":{\"index\":\"kibana_sample_data_ecommerce_transform2\"},\"frequency\":\"5m\",\"sync\":{\"time\":{\"field\":\"order_date\",\"delay\":\"60s\"}}}' \"$ELASTICSEARCH_URL/_transform/ecommerce_transform2\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement\n    .PutTransformAsync(transformId: \"ecommerce_transform2\", d1 => d1\n        .Description(\"Latest order for each customer\")\n        .Dest(d2 => d2\n            .Index(\"kibana_sample_data_ecommerce_transform2\")\n        )\n        .Frequency(\"5m\")\n        .Latest(d2 => d2\n            .Sort(x => x.OrderDate)\n            .UniqueKey(x => x.CustomerId)\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"kibana_sample_data_ecommerce\" })\n        )\n        .Sync(d2 => d2\n            .Time(d3 => d3\n                .Delay(\"60s\")\n                .Field(x => x.OrderDate)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -15897,6 +17929,10 @@
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"kibana_sample_data_ecommerce\",\"query\":{\"term\":{\"geoip.continent_name\":{\"value\":\"Asia\"}}}},\"pivot\":{\"group_by\":{\"customer_id\":{\"terms\":{\"field\":\"customer_id\",\"missing_bucket\":true}}},\"aggregations\":{\"max_price\":{\"max\":{\"field\":\"taxful_total_price\"}}}},\"description\":\"Maximum priced ecommerce data by customer_id in Asia\",\"dest\":{\"index\":\"kibana_sample_data_ecommerce_transform1\",\"pipeline\":\"add_timestamp_pipeline\"},\"frequency\":\"5m\",\"sync\":{\"time\":{\"field\":\"order_date\",\"delay\":\"60s\"}},\"retention_policy\":{\"time\":{\"field\":\"order_date\",\"max_age\":\"30d\"}}}' \"$ELASTICSEARCH_URL/_transform/ecommerce_transform1\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement\n    .PutTransformAsync(transformId: \"ecommerce_transform1\", d1 => d1\n        .Description(\"Maximum priced ecommerce data by customer_id in Asia\")\n        .Dest(d2 => d2\n            .Index(\"kibana_sample_data_ecommerce_transform1\")\n            .Pipeline(\"add_timestamp_pipeline\")\n        )\n        .Frequency(\"5m\")\n        .Pivot(d2 => d2\n            .Aggregations(d3 => d3\n                .Add(\"max_price\", d4 => d4\n                    .Max(d5 => d5\n                        .Field(x => x.TaxfulTotalPrice)\n                    )\n                )\n            )\n            .GroupBy(d3 => d3\n                .Add(\"customer_id\", d4 => d4\n                    .Terms(d5 => d5\n                        .Field(x => x.CustomerId)\n                        .MissingBucket(true)\n                    )\n                )\n            )\n        )\n        .RetentionPolicy(d2 => d2\n            .Time(d3 => d3\n                .Field(x => x.OrderDate)\n                .MaxAge(\"30d\")\n            )\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"kibana_sample_data_ecommerce\" })\n            .Query(d3 => d3\n                .Term(d4 => d4\n                    .Field(x => x.Geoip.ContinentName)\n                    .Value(\"Asia\")\n                )\n            )\n        )\n        .Sync(d2 => d2\n            .Time(d3 => d3\n                .Delay(\"60s\")\n                .Field(x => x.OrderDate)\n            )\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.transform().putTransform(p -> p\n    .description(\"Maximum priced ecommerce data by customer_id in Asia\")\n    .dest(d -> d\n        .index(\"kibana_sample_data_ecommerce_transform1\")\n        .pipeline(\"add_timestamp_pipeline\")\n    )\n    .frequency(f -> f\n        .time(\"5m\")\n    )\n    .pivot(pi -> pi\n        .aggregations(\"max_price\", a -> a\n            .max(m -> m\n                .field(\"taxful_total_price\")\n            )\n        )\n        .groupBy(\"customer_id\", g -> g\n            .terms(t -> t\n                .field(\"customer_id\")\n                .missingBucket(true)\n            )\n        )\n    )\n    .retentionPolicy(r -> r\n        .time(t -> t\n            .field(\"order_date\")\n            .maxAge(m -> m\n                .time(\"30d\")\n            )\n        )\n    )\n    .source(s -> s\n        .index(\"kibana_sample_data_ecommerce\")\n        .query(q -> q\n            .term(te -> te\n                .field(\"geoip.continent_name\")\n                .value(FieldValue.of(\"Asia\"))\n            )\n        )\n    )\n    .sync(sy -> sy\n        .time(ti -> ti\n            .delay(d -> d\n                .time(\"60s\")\n            )\n            .field(\"order_date\")\n        )\n    )\n    .transformId(\"ecommerce_transform1\")\n);\n"
     }
@@ -15904,23 +17940,27 @@
   "specification/transform/update_transform/examples/request/UpdateTransformRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.transform.update_transform(\n    transform_id=\"simple-kibana-ecomm-pivot\",\n    source={\n        \"index\": \"kibana_sample_data_ecommerce\",\n        \"query\": {\n            \"term\": {\n                \"geoip.continent_name\": {\n                    \"value\": \"Asia\"\n                }\n            }\n        }\n    },\n    pivot={\n        \"group_by\": {\n            \"customer_id\": {\n                \"terms\": {\n                    \"field\": \"customer_id\",\n                    \"missing_bucket\": True\n                }\n            }\n        },\n        \"aggregations\": {\n            \"max_price\": {\n                \"max\": {\n                    \"field\": \"taxful_total_price\"\n                }\n            }\n        }\n    },\n    description=\"Maximum priced ecommerce data by customer_id in Asia\",\n    dest={\n        \"index\": \"kibana_sample_data_ecommerce_transform1\",\n        \"pipeline\": \"add_timestamp_pipeline\"\n    },\n    frequency=\"5m\",\n    sync={\n        \"time\": {\n            \"field\": \"order_date\",\n            \"delay\": \"60s\"\n        }\n    },\n    retention_policy={\n        \"time\": {\n            \"field\": \"order_date\",\n            \"max_age\": \"30d\"\n        }\n    },\n)"
+      "code": "resp = client.transform.update_transform(\n    transform_id=\"simple-kibana-ecomm-pivot\",\n    source={\n        \"index\": \"kibana_sample_data_ecommerce\",\n        \"query\": {\n            \"term\": {\n                \"geoip.continent_name\": {\n                    \"value\": \"Asia\"\n                }\n            }\n        }\n    },\n    description=\"Maximum priced ecommerce data by customer_id in Asia\",\n    dest={\n        \"index\": \"kibana_sample_data_ecommerce_transform_v2\",\n        \"pipeline\": \"add_timestamp_pipeline\"\n    },\n    frequency=\"15m\",\n    sync={\n        \"time\": {\n            \"field\": \"order_date\",\n            \"delay\": \"120s\"\n        }\n    },\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.transform.updateTransform({\n  transform_id: \"simple-kibana-ecomm-pivot\",\n  source: {\n    index: \"kibana_sample_data_ecommerce\",\n    query: {\n      term: {\n        \"geoip.continent_name\": {\n          value: \"Asia\",\n        },\n      },\n    },\n  },\n  pivot: {\n    group_by: {\n      customer_id: {\n        terms: {\n          field: \"customer_id\",\n          missing_bucket: true,\n        },\n      },\n    },\n    aggregations: {\n      max_price: {\n        max: {\n          field: \"taxful_total_price\",\n        },\n      },\n    },\n  },\n  description: \"Maximum priced ecommerce data by customer_id in Asia\",\n  dest: {\n    index: \"kibana_sample_data_ecommerce_transform1\",\n    pipeline: \"add_timestamp_pipeline\",\n  },\n  frequency: \"5m\",\n  sync: {\n    time: {\n      field: \"order_date\",\n      delay: \"60s\",\n    },\n  },\n  retention_policy: {\n    time: {\n      field: \"order_date\",\n      max_age: \"30d\",\n    },\n  },\n});"
+      "code": "const response = await client.transform.updateTransform({\n  transform_id: \"simple-kibana-ecomm-pivot\",\n  source: {\n    index: \"kibana_sample_data_ecommerce\",\n    query: {\n      term: {\n        \"geoip.continent_name\": {\n          value: \"Asia\",\n        },\n      },\n    },\n  },\n  description: \"Maximum priced ecommerce data by customer_id in Asia\",\n  dest: {\n    index: \"kibana_sample_data_ecommerce_transform_v2\",\n    pipeline: \"add_timestamp_pipeline\",\n  },\n  frequency: \"15m\",\n  sync: {\n    time: {\n      field: \"order_date\",\n      delay: \"120s\",\n    },\n  },\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.transform.update_transform(\n  transform_id: \"simple-kibana-ecomm-pivot\",\n  body: {\n    \"source\": {\n      \"index\": \"kibana_sample_data_ecommerce\",\n      \"query\": {\n        \"term\": {\n          \"geoip.continent_name\": {\n            \"value\": \"Asia\"\n          }\n        }\n      }\n    },\n    \"pivot\": {\n      \"group_by\": {\n        \"customer_id\": {\n          \"terms\": {\n            \"field\": \"customer_id\",\n            \"missing_bucket\": true\n          }\n        }\n      },\n      \"aggregations\": {\n        \"max_price\": {\n          \"max\": {\n            \"field\": \"taxful_total_price\"\n          }\n        }\n      }\n    },\n    \"description\": \"Maximum priced ecommerce data by customer_id in Asia\",\n    \"dest\": {\n      \"index\": \"kibana_sample_data_ecommerce_transform1\",\n      \"pipeline\": \"add_timestamp_pipeline\"\n    },\n    \"frequency\": \"5m\",\n    \"sync\": {\n      \"time\": {\n        \"field\": \"order_date\",\n        \"delay\": \"60s\"\n      }\n    },\n    \"retention_policy\": {\n      \"time\": {\n        \"field\": \"order_date\",\n        \"max_age\": \"30d\"\n      }\n    }\n  }\n)"
+      "code": "response = client.transform.update_transform(\n  transform_id: \"simple-kibana-ecomm-pivot\",\n  body: {\n    \"source\": {\n      \"index\": \"kibana_sample_data_ecommerce\",\n      \"query\": {\n        \"term\": {\n          \"geoip.continent_name\": {\n            \"value\": \"Asia\"\n          }\n        }\n      }\n    },\n    \"description\": \"Maximum priced ecommerce data by customer_id in Asia\",\n    \"dest\": {\n      \"index\": \"kibana_sample_data_ecommerce_transform_v2\",\n      \"pipeline\": \"add_timestamp_pipeline\"\n    },\n    \"frequency\": \"15m\",\n    \"sync\": {\n      \"time\": {\n        \"field\": \"order_date\",\n        \"delay\": \"120s\"\n      }\n    }\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->transform()->updateTransform([\n    \"transform_id\" => \"simple-kibana-ecomm-pivot\",\n    \"body\" => [\n        \"source\" => [\n            \"index\" => \"kibana_sample_data_ecommerce\",\n            \"query\" => [\n                \"term\" => [\n                    \"geoip.continent_name\" => [\n                        \"value\" => \"Asia\",\n                    ],\n                ],\n            ],\n        ],\n        \"pivot\" => [\n            \"group_by\" => [\n                \"customer_id\" => [\n                    \"terms\" => [\n                        \"field\" => \"customer_id\",\n                        \"missing_bucket\" => true,\n                    ],\n                ],\n            ],\n            \"aggregations\" => [\n                \"max_price\" => [\n                    \"max\" => [\n                        \"field\" => \"taxful_total_price\",\n                    ],\n                ],\n            ],\n        ],\n        \"description\" => \"Maximum priced ecommerce data by customer_id in Asia\",\n        \"dest\" => [\n            \"index\" => \"kibana_sample_data_ecommerce_transform1\",\n            \"pipeline\" => \"add_timestamp_pipeline\",\n        ],\n        \"frequency\" => \"5m\",\n        \"sync\" => [\n            \"time\" => [\n                \"field\" => \"order_date\",\n                \"delay\" => \"60s\",\n            ],\n        ],\n        \"retention_policy\" => [\n            \"time\" => [\n                \"field\" => \"order_date\",\n                \"max_age\" => \"30d\",\n            ],\n        ],\n    ],\n]);"
+      "code": "$resp = $client->transform()->updateTransform([\n    \"transform_id\" => \"simple-kibana-ecomm-pivot\",\n    \"body\" => [\n        \"source\" => [\n            \"index\" => \"kibana_sample_data_ecommerce\",\n            \"query\" => [\n                \"term\" => [\n                    \"geoip.continent_name\" => [\n                        \"value\" => \"Asia\",\n                    ],\n                ],\n            ],\n        ],\n        \"description\" => \"Maximum priced ecommerce data by customer_id in Asia\",\n        \"dest\" => [\n            \"index\" => \"kibana_sample_data_ecommerce_transform_v2\",\n            \"pipeline\" => \"add_timestamp_pipeline\",\n        ],\n        \"frequency\" => \"15m\",\n        \"sync\" => [\n            \"time\" => [\n                \"field\" => \"order_date\",\n                \"delay\" => \"120s\",\n            ],\n        ],\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"kibana_sample_data_ecommerce\",\"query\":{\"term\":{\"geoip.continent_name\":{\"value\":\"Asia\"}}}},\"pivot\":{\"group_by\":{\"customer_id\":{\"terms\":{\"field\":\"customer_id\",\"missing_bucket\":true}}},\"aggregations\":{\"max_price\":{\"max\":{\"field\":\"taxful_total_price\"}}}},\"description\":\"Maximum priced ecommerce data by customer_id in Asia\",\"dest\":{\"index\":\"kibana_sample_data_ecommerce_transform1\",\"pipeline\":\"add_timestamp_pipeline\"},\"frequency\":\"5m\",\"sync\":{\"time\":{\"field\":\"order_date\",\"delay\":\"60s\"}},\"retention_policy\":{\"time\":{\"field\":\"order_date\",\"max_age\":\"30d\"}}}' \"$ELASTICSEARCH_URL/_transform/simple-kibana-ecomm-pivot/_update\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"kibana_sample_data_ecommerce\",\"query\":{\"term\":{\"geoip.continent_name\":{\"value\":\"Asia\"}}}},\"description\":\"Maximum priced ecommerce data by customer_id in Asia\",\"dest\":{\"index\":\"kibana_sample_data_ecommerce_transform_v2\",\"pipeline\":\"add_timestamp_pipeline\"},\"frequency\":\"15m\",\"sync\":{\"time\":{\"field\":\"order_date\",\"delay\":\"120s\"}}}' \"$ELASTICSEARCH_URL/_transform/simple-kibana-ecomm-pivot/_update\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement\n    .UpdateTransformAsync(transformId: \"simple-kibana-ecomm-pivot\", d1 => d1\n        .Description(\"Maximum priced ecommerce data by customer_id in Asia\")\n        .Dest(d2 => d2\n            .Index(\"kibana_sample_data_ecommerce_transform_v2\")\n            .Pipeline(\"add_timestamp_pipeline\")\n        )\n        .Frequency(\"15m\")\n        .Source(d2 => d2\n            .Indices(new[] { \"kibana_sample_data_ecommerce\" })\n            .Query(d3 => d3\n                .Term(d4 => d4\n                    .Field(x => x.Geoip.ContinentName)\n                    .Value(\"Asia\")\n                )\n            )\n        )\n        .Sync(d2 => d2\n            .Time(d3 => d3\n                .Delay(\"120s\")\n                .Field(x => x.OrderDate)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -15949,6 +17989,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce_transform/_reset\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement.ResetTransformAsync(transformId: \"ecommerce_transform\");"
+    },
+    {
       "language": "Java",
       "code": "client.transform().resetTransform(r -> r\n    .transformId(\"ecommerce_transform\")\n);\n"
     }
@@ -15973,6 +18017,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce_transform/_stop\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement.StopTransformAsync(transformId: \"ecommerce_transform\");"
     },
     {
       "language": "Java",
@@ -16001,6 +18049,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce-customer-transform/_stats\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement.GetTransformStatsAsync(transformId: new[] { \"ecommerce-customer-transform\" });"
+    },
+    {
       "language": "Java",
       "code": "client.transform().getTransformStats(g -> g\n    .transformId(\"ecommerce-customer-transform\")\n);\n"
     }
@@ -16025,6 +18077,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce_transform\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement.DeleteTransformAsync(transformId: \"ecommerce_transform\");"
     },
     {
       "language": "Java",
@@ -16053,6 +18109,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"follower_cluster\":\"<follower_cluster>\",\"follower_index\":\"<follower_index>\",\"follower_index_uuid\":\"<follower_index_uuid>\",\"leader_remote_cluster\":\"<leader_remote_cluster>\"}' \"$ELASTICSEARCH_URL/<leader_index>/_ccr/forget_follower\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication\n    .ForgetFollowerAsync(index: \"<leader_index>\", d1 => d1\n        .FollowerCluster(\"<follower_cluster>\")\n        .FollowerIndex(\"<follower_index>\")\n        .FollowerIndexUuid(\"<follower_index_uuid>\")\n        .LeaderRemoteCluster(\"<leader_remote_cluster>\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ccr().forgetFollower(f -> f\n    .followerCluster(\"<follower_cluster>\")\n    .followerIndex(\"<follower_index>\")\n    .followerIndexUuid(\"<follower_index_uuid>\")\n    .index(\"<leader_index>\")\n    .leaderRemoteCluster(\"<leader_remote_cluster>\")\n);\n"
     }
@@ -16077,6 +18137,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ccr/auto_follow/my_auto_follow_pattern\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication.DeleteAutoFollowPatternAsync(name: \"my_auto_follow_pattern\");"
     },
     {
       "language": "Java",
@@ -16105,6 +18169,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ccr/auto_follow/my_auto_follow_pattern/resume\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication.ResumeAutoFollowPatternAsync(name: \"my_auto_follow_pattern\");"
+    },
+    {
       "language": "Java",
       "code": "client.ccr().resumeAutoFollowPattern(r -> r\n    .name(\"my_auto_follow_pattern\")\n);\n"
     }
@@ -16129,6 +18197,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/follower_index/_ccr/pause_follow\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication.PauseFollowAsync(index: \"follower_index\");"
     },
     {
       "language": "Java",
@@ -16183,6 +18255,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ccr/auto_follow/my_auto_follow_pattern\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication\n    .GetAutoFollowPatternAsync(d1 => d1\n        .Name(\"my_auto_follow_pattern\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ccr().getAutoFollowPattern(g -> g\n    .name(\"my_auto_follow_pattern\")\n);\n"
     }
@@ -16207,6 +18283,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"remote_cluster\":\"remote_cluster\",\"leader_index_patterns\":[\"leader_index*\"],\"follow_index_pattern\":\"{{leader_index}}-follower\",\"settings\":{\"index.number_of_replicas\":0},\"max_read_request_operation_count\":1024,\"max_outstanding_read_requests\":16,\"max_read_request_size\":\"1024k\",\"max_write_request_operation_count\":32768,\"max_write_request_size\":\"16k\",\"max_outstanding_write_requests\":8,\"max_write_buffer_count\":512,\"max_write_buffer_size\":\"512k\",\"max_retry_delay\":\"10s\",\"read_poll_timeout\":\"30s\"}' \"$ELASTICSEARCH_URL/_ccr/auto_follow/my_auto_follow_pattern\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication\n    .PutAutoFollowPatternAsync(name: \"my_auto_follow_pattern\", d1 => d1\n        .FollowIndexPattern(\"{{leader_index}}-follower\")\n        .LeaderIndexPatterns(\"leader_index*\")\n        .MaxOutstandingReadRequests(16)\n        .MaxOutstandingWriteRequests(8)\n        .MaxReadRequestOperationCount(1024)\n        .MaxReadRequestSize(new ByteSize(\"1024k\"))\n        .MaxRetryDelay(\"10s\")\n        .MaxWriteBufferCount(512)\n        .MaxWriteBufferSize(new ByteSize(\"512k\"))\n        .MaxWriteRequestOperationCount(32768)\n        .MaxWriteRequestSize(new ByteSize(\"16k\"))\n        .ReadPollTimeout(\"30s\")\n        .RemoteCluster(\"remote_cluster\")\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.number_of_replicas\", 0 }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -16235,6 +18315,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/follower_index/_ccr/info\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication.FollowInfoAsync(indices: new[] { \"follower_index\" });"
+    },
+    {
       "language": "Java",
       "code": "client.ccr().followInfo(f -> f\n    .index(\"follower_index\")\n);\n"
     }
@@ -16259,6 +18343,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/follower_index/_ccr/unfollow\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication.UnfollowAsync(index: \"follower_index\");"
     },
     {
       "language": "Java",
@@ -16287,6 +18375,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"max_read_request_operation_count\":1024,\"max_outstanding_read_requests\":16,\"max_read_request_size\":\"1024k\",\"max_write_request_operation_count\":32768,\"max_write_request_size\":\"16k\",\"max_outstanding_write_requests\":8,\"max_write_buffer_count\":512,\"max_write_buffer_size\":\"512k\",\"max_retry_delay\":\"10s\",\"read_poll_timeout\":\"30s\"}' \"$ELASTICSEARCH_URL/follower_index/_ccr/resume_follow\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication\n    .ResumeFollowAsync(index: \"follower_index\", d1 => d1\n        .MaxOutstandingReadRequests(16L)\n        .MaxOutstandingWriteRequests(8L)\n        .MaxReadRequestOperationCount(1024L)\n        .MaxReadRequestSize(\"1024k\")\n        .MaxRetryDelay(\"10s\")\n        .MaxWriteBufferCount(512L)\n        .MaxWriteBufferSize(\"512k\")\n        .MaxWriteRequestOperationCount(32768L)\n        .MaxWriteRequestSize(\"16k\")\n        .ReadPollTimeout(\"30s\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ccr().resumeFollow(r -> r\n    .index(\"follower_index\")\n    .maxOutstandingReadRequests(16L)\n    .maxOutstandingWriteRequests(8L)\n    .maxReadRequestOperationCount(1024L)\n    .maxReadRequestSize(\"1024k\")\n    .maxRetryDelay(m -> m\n        .time(\"10s\")\n    )\n    .maxWriteBufferCount(512L)\n    .maxWriteBufferSize(\"512k\")\n    .maxWriteRequestOperationCount(32768L)\n    .maxWriteRequestSize(\"16k\")\n    .readPollTimeout(re -> re\n        .time(\"30s\")\n    )\n);\n"
     }
@@ -16311,6 +18403,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/follower_index/_ccr/stats\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication.FollowStatsAsync(indices: new[] { \"follower_index\" });"
     },
     {
       "language": "Java",
@@ -16339,6 +18435,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ccr/stats\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication.StatsAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.ccr().stats(s -> s);\n"
     }
@@ -16363,6 +18463,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ccr/auto_follow/my_auto_follow_pattern/pause\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.CrossClusterReplication.PauseAutoFollowPatternAsync(name: \"my_auto_follow_pattern\");"
     },
     {
       "language": "Java",
@@ -16391,6 +18495,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ilm/status\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement.GetStatusAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.ilm().getStatus();\n"
     }
@@ -16415,6 +18523,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"current_step\":{\"phase\":\"new\",\"action\":\"complete\",\"name\":\"complete\"},\"next_step\":{\"phase\":\"warm\",\"action\":\"forcemerge\",\"name\":\"forcemerge\"}}' \"$ELASTICSEARCH_URL/_ilm/move/my-index-000001\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement\n    .MoveToStepAsync(index: \"my-index-000001\", d1 => d1\n        .CurrentStep(d2 => d2\n            .Action(\"complete\")\n            .Name(\"complete\")\n            .Phase(\"new\")\n        )\n        .NextStep(d2 => d2\n            .Action(\"forcemerge\")\n            .Name(\"forcemerge\")\n            .Phase(\"warm\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -16443,6 +18555,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"current_step\":{\"phase\":\"hot\",\"action\":\"complete\",\"name\":\"complete\"},\"next_step\":{\"phase\":\"warm\"}}' \"$ELASTICSEARCH_URL/_ilm/move/my-index-000001\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement\n    .MoveToStepAsync(index: \"my-index-000001\", d1 => d1\n        .CurrentStep(d2 => d2\n            .Action(\"complete\")\n            .Name(\"complete\")\n            .Phase(\"hot\")\n        )\n        .NextStep(d2 => d2\n            .Phase(\"warm\")\n        )\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ilm().moveToStep(m -> m\n    .currentStep(c -> c\n        .action(\"complete\")\n        .name(\"complete\")\n        .phase(\"hot\")\n    )\n    .index(\"my-index-000001\")\n    .nextStep(n -> n\n        .phase(\"warm\")\n    )\n);\n"
     }
@@ -16467,6 +18583,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"legacy_template_to_delete\":\"global-template\",\"node_attribute\":\"custom_attribute_name\"}' \"$ELASTICSEARCH_URL/_ilm/migrate_to_data_tiers\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement\n    .MigrateToDataTiersAsync(d1 => d1\n        .LegacyTemplateToDelete(\"global-template\")\n        .NodeAttribute(\"custom_attribute_name\")\n    );"
     },
     {
       "language": "Java",
@@ -16495,6 +18615,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_ilm/retry\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement.RetryAsync(index: \"my-index-000001\");"
+    },
+    {
       "language": "Java",
       "code": "client.ilm().retry(r -> r\n    .index(\"my-index-000001\")\n);\n"
     }
@@ -16521,6 +18645,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ilm/policy/my_policy\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement.DeleteLifecycleAsync(name: \"my_policy\");"
+    },
+    {
       "language": "Java",
       "code": "client.ilm().deleteLifecycle(d -> d\n    .name(\"my_policy\")\n);\n"
     }
@@ -16545,6 +18673,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ilm/start\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement.StartAsync();"
     },
     {
       "language": "Java",
@@ -16599,6 +18731,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ilm/stop\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement.StopAsync();"
+    },
+    {
       "language": "Java",
       "code": "client.ilm().stop(s -> s);\n"
     }
@@ -16623,6 +18759,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/logs-my_app-default/_ilm/remove\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement.RemovePolicyAsync(index: \"logs-my_app-default\");"
     },
     {
       "language": "Java",
@@ -16651,6 +18791,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ilm/policy/my_policy\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement\n    .GetLifecycleAsync(d1 => d1\n        .Name(\"my_policy\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.ilm().getLifecycle(g -> g\n    .name(\"my_policy\")\n);\n"
     }
@@ -16675,6 +18819,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"policy\":{\"_meta\":{\"description\":\"used for nginx log\",\"project\":{\"name\":\"myProject\",\"department\":\"myDepartment\"}},\"phases\":{\"warm\":{\"min_age\":\"10d\",\"actions\":{\"forcemerge\":{\"max_num_segments\":1}}},\"delete\":{\"min_age\":\"30d\",\"actions\":{\"delete\":{}}}}}}' \"$ELASTICSEARCH_URL/_ilm/policy/my_policy\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.IndexLifecycleManagement\n    .PutLifecycleAsync(name: \"my_policy\", d1 => d1\n        .Policy(d2 => d2\n            .Meta(new Dictionary<string, object>()\n            {\n                { \"description\", \"used for nginx log\" },\n                { \"project\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"name\": \"myProject\",\n                  \"department\": \"myDepartment\"\n                }\n                \"\"\") }\n            })\n            .Phases(d3 => d3\n                .Delete(d4 => d4\n                    .Actions(d5 => d5\n                        .Delete()\n                    )\n                    .MinAge(\"30d\")\n                )\n                .Warm(d4 => d4\n                    .Actions(d5 => d5\n                        .Forcemerge(d6 => d6\n                            .MaxNumSegments(1)\n                        )\n                    )\n                    .MinAge(\"10d\")\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -16703,6 +18851,10 @@
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_sql/async/delete/FmdMX2pIang3UWhLRU5QS0lqdlppYncaMUpYQ05oSkpTc3kwZ21EdC1tbFJXQToxOTI=\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Sql.DeleteAsyncAsync(id: \"FmdMX2pIang3UWhLRU5QS0lqdlppYncaMUpYQ05oSkpTc3kwZ21EdC1tbFJXQToxOTI=\");"
+    },
+    {
       "language": "Java",
       "code": "client.sql().deleteAsync(d -> d\n    .id(\"FmdMX2pIang3UWhLRU5QS0lqdlppYncaMUpYQ05oSkpTc3kwZ21EdC1tbFJXQToxOTI=\")\n);\n"
     }
@@ -16727,6 +18879,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"SELECT * FROM library ORDER BY page_count DESC\",\"fetch_size\":10}' \"$ELASTICSEARCH_URL/_sql/translate\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Sql\n    .TranslateAsync(d1 => d1\n        .FetchSize(10)\n        .Query(\"SELECT * FROM library ORDER BY page_count DESC\")\n    );"
     },
     {
       "language": "Java",
@@ -16755,6 +18911,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"cursor\":\"sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWYUpOYklQMHhRUEtld3RsNnFtYU1hQQ==:BAFmBGRhdGUBZgVsaWtlcwFzB21lc3NhZ2UBZgR1c2Vy9f///w8=\"}' \"$ELASTICSEARCH_URL/_sql/close\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Sql\n    .ClearCursorAsync(d1 => d1\n        .Cursor(\"sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWYUpOYklQMHhRUEtld3RsNnFtYU1hQQ==:BAFmBGRhdGUBZgVsaWtlcwFzB21lc3NhZ2UBZgR1c2Vy9f///w8=\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.sql().clearCursor(c -> c\n    .cursor(\"sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWYUpOYklQMHhRUEtld3RsNnFtYU1hQQ==:BAFmBGRhdGUBZgVsaWtlcwFzB21lc3NhZ2UBZgR1c2Vy9f///w8=\")\n);\n"
     }
@@ -16779,6 +18939,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_sql/async/FnR0TDhyWUVmUmVtWXRWZER4MXZiNFEad2F5UDk2ZVdTVHV1S0xDUy00SklUdzozMTU=?wait_for_completion_timeout=2s&format=json\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Sql\n    .GetAsyncAsync(id: \"FnR0TDhyWUVmUmVtWXRWZER4MXZiNFEad2F5UDk2ZVdTVHV1S0xDUy00SklUdzozMTU=\", d1 => d1\n        .Format(\"json\")\n        .WaitForCompletionTimeout(\"2s\")\n    );"
     },
     {
       "language": "Java",
@@ -16807,6 +18971,10 @@
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_sql/async/status/FnR0TDhyWUVmUmVtWXRWZER4MXZiNFEad2F5UDk2ZVdTVHV1S0xDUy00SklUdzozMTU=\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Sql.GetAsyncStatusAsync(id: \"FnR0TDhyWUVmUmVtWXRWZER4MXZiNFEad2F5UDk2ZVdTVHV1S0xDUy00SklUdzozMTU=\");"
+    },
+    {
       "language": "Java",
       "code": "client.sql().getAsyncStatus(g -> g\n    .id(\"FnR0TDhyWUVmUmVtWXRWZER4MXZiNFEad2F5UDk2ZVdTVHV1S0xDUy00SklUdzozMTU=\")\n);\n"
     }
@@ -16833,6 +19001,10 @@
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"SELECT * FROM library ORDER BY page_count DESC LIMIT 5\"}' \"$ELASTICSEARCH_URL/_sql?format=txt\""
     },
     {
+      "language": "C#",
+      "code": "var response = await client.Sql\n    .QueryAsync(d1 => d1\n        .Format(SqlFormat.Txt)\n        .Query(\"SELECT * FROM library ORDER BY page_count DESC LIMIT 5\")\n    );"
+    },
+    {
       "language": "Java",
       "code": "client.sql().query(q -> q\n    .format(SqlFormat.Txt)\n    .query(\"SELECT * FROM library ORDER BY page_count DESC LIMIT 5\")\n);\n"
     }
@@ -16857,6 +19029,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"aliases\":{\"alias_1\":{},\"alias_2\":{\"filter\":{\"term\":{\"user.id\":\"kimchy\"}}}}}' \"$ELASTICSEARCH_URL/test\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .CreateAsync(index: \"test\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"alias_1\", new Alias())\n            .Add(\"alias_2\", d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n            )\n        )\n    );"
     }
   ],
   "specification/indices/create/examples/request/indicesCreateRequestExample4.yaml": [
@@ -16879,6 +19055,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{}' \"$ELASTICSEARCH_URL/my-index-000001\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices.CreateAsync(index: \"my-index-000001\");"
     }
   ],
   "specification/indices/create/examples/request/indicesCreateRequestExample5.yaml": [
@@ -16901,6 +19081,504 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"mappings\":{\"properties\":{\"field1\":{\"type\":\"text\"}}}}' \"$ELASTICSEARCH_URL/test\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .CreateAsync(index: \"test\", d1 => d1\n        .Mappings(d2 => d2\n            .Properties(d3 => d3\n                .Text(x => x.Field1)\n            )\n        )\n    );"
+    }
+  ],
+  "specification/indices/put_alias/examples/request/indicesPutAliasRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.indices.put_alias(\n    index=\"logs-my_app-default\",\n    name=\"logs\",\n    is_write_index=True,\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.indices.putAlias({\n  index: \"logs-my_app-default\",\n  name: \"logs\",\n  is_write_index: true,\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.indices.put_alias(\n  index: \"logs-my_app-default\",\n  name: \"logs\",\n  body: {\n    \"is_write_index\": true\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->indices()->putAlias([\n    \"index\" => \"logs-my_app-default\",\n    \"name\" => \"logs\",\n    \"body\" => [\n        \"is_write_index\" => true,\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"is_write_index\":true}' \"$ELASTICSEARCH_URL/logs-my_app-default/_alias/logs\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutAliasAsync(indices: new[] { \"logs-my_app-default\" }, name: \"logs\", d1 => d1\n        .IsWriteIndex(true)\n    );"
+    }
+  ],
+  "specification/indices/put_alias/examples/request/indicesPutAliasRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.indices.put_alias(\n    index=\"my-index-2099.05.06-000001\",\n    name=\"my-alias\",\n    routing=\"1\",\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.indices.putAlias({\n  index: \"my-index-2099.05.06-000001\",\n  name: \"my-alias\",\n  routing: 1,\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.indices.put_alias(\n  index: \"my-index-2099.05.06-000001\",\n  name: \"my-alias\",\n  body: {\n    \"routing\": \"1\"\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->indices()->putAlias([\n    \"index\" => \"my-index-2099.05.06-000001\",\n    \"name\" => \"my-alias\",\n    \"body\" => [\n        \"routing\" => \"1\",\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"routing\":\"1\"}' \"$ELASTICSEARCH_URL/my-index-2099.05.06-000001/_alias/my-alias\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .PutAliasAsync(indices: new[] { \"my-index-2099.05.06-000001\" }, name: \"my-alias\", d1 => d1\n        .Routing(\"1\")\n    );"
+    }
+  ],
+  "specification/indices/rollover/examples/request/indicesRolloverRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.indices.rollover(\n    alias=\"my-data-stream\",\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.indices.rollover({\n  alias: \"my-data-stream\",\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.indices.rollover(\n  alias: \"my-data-stream\",\n  body: {}\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->indices()->rollover([\n    \"alias\" => \"my-data-stream\",\n    \"body\" => new ArrayObject([]),\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{}' \"$ELASTICSEARCH_URL/my-data-stream/_rollover\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Indices\n    .RolloverAsync(new RolloverRequest()\n    {\n        Alias = \"my-data-stream\"\n    });"
+    }
+  ],
+  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"amazon_sagemaker_embeddings\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\",\n            \"dimensions\": 384,\n            \"element_type\": \"float\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"amazon_sagemaker_embeddings\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n      dimensions: 384,\n      element_type: \"float\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"amazon_sagemaker_embeddings\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\",\n      \"dimensions\": 384,\n      \"element_type\": \"float\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"amazon_sagemaker_embeddings\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n            \"dimensions\" => 384,\n            \"element_type\" => \"float\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\",\"dimensions\":384,\"element_type\":\"float\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/amazon_sagemaker_embeddings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\",\n              \"dimensions\": 384,\n              \"element_type\": \"float\"\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"amazon_sagemaker_completion\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"amazon_sagemaker_completion\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"amazon_sagemaker_completion\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"amazon_sagemaker_completion\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/completion/amazon_sagemaker_completion\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"chat_completion\",\n    inference_id=\"amazon_sagemaker_chat_completion\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"chat_completion\",\n  inference_id: \"amazon_sagemaker_chat_completion\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"chat_completion\",\n  inference_id: \"amazon_sagemaker_chat_completion\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"chat_completion\",\n    \"inference_id\" => \"amazon_sagemaker_chat_completion\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/chat_completion/amazon_sagemaker_chat_completion\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample4.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"sparse_embedding\",\n    inference_id=\"amazon_sagemaker_sparse_embedding\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"sparse_embedding\",\n  inference_id: \"amazon_sagemaker_sparse_embedding\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"sparse_embedding\",\n  inference_id: \"amazon_sagemaker_sparse_embedding\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"sparse_embedding\",\n    \"inference_id\" => \"amazon_sagemaker_sparse_embedding\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/amazon_sagemaker_sparse_embedding\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_sparse_embedding\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample5.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"amazon_sagemaker_rerank\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"amazon_sagemaker_rerank\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"amazon_sagemaker_rerank\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"amazon_sagemaker_rerank\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/amazon_sagemaker_rerank\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/inference/put_cohere/examples/request/PutCohereRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"cohere-completion\",\n    inference_config={\n        \"service\": \"cohere\",\n        \"service_settings\": {\n            \"api_key\": \"Cohere-API-key\",\n            \"model_id\": \"command-a-03-2025\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"cohere-completion\",\n  inference_config: {\n    service: \"cohere\",\n    service_settings: {\n      api_key: \"Cohere-API-key\",\n      model_id: \"command-a-03-2025\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"cohere-completion\",\n  body: {\n    \"service\": \"cohere\",\n    \"service_settings\": {\n      \"api_key\": \"Cohere-API-key\",\n      \"model_id\": \"command-a-03-2025\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"cohere-completion\",\n    \"body\" => [\n        \"service\" => \"cohere\",\n        \"service_settings\" => [\n            \"api_key\" => \"Cohere-API-key\",\n            \"model_id\" => \"command-a-03-2025\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"cohere\",\"service_settings\":{\"api_key\":\"Cohere-API-key\",\"model_id\":\"command-a-03-2025\"}}' \"$ELASTICSEARCH_URL/_inference/completion/cohere-completion\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"cohere-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Cohere-API-key\",\n              \"model_id\": \"command-a-03-2025\"\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/inference/put_custom/examples/request/PutCustomRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"custom-embeddings\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.openai.com/v1/embeddings\",\n            \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json;charset=utf-8\"\n            },\n            \"request\": \"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n            }\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"custom-embeddings\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.openai.com/v1/embeddings\",\n      headers: {\n        Authorization: \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json;charset=utf-8\",\n      },\n      request: '{\"input\": ${input}, \"model\": \"text-embedding-3-small\"}',\n      response: {\n        json_parser: {\n          text_embeddings: \"$.data[*].embedding[*]\",\n        },\n      },\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"custom-embeddings\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.openai.com/v1/embeddings\",\n      \"headers\": {\n        \"Authorization\": \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json;charset=utf-8\"\n      },\n      \"request\": \"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\n      \"response\": {\n        \"json_parser\": {\n          \"text_embeddings\": \"$.data[*].embedding[*]\"\n        }\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"custom-embeddings\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.openai.com/v1/embeddings\",\n            \"headers\" => [\n                \"Authorization\" => \"Bearer \\${api_key}\",\n                \"Content-Type\" => \"application/json;charset=utf-8\",\n            ],\n            \"request\" => \"{\\\"input\\\": \\${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"text_embeddings\" => \"$.data[*].embedding[*]\",\n                ],\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.openai.com/v1/embeddings\",\"headers\":{\"Authorization\":\"Bearer ${api_key}\",\"Content-Type\":\"application/json;charset=utf-8\"},\"request\":\"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\"response\":{\"json_parser\":{\"text_embeddings\":\"$.data[*].embedding[*]\"}}}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/custom-embeddings\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.openai.com/v1/embeddings\",\n              \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json;charset=utf-8\"\n              },\n              \"request\": \"{\\u0022input\\u0022: ${input}, \\u0022model\\u0022: \\u0022text-embedding-3-small\\u0022}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/inference/put_custom/examples/request/PutCustomRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"custom-rerank\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.cohere.com/v2/rerank\",\n            \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n            },\n            \"request\": \"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"reranked_index\": \"$.results[*].index\",\n                    \"relevance_score\": \"$.results[*].relevance_score\"\n                }\n            }\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.cohere.com/v2/rerank\",\n      headers: {\n        Authorization: \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\",\n      },\n      request:\n        '{\"documents\": ${input}, \"query\": ${query}, \"model\": \"rerank-v3.5\"}',\n      response: {\n        json_parser: {\n          reranked_index: \"$.results[*].index\",\n          relevance_score: \"$.results[*].relevance_score\",\n        },\n      },\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.cohere.com/v2/rerank\",\n      \"headers\": {\n        \"Authorization\": \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\"\n      },\n      \"request\": \"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\n      \"response\": {\n        \"json_parser\": {\n          \"reranked_index\": \"$.results[*].index\",\n          \"relevance_score\": \"$.results[*].relevance_score\"\n        }\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"custom-rerank\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.cohere.com/v2/rerank\",\n            \"headers\" => [\n                \"Authorization\" => \"bearer \\${api_key}\",\n                \"Content-Type\" => \"application/json\",\n            ],\n            \"request\" => \"{\\\"documents\\\": \\${input}, \\\"query\\\": \\${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"reranked_index\" => \"$.results[*].index\",\n                    \"relevance_score\" => \"$.results[*].relevance_score\",\n                ],\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.cohere.com/v2/rerank\",\"headers\":{\"Authorization\":\"bearer ${api_key}\",\"Content-Type\":\"application/json\"},\"request\":\"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\"response\":{\"json_parser\":{\"reranked_index\":\"$.results[*].index\",\"relevance_score\":\"$.results[*].relevance_score\"}}}}' \"$ELASTICSEARCH_URL/_inference/rerank/custom-rerank\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.cohere.com/v2/rerank\",\n              \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n              },\n              \"request\": \"{\\u0022documents\\u0022: ${input}, \\u0022query\\u0022: ${query}, \\u0022model\\u0022: \\u0022rerank-v3.5\\u0022}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"reranked_index\": \"$.results[*].index\",\n                  \"relevance_score\": \"$.results[*].relevance_score\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/inference/put_custom/examples/request/PutCustomRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"custom-text-embedding\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.cohere.com/v2/embed\",\n            \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n            },\n            \"request\": \"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"text_embeddings\": \"$.embeddings.float[*]\"\n                }\n            },\n            \"input_type\": {\n                \"translation\": {\n                    \"ingest\": \"search_document\",\n                    \"search\": \"search_query\"\n                },\n                \"default\": \"search_document\"\n            }\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.cohere.com/v2/embed\",\n      headers: {\n        Authorization: \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\",\n      },\n      request:\n        '{\"texts\": ${input}, \"model\": \"embed-v4.0\", \"input_type\": ${input_type}}',\n      response: {\n        json_parser: {\n          text_embeddings: \"$.embeddings.float[*]\",\n        },\n      },\n      input_type: {\n        translation: {\n          ingest: \"search_document\",\n          search: \"search_query\",\n        },\n        default: \"search_document\",\n      },\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.cohere.com/v2/embed\",\n      \"headers\": {\n        \"Authorization\": \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\"\n      },\n      \"request\": \"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\n      \"response\": {\n        \"json_parser\": {\n          \"text_embeddings\": \"$.embeddings.float[*]\"\n        }\n      },\n      \"input_type\": {\n        \"translation\": {\n          \"ingest\": \"search_document\",\n          \"search\": \"search_query\"\n        },\n        \"default\": \"search_document\"\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"custom-text-embedding\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.cohere.com/v2/embed\",\n            \"headers\" => [\n                \"Authorization\" => \"bearer \\${api_key}\",\n                \"Content-Type\" => \"application/json\",\n            ],\n            \"request\" => \"{\\\"texts\\\": \\${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": \\${input_type}}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"text_embeddings\" => \"$.embeddings.float[*]\",\n                ],\n            ],\n            \"input_type\" => [\n                \"translation\" => [\n                    \"ingest\" => \"search_document\",\n                    \"search\" => \"search_query\",\n                ],\n                \"default\" => \"search_document\",\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.cohere.com/v2/embed\",\"headers\":{\"Authorization\":\"bearer ${api_key}\",\"Content-Type\":\"application/json\"},\"request\":\"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\"response\":{\"json_parser\":{\"text_embeddings\":\"$.embeddings.float[*]\"}},\"input_type\":{\"translation\":{\"ingest\":\"search_document\",\"search\":\"search_query\"},\"default\":\"search_document\"}}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/custom-text-embedding\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.cohere.com/v2/embed\",\n              \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n              },\n              \"request\": \"{\\u0022texts\\u0022: ${input}, \\u0022model\\u0022: \\u0022embed-v4.0\\u0022, \\u0022input_type\\u0022: ${input_type}}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"text_embeddings\": \"$.embeddings.float[*]\"\n                }\n              },\n              \"input_type\": {\n                \"translation\": {\n                  \"ingest\": \"search_document\",\n                  \"search\": \"search_query\"\n                },\n                \"default\": \"search_document\"\n              }\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/inference/put_custom/examples/request/PutCustomRequestExample4.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"custom-rerank-jina\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.jina.ai/v1/rerank\",\n            \"headers\": {\n                \"Content-Type\": \"application/json\",\n                \"Authorization\": \"Bearer ${api_key}\"\n            },\n            \"request\": \"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"relevance_score\": \"$.results[*].relevance_score\",\n                    \"reranked_index\": \"$.results[*].index\"\n                }\n            }\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank-jina\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.jina.ai/v1/rerank\",\n      headers: {\n        \"Content-Type\": \"application/json\",\n        Authorization: \"Bearer ${api_key}\",\n      },\n      request:\n        '{\"model\": \"jina-reranker-v2-base-multilingual\",\"query\": ${query},\"documents\":${input}}',\n      response: {\n        json_parser: {\n          relevance_score: \"$.results[*].relevance_score\",\n          reranked_index: \"$.results[*].index\",\n        },\n      },\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank-jina\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.jina.ai/v1/rerank\",\n      \"headers\": {\n        \"Content-Type\": \"application/json\",\n        \"Authorization\": \"Bearer ${api_key}\"\n      },\n      \"request\": \"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\n      \"response\": {\n        \"json_parser\": {\n          \"relevance_score\": \"$.results[*].relevance_score\",\n          \"reranked_index\": \"$.results[*].index\"\n        }\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"custom-rerank-jina\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.jina.ai/v1/rerank\",\n            \"headers\" => [\n                \"Content-Type\" => \"application/json\",\n                \"Authorization\" => \"Bearer \\${api_key}\",\n            ],\n            \"request\" => \"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": \\${query},\\\"documents\\\":\\${input}}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"relevance_score\" => \"$.results[*].relevance_score\",\n                    \"reranked_index\" => \"$.results[*].index\",\n                ],\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.jina.ai/v1/rerank\",\"headers\":{\"Content-Type\":\"application/json\",\"Authorization\":\"Bearer ${api_key}\"},\"request\":\"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\"response\":{\"json_parser\":{\"relevance_score\":\"$.results[*].relevance_score\",\"reranked_index\":\"$.results[*].index\"}}}}' \"$ELASTICSEARCH_URL/_inference/rerank/custom-rerank-jina\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-rerank-jina\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.jina.ai/v1/rerank\",\n              \"headers\": {\n                \"Content-Type\": \"application/json\",\n                \"Authorization\": \"Bearer ${api_key}\"\n              },\n              \"request\": \"{\\u0022model\\u0022: \\u0022jina-reranker-v2-base-multilingual\\u0022,\\u0022query\\u0022: ${query},\\u0022documents\\u0022:${input}}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"relevance_score\": \"$.results[*].relevance_score\",\n                  \"reranked_index\": \"$.results[*].index\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/inference/put_custom/examples/request/PutCustomRequestExample5.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"custom-text-embedding-hf\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"<dedicated inference endpoint on HF>/v1/embeddings\",\n            \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n            },\n            \"request\": \"{\\\"input\\\": ${input}}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n            }\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding-hf\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"<dedicated inference endpoint on HF>/v1/embeddings\",\n      headers: {\n        Authorization: \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json\",\n      },\n      request: '{\"input\": ${input}}',\n      response: {\n        json_parser: {\n          text_embeddings: \"$.data[*].embedding[*]\",\n        },\n      },\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding-hf\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"<dedicated inference endpoint on HF>/v1/embeddings\",\n      \"headers\": {\n        \"Authorization\": \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json\"\n      },\n      \"request\": \"{\\\"input\\\": ${input}}\",\n      \"response\": {\n        \"json_parser\": {\n          \"text_embeddings\": \"$.data[*].embedding[*]\"\n        }\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"custom-text-embedding-hf\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"<dedicated inference endpoint on HF>/v1/embeddings\",\n            \"headers\" => [\n                \"Authorization\" => \"Bearer \\${api_key}\",\n                \"Content-Type\" => \"application/json\",\n            ],\n            \"request\" => \"{\\\"input\\\": \\${input}}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"text_embeddings\" => \"$.data[*].embedding[*]\",\n                ],\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"<dedicated inference endpoint on HF>/v1/embeddings\",\"headers\":{\"Authorization\":\"Bearer ${api_key}\",\"Content-Type\":\"application/json\"},\"request\":\"{\\\"input\\\": ${input}}\",\"response\":{\"json_parser\":{\"text_embeddings\":\"$.data[*].embedding[*]\"}}}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/custom-text-embedding-hf\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-text-embedding-hf\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"\\u003Cdedicated inference endpoint on HF\\u003E/v1/embeddings\",\n              \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n              },\n              \"request\": \"{\\u0022input\\u0022: ${input}}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
+    }
+  ],
+  "specification/streams/logs_disable/examples/request/PostStreamsDisableRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.streams.logs_disable()"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.streams.logsDisable();"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.streams.logs_disable"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->streams()->logsDisable();"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_streams/logs/_disable\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Streams.LogsDisableAsync();"
+    }
+  ],
+  "specification/streams/logs_enable/examples/request/PostStreamsEnableRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.streams.logs_enable()"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.streams.logsEnable();"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.streams.logs_enable"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->streams()->logsEnable();"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_streams/logs/_enable\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Streams.LogsEnableAsync();"
+    }
+  ],
+  "specification/streams/status/examples/request/GetStreamsStatusRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.streams.status()"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.streams.status();"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.streams.status"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->streams()->status();"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_streams/status\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.Streams.StatusAsync();"
+    }
+  ],
+  "specification/transform/put_transform/examples/request/PutTransformRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.transform.put_transform(\n    transform_id=\"ecommerce_transform3\",\n    source={\n        \"index\": \"kibana_sample_data_ecommerce\"\n    },\n    latest={\n        \"unique_key\": [\n            \"customer_id\"\n        ],\n        \"sort\": \"order_date\"\n    },\n    description=\"Latest order for each customer\",\n    dest={\n        \"index\": \"kibana_sample_data_ecommerce_transform3\",\n        \"aliases\": [\n            {\n                \"alias\": \"kibana_sample_data_ecommerce_transform\"\n            },\n            {\n                \"alias\": \"kibana_sample_data_ecommerce_transform_latest\",\n                \"move_on_creation\": True\n            }\n        ]\n    },\n    frequency=\"5m\",\n    sync={\n        \"time\": {\n            \"field\": \"order_date\",\n            \"delay\": \"60s\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.transform.putTransform({\n  transform_id: \"ecommerce_transform3\",\n  source: {\n    index: \"kibana_sample_data_ecommerce\",\n  },\n  latest: {\n    unique_key: [\"customer_id\"],\n    sort: \"order_date\",\n  },\n  description: \"Latest order for each customer\",\n  dest: {\n    index: \"kibana_sample_data_ecommerce_transform3\",\n    aliases: [\n      {\n        alias: \"kibana_sample_data_ecommerce_transform\",\n      },\n      {\n        alias: \"kibana_sample_data_ecommerce_transform_latest\",\n        move_on_creation: true,\n      },\n    ],\n  },\n  frequency: \"5m\",\n  sync: {\n    time: {\n      field: \"order_date\",\n      delay: \"60s\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.transform.put_transform(\n  transform_id: \"ecommerce_transform3\",\n  body: {\n    \"source\": {\n      \"index\": \"kibana_sample_data_ecommerce\"\n    },\n    \"latest\": {\n      \"unique_key\": [\n        \"customer_id\"\n      ],\n      \"sort\": \"order_date\"\n    },\n    \"description\": \"Latest order for each customer\",\n    \"dest\": {\n      \"index\": \"kibana_sample_data_ecommerce_transform3\",\n      \"aliases\": [\n        {\n          \"alias\": \"kibana_sample_data_ecommerce_transform\"\n        },\n        {\n          \"alias\": \"kibana_sample_data_ecommerce_transform_latest\",\n          \"move_on_creation\": true\n        }\n      ]\n    },\n    \"frequency\": \"5m\",\n    \"sync\": {\n      \"time\": {\n        \"field\": \"order_date\",\n        \"delay\": \"60s\"\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->transform()->putTransform([\n    \"transform_id\" => \"ecommerce_transform3\",\n    \"body\" => [\n        \"source\" => [\n            \"index\" => \"kibana_sample_data_ecommerce\",\n        ],\n        \"latest\" => [\n            \"unique_key\" => array(\n                \"customer_id\",\n            ),\n            \"sort\" => \"order_date\",\n        ],\n        \"description\" => \"Latest order for each customer\",\n        \"dest\" => [\n            \"index\" => \"kibana_sample_data_ecommerce_transform3\",\n            \"aliases\" => array(\n                [\n                    \"alias\" => \"kibana_sample_data_ecommerce_transform\",\n                ],\n                [\n                    \"alias\" => \"kibana_sample_data_ecommerce_transform_latest\",\n                    \"move_on_creation\" => true,\n                ],\n            ),\n        ],\n        \"frequency\" => \"5m\",\n        \"sync\" => [\n            \"time\" => [\n                \"field\" => \"order_date\",\n                \"delay\" => \"60s\",\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"kibana_sample_data_ecommerce\"},\"latest\":{\"unique_key\":[\"customer_id\"],\"sort\":\"order_date\"},\"description\":\"Latest order for each customer\",\"dest\":{\"index\":\"kibana_sample_data_ecommerce_transform3\",\"aliases\":[{\"alias\":\"kibana_sample_data_ecommerce_transform\"},{\"alias\":\"kibana_sample_data_ecommerce_transform_latest\",\"move_on_creation\":true}]},\"frequency\":\"5m\",\"sync\":{\"time\":{\"field\":\"order_date\",\"delay\":\"60s\"}}}' \"$ELASTICSEARCH_URL/_transform/ecommerce_transform3\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement\n    .PutTransformAsync(transformId: \"ecommerce_transform3\", d1 => d1\n        .Description(\"Latest order for each customer\")\n        .Dest(d2 => d2\n            .Index(\"kibana_sample_data_ecommerce_transform3\")\n        )\n        .Frequency(\"5m\")\n        .Latest(d2 => d2\n            .Sort(x => x.OrderDate)\n            .UniqueKey(x => x.CustomerId)\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"kibana_sample_data_ecommerce\" })\n        )\n        .Sync(d2 => d2\n            .Time(d3 => d3\n                .Delay(\"60s\")\n                .Field(x => x.OrderDate)\n            )\n        )\n    );"
+    }
+  ],
+  "specification/transform/set_upgrade_mode/examples/request/TransformSetUpgradeModeExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.transform.set_upgrade_mode(\n    enabled=True,\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.transform.setUpgradeMode({\n  enabled: \"true\",\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.transform.set_upgrade_mode(\n  enabled: \"true\"\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->transform()->setUpgradeMode([\n    \"enabled\" => \"true\",\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/set_upgrade_mode?enabled=true\""
+    },
+    {
+      "language": "C#",
+      "code": "var response = await client.TransformManagement\n    .SetUpgradeModeAsync(d1 => d1\n        .Enabled(true)\n    );"
     }
   ]
 }

--- a/docs/examples/package-lock.json
+++ b/docs/examples/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@elastic/request-converter": "^9.1.2",
+        "@elastic/request-converter": "~8.19.3",
+        "@elastic/request-converter-dotnet": "~8.19.3",
         "@redocly/cli": "^1.34.3",
         "java-caller": "^4.1.1",
         "yaml": "^2.8.0"
@@ -44,9 +45,9 @@
       }
     },
     "node_modules/@elastic/request-converter": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@elastic/request-converter/-/request-converter-9.1.2.tgz",
-      "integrity": "sha512-7UTpzcKMAAB75ObfUpTvsE1v00rC5zyoZf2f12KkWsxmCZvaG0RLtYXrsxufSJe9SscUqzTeEgdK/tv3ZJNhYQ==",
+      "version": "8.19.3",
+      "resolved": "https://registry.npmjs.org/@elastic/request-converter/-/request-converter-8.19.3.tgz",
+      "integrity": "sha512-xXLyPIy8kuoOv54LqMThsMw6tkOm4rDD9oMwJTwp27ifGRXTDjlJ7gLZjIxyPYCdLaN9VS9Szrmx/IYETzGAaQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64url": "^3.0.1",
@@ -57,7 +58,21 @@
       },
       "bin": {
         "es-request-converter": "dist/es-request-converter.js"
+      },
+      "peerDependencies": {
+        "@elastic/request-converter-dotnet": "~8.19.0"
+      },
+      "peerDependenciesMeta": {
+        "@elastic/request-converter-dotnet": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/@elastic/request-converter-dotnet": {
+      "version": "8.19.3",
+      "resolved": "https://registry.npmjs.org/@elastic/request-converter-dotnet/-/request-converter-dotnet-8.19.3.tgz",
+      "integrity": "sha512-JDvS5CI1ef6raUUeXCpVCehOTg7IsY1mN9gfwvXvezp/eg3sa3gqxitB7xn3ODmBEabd8DAVLlUZP2WJ7YaKOA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
@@ -157,7 +172,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -976,7 +990,6 @@
       "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -1230,7 +1243,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
@@ -1746,7 +1760,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -1945,7 +1958,6 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.13.7.tgz",
       "integrity": "sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -2470,7 +2482,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2480,7 +2491,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -2827,7 +2837,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.18.tgz",
       "integrity": "sha512-Mvf3gJFzZCkhjY2Y/Fx9z1m3dxbza0uI9H1CbNZm/jSHCojzJhQ0R7bByrlFJINnMzz/gPulpoFFGymNwrsMcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",

--- a/docs/examples/package.json
+++ b/docs/examples/package.json
@@ -4,9 +4,9 @@
   },
   "dependencies": {
     "@elastic/request-converter": "~8.19.3",
-    "@elastic/request-converter-dotnet": "~8.19.2",
+    "@elastic/request-converter-dotnet": "~8.19.3",
     "@redocly/cli": "^1.34.3",
-    "yaml": "^2.8.0",
-    "java-caller": "^4.1.1"
+    "java-caller": "^4.1.1",
+    "yaml": "^2.8.0"
   }
 }

--- a/docs/examples/package.json
+++ b/docs/examples/package.json
@@ -6,7 +6,7 @@
     "@elastic/request-converter": "~8.19.3",
     "@elastic/request-converter-dotnet": "~8.19.3",
     "@redocly/cli": "^1.34.3",
-    "java-caller": "^4.1.1",
-    "yaml": "^2.8.0"
+    "yaml": "^2.8.0",
+    "java-caller": "^4.1.1"
   }
 }

--- a/specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample1.yaml
+++ b/specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample1.yaml
@@ -1,5 +1,7 @@
 summary: A text embedding task
-description: Run `PUT _inference/text_embedding/amazon_sagemaker_embeddings` to create an inference endpoint that performs a text embedding task.
+description:
+  Run `PUT _inference/text_embedding/amazon_sagemaker_embeddings` to create an inference endpoint that performs a text
+  embedding task.
 method_request: 'PUT _inference/text_embedding/amazon_sagemaker_embeddings'
 # type: "request"
 value: |-

--- a/specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample3.yaml
+++ b/specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample3.yaml
@@ -1,5 +1,7 @@
 summary: A chat completion task
-description: Run `PUT _inference/chat_completion/amazon_sagemaker_chat_completion` to create an inference endpoint that performs a chat completion task.
+description:
+  Run `PUT _inference/chat_completion/amazon_sagemaker_chat_completion` to create an inference endpoint that performs a
+  chat completion task.
 method_request: 'PUT _inference/chat_completion/amazon_sagemaker_chat_completion'
 # type: "request"
 value: |-

--- a/specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample4.yaml
+++ b/specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample4.yaml
@@ -1,5 +1,7 @@
 summary: A sparse embedding task
-description: Run `PUT _inference/sparse_embedding/amazon_sagemaker_sparse_embedding` to create an inference endpoint that performs a sparse embedding task.
+description:
+  Run `PUT _inference/sparse_embedding/amazon_sagemaker_sparse_embedding` to create an inference endpoint that performs a
+  sparse embedding task.
 method_request: 'PUT _inference/sparse_embedding/amazon_sagemaker_sparse_embedding'
 # type: "request"
 value: |-

--- a/specification/inference/put_custom/examples/request/PutCustomRequestExample5.yaml
+++ b/specification/inference/put_custom/examples/request/PutCustomRequestExample5.yaml
@@ -1,5 +1,7 @@
 summary: Custom text embedding task (Hugging Face)
-description: Run `PUT _inference/text_embedding/custom-text-embedding-hf` to create an inference endpoint that performs a text embedding task by using the Qwen/Qwen3-Embedding-8B model.
+description:
+  Run `PUT _inference/text_embedding/custom-text-embedding-hf` to create an inference endpoint that performs a text
+  embedding task by using the Qwen/Qwen3-Embedding-8B model.
 method_request: 'PUT _inference/text_embedding/custom-text-embedding-hf'
 # type: "request"
 value: |-


### PR DESCRIPTION
Runs `make generate-language-examples` on `8.19`, using `@elastic/request-converter` 8.19.3 and `@elastic/request-converter-dotnet` 8.19.0 (the versions declared after #6532). Companion to #6528 (`main`) and #6530 (`9.5`).

## What changed

- **Adds C# examples for 564 requests.** C# generation was backported in #6527, but the generated examples themselves were never committed, so `languageExamples.json` had no C# entries at all until now. 108 requests are still skipped because the .NET request converter does not support those endpoints yet (mostly `cat.*`, `watcher.*`, `connector.*`, `logstash.*`), which the generator treats as best-effort.
- **Refreshes stale examples in Python/JavaScript/Ruby/PHP/curl.** The lockfile on this branch was still resolving `@elastic/request-converter` **9.1.2** from a stale `^9.1.2` range, i.e. a 9.x converter was being used on the 8.19 branch, and some examples had not been regenerated since their request YAML changed. Notable fixes:
  - `_bulk` and `_msearch` curl examples now send `Content-Type: application/x-ndjson` with newline-delimited documents instead of a JSON array with `application/json`.
  - `indices/put_alias` example 1 now generates `client.indices.put_alias(...)` against `my-index-2099.05.06-000001`, matching the request in the YAML; it previously generated an unrelated `client.indices.update_aliases(...)` call.
- **Each language is now rendered with its own converter policy.** Before elastic/request-converter#120 (shipped in 8.19.3), the exporters leaked their Handlebars helpers into one another, so in multi-language runs everything after the first request was rendered with the PHP exporter's supported-API and aliasing rules. With that fixed:
  - `indices.create_from`, the migrate-reindex APIs, `snapshot.repository_verify_integrity`, `connector.last_sync`, and `security.delegate_pki` generate typed Python/JavaScript/Ruby calls instead of transport-level fallbacks; they were previously suppressed by the PHP exporter's policy.
  - Python examples use valid keyword arguments again: `from_` instead of the reserved word `from`, `security_tokens`/`security_profile` instead of `security-tokens`/`security-profile`, and `index_auto_expand_replicas` instead of `index.auto_expand_replicas`. The JavaScript `ingest.put_pipeline` example keeps `_meta` instead of `meta`.
  - Ruby examples for `rollup.*`, `autoscaling.*`, and `shutdown.*` are rendered as transport-level `perform_request(...)` calls: these endpoints are deliberately marked unsupported by the Ruby exporter and only appeared as typed calls before because of the leaked PHP policy.
- **Rewraps four example descriptions** in `inference/put_amazonsagemaker` and `inference/put_custom` to the generator's 132-column width.
- **Syncs `docs/examples/package-lock.json`** to the `~8.19.3` / `~8.19.0` ranges declared in `package.json`.

The Ruby `autoscaling.put_autoscaling_policy` fallback renders its path placeholder HTML-escaped (`/_autoscaling/policy/&lt;name&gt;`); that is a converter template bug tracked in elastic/request-converter#125.

Curl and Java examples are unaffected.
