### PR TITLE
Document transform dest.aliases and move_on_creation in the API spec

### DIFF
--- a/specification/transform/_types/Transform.ts
+++ b/specification/transform/_types/Transform.ts
@@ -24,7 +24,13 @@ import {
   HistogramAggregation,
   TermsAggregation
 } from '@_types/aggregations/bucket'
-import { Field, IndexName, Indices, ProjectRouting } from '@_types/common'
+import {
+  Field,
+  IndexAlias,
+  IndexName,
+  Indices,
+  ProjectRouting
+} from '@_types/common'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { float, integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
@@ -39,9 +45,34 @@ export class Destination {
    */
   index?: IndexName
   /**
+   * The aliases that the destination index for the transform should have.
+   * Aliases are manipulated using the stored credentials of the transform, which means the secondary credentials
+   * supplied at creation time (if both primary and secondary credentials are specified).
+   *
+   * The destination index is added to the aliases regardless of whether the destination index was created by the
+   * transform or pre-created by the user.
+   * @availability stack since=8.8.0
+   * @availability serverless
+   */
+  aliases?: DestinationAlias[]
+  /**
    * The unique identifier for an ingest pipeline.
    */
   pipeline?: string
+}
+
+export class DestinationAlias {
+  /**
+   * The name of the alias.
+   */
+  alias: IndexAlias
+  /**
+   * Whether the destination index should be the only index in this alias.
+   * If `true`, all the other indices will be removed from this alias before adding the destination index to this
+   * alias. This does not delete the removed indices; it only removes them from the alias.
+   * @server_default false
+   */
+  move_on_creation?: boolean
 }
 
 export class Latest {

--- a/specification/transform/get_transform/types.ts
+++ b/specification/transform/get_transform/types.ts
@@ -19,9 +19,9 @@
 
 import { Id, Metadata, VersionString } from '@_types/common'
 import { DateTime, Duration, EpochTime, UnitMillis } from '@_types/Time'
-import { Destination } from '@global/reindex/types'
 import { TransformAuthorization } from '@ml/_types/Authorization'
 import {
+  Destination,
   Latest,
   Pivot,
   RetentionPolicyContainer,

--- a/specification/transform/put_transform/examples/request/PutTransformRequestExample3.yaml
+++ b/specification/transform/put_transform/examples/request/PutTransformRequestExample3.yaml
@@ -1,0 +1,25 @@
+summary: A transform with destination aliases
+method_request: PUT _transform/ecommerce_transform3
+description: >
+  Run `PUT _transform/ecommerce_transform3` to create a transform that adds the destination index to aliases. With
+  `move_on_creation` set to `true`, the destination index becomes the only index in that alias.
+# type: request
+value:
+  source:
+    index: kibana_sample_data_ecommerce
+  latest:
+    unique_key:
+      - customer_id
+    sort: order_date
+  description: Latest order for each customer
+  dest:
+    index: kibana_sample_data_ecommerce_transform3
+    aliases:
+      - alias: kibana_sample_data_ecommerce_transform
+      - alias: kibana_sample_data_ecommerce_transform_latest
+        move_on_creation: true
+  frequency: 5m
+  sync:
+    time:
+      field: order_date
+      delay: 60s

--- a/specification/transform/update_transform/UpdateTransformResponse.ts
+++ b/specification/transform/update_transform/UpdateTransformResponse.ts
@@ -20,9 +20,10 @@
 import { Id, Metadata, VersionString } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
-import { Destination, Source } from '@global/reindex/types'
+import { Source } from '@global/reindex/types'
 import { TransformAuthorization } from '@ml/_types/Authorization'
 import {
+  Destination,
   Latest,
   Pivot,
   RetentionPolicyContainer,


### PR DESCRIPTION
## Summary
- Document `dest.aliases` and `move_on_creation` on the transform Destination type so they appear in the Create/Update/Get transform API docs.
- Point get/update transform responses at the transform Destination type (instead of reindex’s).
- Add a create-transform example that uses destination aliases.

Fixes elastic/docs-content#3755

#### Tested on Elasticsearch serverless, 9.5

## Preview:
<img width="928" height="610" alt="Screenshot 2026-08-05 at 11 20 30" src="https://github.com/user-attachments/assets/c39905c0-c44e-4012-8f1d-64de0bdb816c" />
<img width="630" height="609" alt="Screenshot 2026-08-05 at 11 20 42" src="https://github.com/user-attachments/assets/fc485cbe-0a13-4bc6-a623-131b1424cb63" />
<img width="551" height="728" alt="Screenshot 2026-08-05 at 11 33 15" src="https://github.com/user-attachments/assets/3083ed92-5f9b-4d2e-9de5-7807c6b50332" />
