### PR TITLE
fix(ci): switch backport resolver to openrouter secrets

### DIFF
--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   resolve:
+    if: |
+      (github.event.comment.user.login == 'github-actions[bot]' ||
+       github.event.comment.user.login == 'elastic-vault-github-plugin-prod[bot]') &&
+      contains(github.event.comment.body, 'To backport manually, run these commands')
     uses: elastic/clients-team-automations/.github/workflows/ai-backport-resolver.yml@main
     with:
       comment_body: ${{ github.event.comment.body }}
@@ -14,4 +18,5 @@ jobs:
       generated_paths: "output/"
       regenerate_command: "make setup && make compile && make generate && make transform-to-openapi"
     secrets:
-      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      OPENROUTER_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}


### PR DESCRIPTION
Every trigger of the AI Backport Resolver has been failing with `startup_failure` since the repo's `LITELLM_API_KEY` secret was swapped for `OPENROUTER_API_KEY`/`OPENROUTER_BASE_URL`; the reusable workflow could no longer resolve its required secret. Updates the caller to pass the new secrets, matching the OpenRouter switch in `elastic/clients-team-automations#37`.

Also adds a job-level `if` so the reusable workflow isn't invoked at all for comments that aren't backport failure comments from the backport bot, instead of spinning up a runner for every comment in the repo just to skip through the check step.