### PR TITLE
[8.19] CI: Add OpenAPI lint + S3 publish workflows (#6401)

### DIFF
--- a/.github/actions/build-openapi-docs/action.yml
+++ b/.github/actions/build-openapi-docs/action.yml
@@ -1,0 +1,23 @@
+name: Build OpenAPI docs specs
+description: >
+  Install dependencies and build the docs-ready OpenAPI specs at
+  output/openapi/elasticsearch-openapi-docs.json and
+  output/openapi/elasticsearch-serverless-openapi-docs.json.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node 24
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        cache: npm
+        cache-dependency-path: '**/package-lock.json'
+
+    - name: Setup Dependencies
+      shell: bash
+      run: make setup
+
+    - name: Build OpenAPI docs specs
+      shell: bash
+      run: make transform-to-openapi-for-docs

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,0 +1,37 @@
+name: openapi-lint
+
+on:
+  pull_request:
+    branches:
+      - main
+      - '8.19'
+      - '9.[0-9]+'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Build OpenAPI docs specs
+        uses: ./.github/actions/build-openapi-docs
+
+      - name: Lint stateful spec
+        uses: elastic/docs-actions/openapi/lint@v1
+        with:
+          spec-path: output/openapi/elasticsearch-openapi-docs.json
+
+      - name: Lint serverless spec
+        uses: elastic/docs-actions/openapi/lint@v1
+        with:
+          spec-path: output/openapi/elasticsearch-serverless-openapi-docs.json

--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -1,0 +1,61 @@
+name: openapi-publish
+
+on:
+  push:
+    branches:
+      - main
+      - '8.19'
+      - '9.[0-9]+'
+    paths:
+      - 'output/openapi/elasticsearch-openapi.json'
+      - 'output/openapi/elasticsearch-serverless-openapi.json'
+      - 'specification/**/examples/request/*.yaml'
+      - 'docs/examples/**'
+      - '.github/actions/build-openapi-docs/**'
+      - '.github/workflows/openapi-publish.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-lint-publish:
+    runs-on: ubuntu-latest
+    # Avoid running on forks
+    if: github.repository_owner == 'elastic'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Build OpenAPI docs specs
+        uses: ./.github/actions/build-openapi-docs
+
+      - name: Lint stateful spec
+        uses: elastic/docs-actions/openapi/lint@v1
+        with:
+          spec-path: output/openapi/elasticsearch-openapi-docs.json
+
+      - name: Lint serverless spec
+        uses: elastic/docs-actions/openapi/lint@v1
+        with:
+          spec-path: output/openapi/elasticsearch-serverless-openapi-docs.json
+
+      - name: Publish stateful spec
+        uses: elastic/docs-actions/openapi/upload@v1
+        with:
+          spec-path: output/openapi/elasticsearch-openapi-docs.json
+          spec-name: elasticsearch
+
+      # Serverless is always-latest: only publish from main.
+      - name: Publish serverless spec
+        if: github.ref_name == 'main'
+        uses: elastic/docs-actions/openapi/upload@v1
+        with:
+          spec-path: output/openapi/elasticsearch-serverless-openapi-docs.json
+          spec-name: elasticsearch-serverless


### PR DESCRIPTION
## Summary
- Manual backport of #6401 to `8.19` (automated backport failed on `specification/_doc_ids/table.csv`).
- Brings in the OpenAPI lint and S3 publish workflows, plus the shared `build-openapi-docs` composite action.
- Dropped the `table.csv` cluster-name URL fix: `8.19` uses a different doc URL and does not have the malformed double `#`.

## Notes
- Cherry-picked `91a9eb1f3a600f93659b43b92f68543fd2c359a0` with conflict resolution on `specification/_doc_ids/table.csv` (kept `8.19` content).
- On `8.19`, `make transform-to-openapi-for-docs` builds only the stateful docs spec. Serverless publish remains main-only in the workflow; confirm lint against the serverless docs path is acceptable on this branch.

## Test plan
- [ ] `openapi-lint` runs green on this PR
- [ ] After merge, a qualifying push to `8.19` publishes the stateful spec only

Related: #6401