### PR TITLE
Bump @elastic/request-converter-dotnet to 0.0.0-main.g87d82d642f4a

### DIFF
--- a/docs/examples/generate-language-examples.js
+++ b/docs/examples/generate-language-examples.js
@@ -30,6 +30,14 @@ const LANGUAGES = ['Python', 'JavaScript', 'Ruby', 'PHP', 'curl', 'C#'];
 // endpoint-coverage gaps; a failed conversion skips that language for the
 // example instead of aborting the whole run.
 const BEST_EFFORT_LANGUAGES = new Set(['C#']);
+
+const LANGUAGE_OPTIONS = {
+  'C#': {
+    client_call_format: 'inline',
+    client_call_style: 'async',
+    emit_usings: false,
+  },
+};
 const conversionFailures = [];
 
 const EXAMPLES_JSON = 'docs/examples/languageExamples.json';
@@ -56,7 +64,7 @@ async function generateLanguages(example) {
     try {
       alternatives.push({
         language: lang,
-        code: (await convertRequests(request, lang, {})).trim(),
+        code: (await convertRequests(request, lang, LANGUAGE_OPTIONS[lang] ?? {})).trim(),
       });
     } catch (err) {
       if (!BEST_EFFORT_LANGUAGES.has(lang)) {

--- a/docs/examples/package.json
+++ b/docs/examples/package.json
@@ -4,7 +4,7 @@
   },
   "dependencies": {
     "@elastic/request-converter": "~9.4.2",
-    "@elastic/request-converter-dotnet": "~9.4.0",
+    "@elastic/request-converter-dotnet": "latest-main",
     "@redocly/cli": "^1.34.5",
     "yaml": "^2.8.0",
     "java-caller": "^4.1.1"


### PR DESCRIPTION
Automated bump of `@elastic/request-converter-dotnet` to `latest-main` in `docs/examples/package.json`.

Triggered by the publish of `@elastic/request-converter-dotnet@0.0.0-main.g87d82d642f4a` (dist-tag `latest-main`, source branch `main`).

Additionally passes converter options for the C# examples: an inline async client call
(`client_call_format: inline`, `client_call_style: async`) and no `using` directives (`emit_usings: false`);
the exporter's descriptor syntax default stays in effect.

The lockfile is intentionally left unchanged; CI `npm install` reconciles the new version.