### PR TITLE
Bump @elastic/request-converter to 9.4.2

### DIFF
--- a/docs/examples/package.json
+++ b/docs/examples/package.json
@@ -3,7 +3,7 @@
     "transform-to-openapi": "npm run transform-to-openapi --prefix compiler --"
   },
   "dependencies": {
-    "@elastic/request-converter": "~9.4.1",
+    "@elastic/request-converter": "~9.4.2",
     "@elastic/request-converter-dotnet": "~9.4.0",
     "@redocly/cli": "^1.34.5",
     "yaml": "^2.8.0",


### PR DESCRIPTION
Automated bump of `@elastic/request-converter` to `~9.4.2` in `docs/examples/package.json`.

Triggered by the publish of `@elastic/request-converter@9.4.2` (dist-tag `latest-9.4`, source branch `9.4`).

The lockfile is intentionally left unchanged; CI `npm install` reconciles the new version.