### PR TITLE
Bump @elastic/request-converter to 8.19.3

### DIFF
--- a/docs/examples/package.json
+++ b/docs/examples/package.json
@@ -3,7 +3,7 @@
     "transform-to-openapi": "npm run transform-to-openapi --prefix compiler --"
   },
   "dependencies": {
-    "@elastic/request-converter": "~8.19.2",
+    "@elastic/request-converter": "~8.19.3",
     "@elastic/request-converter-dotnet": "~8.19.0",
     "@redocly/cli": "^1.34.3",
     "yaml": "^2.8.0",


### PR DESCRIPTION
Automated bump of `@elastic/request-converter` to `~8.19.3` in `docs/examples/package.json`.

Triggered by the publish of `@elastic/request-converter@8.19.3` (dist-tag `latest-8.19`, source branch `8.19`).

The lockfile is intentionally left unchanged; CI `npm install` reconciles the new version.