### PR TITLE
Regenerate language examples

### DIFF
--- a/docs/examples/languageExamples.json
+++ b/docs/examples/languageExamples.json
@@ -792,7 +792,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.SearchableSnapshots\n    .MountAsync(repository: \"my_repository\", snapshot: \"my_snapshot\", d1 => d1\n        .WaitForCompletion(true)\n        .IgnoreIndexSettings(\"index.refresh_interval\")\n        .Index(\"my_docs\")\n        .IndexSettings(new Dictionary<string, object>()\n        {\n            { \"index.number_of_replicas\", 0 }\n        })\n        .RenamedIndex(\"docs\")\n    );"
+      "code": "var response = await client.SearchableSnapshots\n    .MountAsync(repository: \"my_repository\", snapshot: \"my_snapshot\", d1 => d1\n        .WaitForCompletion(true)\n        .IgnoreIndexSettings(\"index.refresh_interval\")\n        .Index(\"my_docs\")\n        .IndexSettings(new Dictionary<string, object>()\n        {\n            { \"index.number_of_replicas\", 0 }\n        })\n        .RenamedIndex(\"docs\")\n    );"
     },
     {
       "language": "Java",
@@ -882,7 +882,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Snapshot;\n\nvar response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_s3_repository\", d1 => d1\n        .Repository(new S3Repository()\n        {\n            Settings = new()\n            {\n                Bucket = \"my-bucket\"\n            }\n        })\n    );"
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_s3_repository\", d1 => d1\n        .Repository(new S3Repository()\n        {\n            Settings = new()\n            {\n                Bucket = \"my-bucket\"\n            }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -912,7 +912,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Snapshot;\n\nvar response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_src_only_repository\", d1 => d1\n        .Repository(new SourceOnlyRepository()\n        {\n            Settings = new SourceOnlyRepositorySettingsForSharedFileSystem()\n            {\n                Location = \"my_backup_repository\"\n            }\n        })\n    );"
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_src_only_repository\", d1 => d1\n        .Repository(new SourceOnlyRepository()\n        {\n            Settings = new SourceOnlyRepositorySettingsForSharedFileSystem()\n            {\n                Location = \"my_backup_repository\"\n            }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -942,7 +942,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Snapshot;\n\nvar response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_backup\", d1 => d1\n        .Repository(new AzureRepository()\n        {\n            Settings = new()\n            {\n                Client = \"secondary\"\n            }\n        })\n    );"
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_backup\", d1 => d1\n        .Repository(new AzureRepository()\n        {\n            Settings = new()\n            {\n                Client = \"secondary\"\n            }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -972,7 +972,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Snapshot;\n\nvar response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_gcs_repository\", d1 => d1\n        .Repository(new GcsRepository()\n        {\n            Settings = new()\n            {\n                BasePath = \"dev\",\n                Bucket = \"my_other_bucket\"\n            }\n        })\n    );"
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_gcs_repository\", d1 => d1\n        .Repository(new GcsRepository()\n        {\n            Settings = new()\n            {\n                BasePath = \"dev\",\n                Bucket = \"my_other_bucket\"\n            }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -1002,7 +1002,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Snapshot;\n\nvar response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_repository\", d1 => d1\n        .Repository(new SharedFileSystemRepository()\n        {\n            Settings = new()\n            {\n                Location = \"my_backup_location\"\n            }\n        })\n    );"
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_repository\", d1 => d1\n        .Repository(new SharedFileSystemRepository()\n        {\n            Settings = new()\n            {\n                Location = \"my_backup_location\"\n            }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -1032,7 +1032,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Snapshot;\n\nvar response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_read_only_url_repository\", d1 => d1\n        .Repository(new ReadOnlyUrlRepository()\n        {\n            Settings = new()\n            {\n                Url = \"file:/mount/backups/my_fs_backup_location\"\n            }\n        })\n    );"
+      "code": "var response = await client.Snapshot\n    .CreateRepositoryAsync(name: \"my_read_only_url_repository\", d1 => d1\n        .Repository(new ReadOnlyUrlRepository()\n        {\n            Settings = new()\n            {\n                Url = \"file:/mount/backups/my_fs_backup_location\"\n            }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -1122,7 +1122,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Snapshot;\n\nvar response = await client.Snapshot\n    .GetAsync(repository: \"my_repository\", snapshot: new[] { \"snapshot_*\" }, d1 => d1\n        .FromSortValue(\"1577833200000\")\n        .Sort(SnapshotSort.StartTime)\n    );"
+      "code": "var response = await client.Snapshot\n    .GetAsync(repository: \"my_repository\", snapshot: new[] { \"snapshot_*\" }, d1 => d1\n        .FromSortValue(\"1577833200000\")\n        .Sort(SnapshotSort.StartTime)\n    );"
     },
     {
       "language": "Java",
@@ -1152,7 +1152,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client.Snapshot\n    .RepositoryAnalyzeAsync(name: \"my_repository\", d1 => d1\n        .BlobCount(10)\n        .MaxBlobSize(new ByteSize(\"1mb\"))\n        .Timeout(\"120s\")\n    );"
+      "code": "var response = await client.Snapshot\n    .RepositoryAnalyzeAsync(name: \"my_repository\", d1 => d1\n        .BlobCount(10)\n        .MaxBlobSize(new ByteSize(\"1mb\"))\n        .Timeout(\"120s\")\n    );"
     },
     {
       "language": "Java",
@@ -1332,7 +1332,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Snapshot\n    .CreateAsync(repository: \"my_repository\", snapshot: \"snapshot_2\", d1 => d1\n        .WaitForCompletion(true)\n        .IgnoreUnavailable(true)\n        .IncludeGlobalState(false)\n        .Indices(new[] { \"index_1,index_2\" })\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"taken_by\", \"user123\" },\n            { \"taken_because\", \"backup before upgrading\" }\n        })\n        .Partial(true)\n    );"
+      "code": "var response = await client.Snapshot\n    .CreateAsync(repository: \"my_repository\", snapshot: \"snapshot_2\", d1 => d1\n        .WaitForCompletion(true)\n        .IgnoreUnavailable(true)\n        .IncludeGlobalState(false)\n        .Indices(new[] { \"index_1,index_2\" })\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"taken_by\", \"user123\" },\n            { \"taken_because\", \"backup before upgrading\" }\n        })\n        .Partial(true)\n    );"
     },
     {
       "language": "Java",
@@ -1512,7 +1512,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Cluster\n    .PutComponentTemplateAsync(name: \"template_1\", d1 => d1\n        .Template(d2 => d2\n            .Aliases(d3 => d3\n                .Add(\"alias1\", new Alias())\n                .Add(\"alias2\", d4 => d4\n                    .Filter(d5 => d5\n                        .Term(d6 => d6\n                            .Field(x => x.User.Id)\n                            .Value(\"kimchy\")\n                        )\n                    )\n                    .Routing(\"shard-1\")\n                )\n                .Add(\"{index}-alias\", new Alias())\n            )\n            .Settings(d3 => d3\n                .NumberOfShards(1)\n            )\n        )\n    );"
+      "code": "var response = await client.Cluster\n    .PutComponentTemplateAsync(name: \"template_1\", d1 => d1\n        .Template(d2 => d2\n            .Aliases(d3 => d3\n                .Add(\"alias1\", new Alias())\n                .Add(\"alias2\", d4 => d4\n                    .Filter(d5 => d5\n                        .Term(d6 => d6\n                            .Field(x => x.User.Id)\n                            .Value(\"kimchy\")\n                        )\n                    )\n                    .Routing(\"shard-1\")\n                )\n                .Add(\"{index}-alias\", new Alias())\n            )\n            .Settings(d3 => d3\n                .NumberOfShards(1)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -1628,7 +1628,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Cluster\n    .PutSettingsAsync(d1 => d1\n        .Persistent(new Dictionary<string, object>()\n        {\n            { \"action.auto_create_index\", \"my-index-000001,index10,-index1*,+ind*\" }\n        })\n    );"
+      "code": "var response = await client.Cluster\n    .PutSettingsAsync(d1 => d1\n        .Persistent(new Dictionary<string, object>()\n        {\n            { \"action.auto_create_index\", \"my-index-000001,index10,-index1*,+ind*\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -1658,7 +1658,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Cluster\n    .PutSettingsAsync(d1 => d1\n        .Persistent(new Dictionary<string, object>()\n        {\n            { \"indices.recovery.max_bytes_per_sec\", \"50mb\" }\n        })\n    );"
+      "code": "var response = await client.Cluster\n    .PutSettingsAsync(d1 => d1\n        .Persistent(new Dictionary<string, object>()\n        {\n            { \"indices.recovery.max_bytes_per_sec\", \"50mb\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -1744,7 +1744,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client.Cluster.InfoAsync(target: [ClusterInfoTarget.All]);"
+      "code": "var response = await client.Cluster.InfoAsync(target: [ClusterInfoTarget.All]);"
     },
     {
       "language": "Java",
@@ -1972,7 +1972,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Indices\n    .SimulateTemplateAsync(d1 => d1\n        .ComposedOf([\"ct2\"])\n        .IndexPatterns(new[] { \"my-index-*\" })\n        .Priority(10L)\n        .Template(d2 => d2\n            .Settings(d3 => d3\n                .OtherSettings(new Dictionary<string, object>()\n                {\n                    { \"index.number_of_replicas\", 1 }\n                })\n            )\n        )\n    );"
+      "code": "var response = await client.Indices\n    .SimulateTemplateAsync(d1 => d1\n        .ComposedOf([\"ct2\"])\n        .IndexPatterns(new[] { \"my-index-*\" })\n        .Priority(10L)\n        .Template(d2 => d2\n            .Settings(d3 => d3\n                .OtherSettings(new Dictionary<string, object>()\n                {\n                    { \"index.number_of_replicas\", 1 }\n                })\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -2002,7 +2002,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Indices\n    .SplitAsync(index: \"my-index-000001\", target: \"split-my-index-000001\", d1 => d1\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.number_of_shards\", 2 }\n        })\n    );"
+      "code": "var response = await client.Indices\n    .SplitAsync(index: \"my-index-000001\", target: \"split-my-index-000001\", d1 => d1\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.number_of_shards\", 2 }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -2062,7 +2062,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices\n    .ExistsAliasAsync(new ExistsAliasRequest()\n    {\n        Name = new[] { \"my-alias\" }\n    });"
+      "code": "var response = await client.Indices\n    .ExistsAliasAsync(new ExistsAliasRequest()\n    {\n        Name = new[] { \"my-alias\" }\n    });"
     },
     {
       "language": "Java",
@@ -2238,7 +2238,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices\n    .PutTemplateAsync(name: \"template_1\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"alias1\", new Alias())\n            .Add(\"alias2\", d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n                .Routing(\"shard-1\")\n            )\n            .Add(\"{index}-alias\", new Alias())\n        )\n        .IndexPatterns(\"te*\")\n        .Settings(d2 => d2\n            .NumberOfShards(1)\n        )\n    );"
+      "code": "var response = await client.Indices\n    .PutTemplateAsync(name: \"template_1\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"alias1\", new Alias())\n            .Add(\"alias2\", d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n                .Routing(\"shard-1\")\n            )\n            .Add(\"{index}-alias\", new Alias())\n        )\n        .IndexPatterns(\"te*\")\n        .Settings(d2 => d2\n            .NumberOfShards(1)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -2448,7 +2448,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client.Indices\n    .GetSettingsAsync(d1 => d1\n        .Indices(new[] { \"_all\" })\n        .ExpandWildcards(ExpandWildcard.All)\n    );"
+      "code": "var response = await client.Indices\n    .GetSettingsAsync(d1 => d1\n        .Indices(new[] { \"_all\" })\n        .ExpandWildcards(ExpandWildcard.All)\n    );"
     },
     {
       "language": "Java",
@@ -2598,7 +2598,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client.Indices\n    .ResolveIndexAsync(name: new[] { \"f*\", \"remoteCluster1:bar*\" }, d1 => d1\n        .ExpandWildcards(ExpandWildcard.All)\n    );"
+      "code": "var response = await client.Indices\n    .ResolveIndexAsync(name: new[] { \"f*\", \"remoteCluster1:bar*\" }, d1 => d1\n        .ExpandWildcards(ExpandWildcard.All)\n    );"
     },
     {
       "language": "Java",
@@ -3100,7 +3100,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Indices\n    .ShrinkAsync(index: \"my_source_index\", target: \"my_target_index\", d1 => d1\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.routing.allocation.require._name\", null },\n            { \"index.blocks.write\", null }\n        })\n    );"
+      "code": "var response = await client.Indices\n    .ShrinkAsync(index: \"my_source_index\", target: \"my_target_index\", d1 => d1\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.routing.allocation.require._name\", null },\n            { \"index.blocks.write\", null }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -3246,7 +3246,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices\n    .RolloverAsync(new RolloverRequest()\n    {\n        Alias = \"my-data-stream\",\n        Conditions = new()\n        {\n            MaxAge = \"7d\",\n            MaxDocs = 1000L,\n            MaxPrimaryShardDocs = 2000L,\n            MaxPrimaryShardSize = new ByteSize(\"50gb\")\n        }\n    });"
+      "code": "var response = await client.Indices\n    .RolloverAsync(new RolloverRequest()\n    {\n        Alias = \"my-data-stream\",\n        Conditions = new()\n        {\n            MaxAge = \"7d\",\n            MaxDocs = 1000L,\n            MaxPrimaryShardDocs = 2000L,\n            MaxPrimaryShardSize = new ByteSize(\"50gb\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -3426,7 +3426,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices\n    .PutIndexTemplateAsync(name: \"template_1\", d1 => d1\n        .IndexPatterns(new[] { \"template*\" })\n        .Template(d2 => d2\n            .Aliases(d3 => d3\n                .Add(\"alias1\", new Alias())\n                .Add(\"alias2\", d4 => d4\n                    .Filter(d5 => d5\n                        .Term(d6 => d6\n                            .Field(x => x.User.Id)\n                            .Value(\"kimchy\")\n                        )\n                    )\n                    .Routing(\"shard-1\")\n                )\n                .Add(\"{index}-alias\", new Alias())\n            )\n            .Settings(d3 => d3\n                .NumberOfShards(1)\n            )\n        )\n    );"
+      "code": "var response = await client.Indices\n    .PutIndexTemplateAsync(name: \"template_1\", d1 => d1\n        .IndexPatterns(new[] { \"template*\" })\n        .Template(d2 => d2\n            .Aliases(d3 => d3\n                .Add(\"alias1\", new Alias())\n                .Add(\"alias2\", d4 => d4\n                    .Filter(d5 => d5\n                        .Term(d6 => d6\n                            .Field(x => x.User.Id)\n                            .Value(\"kimchy\")\n                        )\n                    )\n                    .Routing(\"shard-1\")\n                )\n                .Add(\"{index}-alias\", new Alias())\n            )\n            .Settings(d3 => d3\n                .NumberOfShards(1)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -3456,7 +3456,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\nusing System.Collections.Generic;\n\nvar response = await client.Indices\n    .CloneAsync(index: \"my_source_index\", target: \"my_target_index\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"my_search_indices\", new Alias())\n        )\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.refresh_interval\", \"2s\" }\n        })\n    );"
+      "code": "var response = await client.Indices\n    .CloneAsync(index: \"my_source_index\", target: \"my_target_index\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"my_search_indices\", new Alias())\n        )\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.refresh_interval\", \"2s\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -3804,7 +3804,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices\n    .ShardStoresAsync(d1 => d1\n        .Status(ShardStoreStatus.Green)\n    );"
+      "code": "var response = await client.Indices\n    .ShardStoresAsync(d1 => d1\n        .Status(ShardStoreStatus.Green)\n    );"
     },
     {
       "language": "Java",
@@ -3894,7 +3894,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices.RemoveBlockAsync(indices: new[] { \"my-index-000001\" }, block: IndicesBlockOptions.Write);"
+      "code": "var response = await client.Indices.RemoveBlockAsync(indices: new[] { \"my-index-000001\" }, block: IndicesBlockOptions.Write);"
     },
     {
       "language": "Java",
@@ -3924,7 +3924,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.QueryDsl;\n\nvar response = await client.Indices\n    .PutAliasAsync(indices: new[] { \"my-index-2099.05.06-000001\" }, name: \"my-alias\", d1 => d1\n        .Filter(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Range(new UntypedRangeQuery()\n                    {\n                        Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Timestamp),\n                        Gte = \"now-1d/d\",\n                        Lt = \"now/d\"\n                    }), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n            )\n        )\n    );"
+      "code": "var response = await client.Indices\n    .PutAliasAsync(indices: new[] { \"my-index-2099.05.06-000001\" }, name: \"my-alias\", d1 => d1\n        .Filter(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Range(new UntypedRangeQuery()\n                    {\n                        Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Timestamp),\n                        Gte = \"now-1d/d\",\n                        Lt = \"now/d\"\n                    }), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -3954,7 +3954,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Indices\n    .PutDataStreamSettingsAsync(name: new[] { \"my-data-stream\" }, d1 => d1\n        .Settings(d2 => d2\n            .OtherSettings(new Dictionary<string, object>()\n            {\n                { \"index.lifecycle.name\", \"new-test-policy\" },\n                { \"index.number_of_shards\", 11 }\n            })\n        )\n    );"
+      "code": "var response = await client.Indices\n    .PutDataStreamSettingsAsync(name: new[] { \"my-data-stream\" }, d1 => d1\n        .Settings(d2 => d2\n            .OtherSettings(new Dictionary<string, object>()\n            {\n                { \"index.lifecycle.name\", \"new-test-policy\" },\n                { \"index.number_of_shards\", 11 }\n            })\n        )\n    );"
     },
     {
       "language": "Java",
@@ -3984,7 +3984,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices\n    .GetFieldMappingAsync(new GetFieldMappingRequest()\n    {\n        Fields = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.Title),\n        Indices = new[] { \"publications\" }\n    });"
+      "code": "var response = await client.Indices\n    .GetFieldMappingAsync(new GetFieldMappingRequest()\n    {\n        Fields = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.Title),\n        Indices = new[] { \"publications\" }\n    });"
     },
     {
       "language": "Java",
@@ -4014,7 +4014,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices\n    .MigrateReindexAsync(d1 => d1\n        .Reindex(d2 => d2\n            .Mode(ModeEnum.Upgrade)\n            .Source(d3 => d3\n                .Index(\"my-data-stream\")\n            )\n        )\n    );"
+      "code": "var response = await client.Indices\n    .MigrateReindexAsync(d1 => d1\n        .Reindex(d2 => d2\n            .Mode(ModeEnum.Upgrade)\n            .Source(d3 => d3\n                .Index(\"my-data-stream\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4104,7 +4104,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices\n    .CreateAsync(index: \"test\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"alias_1\", new Alias())\n            .Add(\"alias_2\", d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n                .Routing(\"shard-1\")\n            )\n        )\n    );"
+      "code": "var response = await client.Indices\n    .CreateAsync(index: \"test\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"alias_1\", new Alias())\n            .Add(\"alias_2\", d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n                .Routing(\"shard-1\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4224,7 +4224,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client.Indices\n    .StatsAsync(d1 => d1\n        .Metric(CommonStatsFlag.Fielddata)\n        .Fields(x => x.MyJoinField)\n    );"
+      "code": "var response = await client.Indices\n    .StatsAsync(d1 => d1\n        .Metric(CommonStatsFlag.Fielddata)\n        .Fields(x => x.MyJoinField)\n    );"
     },
     {
       "language": "Java",
@@ -4434,7 +4434,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Core.ScriptsPainlessExecute;\nusing System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client\n    .ScriptsPainlessExecuteAsync<MyDocument, MyDocument>(d1 => d1\n        .Context(PainlessContext.Filter)\n        .ContextSetup(d2 => d2\n            .Document(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field\": \"four\"\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\")\n        )\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"max_length\", 4 }\n            })\n            .Source(\"doc['field'].value.length() <= params.max_length\")\n        )\n    );"
+      "code": "var response = await client\n    .ScriptsPainlessExecuteAsync<MyDocument, MyDocument>(d1 => d1\n        .Context(PainlessContext.Filter)\n        .ContextSetup(d2 => d2\n            .Document(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field\": \"four\"\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\")\n        )\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"max_length\", 4 }\n            })\n            .Source(\"doc['field'].value.length() <= params.max_length\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4464,7 +4464,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Core.ScriptsPainlessExecute;\nusing System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client\n    .ScriptsPainlessExecuteAsync<MyDocument, MyDocument>(d1 => d1\n        .Context(PainlessContext.Score)\n        .ContextSetup(d2 => d2\n            .Document(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"rank\": 4\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\")\n        )\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"max_rank\", 5 }\n            })\n            .Source(\"doc['rank'].value / params.max_rank\")\n        )\n    );"
+      "code": "var response = await client\n    .ScriptsPainlessExecuteAsync<MyDocument, MyDocument>(d1 => d1\n        .Context(PainlessContext.Score)\n        .ContextSetup(d2 => d2\n            .Document(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"rank\": 4\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\")\n        )\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"max_rank\", 5 }\n            })\n            .Source(\"doc['rank'].value / params.max_rank\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4494,7 +4494,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client\n    .ScriptsPainlessExecuteAsync<MyDocument, MyDocument>(d1 => d1\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 100 },\n                { \"total\", 1000 }\n            })\n            .Source(\"params.count / params.total\")\n        )\n    );"
+      "code": "var response = await client\n    .ScriptsPainlessExecuteAsync<MyDocument, MyDocument>(d1 => d1\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 100 },\n                { \"total\", 1000 }\n            })\n            .Source(\"params.count / params.total\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4554,7 +4554,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Core.MSearch;\nusing Elastic.Clients.Elasticsearch.Core.MSearchTemplate;\nusing System.Collections.Generic;\n\nvar response = await client\n    .MultiSearchTemplateAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"my-index\" })\n        .SearchTemplates([new SearchTemplateRequestItem(new MultisearchHeader(), new TemplateConfig()\n        {\n            Id = \"my-search-template\",\n            Params = new Dictionary<string, object>()\n            {\n                { \"query_string\", \"hello world\" },\n                { \"from\", 0 },\n                { \"size\", 10 }\n            }\n        }), new SearchTemplateRequestItem(new MultisearchHeader(), new TemplateConfig()\n        {\n            Id = \"my-other-search-template\",\n            Params = new Dictionary<string, object>()\n            {\n                { \"query_type\", \"match_all\" }\n            }\n        })])\n    );"
+      "code": "var response = await client\n    .MultiSearchTemplateAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"my-index\" })\n        .SearchTemplates([new SearchTemplateRequestItem(new MultisearchHeader(), new TemplateConfig()\n        {\n            Id = \"my-search-template\",\n            Params = new Dictionary<string, object>()\n            {\n                { \"query_string\", \"hello world\" },\n                { \"from\", 0 },\n                { \"size\", 10 }\n            }\n        }), new SearchTemplateRequestItem(new MultisearchHeader(), new TemplateConfig()\n        {\n            Id = \"my-other-search-template\",\n            Params = new Dictionary<string, object>()\n            {\n                { \"query_type\", \"match_all\" }\n            }\n        })])\n    );"
     }
   ],
   "specification/_global/terms_enum/examples/request/TermsEnumRequestExample1.yaml": [
@@ -4610,7 +4610,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Core.Bulk;\nusing System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkIndexOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field\": \"value1\",\n              \"work_location\": \"41.12,-71.34\",\n              \"raw_location\": \"41.12,-71.34\"\n            }\n            \"\"\"))\n            {\n                Id = \"1\",\n                Index = \"my_index\",\n                DynamicTemplates = new Dictionary<string, string>()\n                {\n                    { \"work_location\", \"geo_point\" }\n                }\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkCreateOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field\": \"value2\",\n              \"home_location\": \"41.12,-71.34\"\n            }\n            \"\"\"))\n            {\n                Id = \"2\",\n                Index = \"my_index\",\n                DynamicTemplates = new Dictionary<string, string>()\n                {\n                    { \"home_location\", \"geo_point\" }\n                }\n            }\n        }\n    });"
+      "code": "var response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkIndexOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field\": \"value1\",\n              \"work_location\": \"41.12,-71.34\",\n              \"raw_location\": \"41.12,-71.34\"\n            }\n            \"\"\"))\n            {\n                Id = \"1\",\n                Index = \"my_index\",\n                DynamicTemplates = new Dictionary<string, string>()\n                {\n                    { \"work_location\", \"geo_point\" }\n                }\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkCreateOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field\": \"value2\",\n              \"home_location\": \"41.12,-71.34\"\n            }\n            \"\"\"))\n            {\n                Id = \"2\",\n                Index = \"my_index\",\n                DynamicTemplates = new Dictionary<string, string>()\n                {\n                    { \"home_location\", \"geo_point\" }\n                }\n            }\n        }\n    });"
     }
   ],
   "specification/_global/bulk/examples/request/BulkRequestExample3.yaml": [
@@ -4636,7 +4636,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Core.Bulk;\nusing System.Text.Json;\n\nvar response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"5\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"my_field\": \"foo\"\n                }\n                \"\"\")\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"6\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"my_field\": \"foo\"\n                }\n                \"\"\")\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkCreateOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"my_field\": \"foo\"\n            }\n            \"\"\"))\n            {\n                Id = \"7\",\n                Index = \"index1\"\n            }\n        }\n    });"
+      "code": "var response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"5\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"my_field\": \"foo\"\n                }\n                \"\"\")\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"6\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"my_field\": \"foo\"\n                }\n                \"\"\")\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkCreateOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"my_field\": \"foo\"\n            }\n            \"\"\"))\n            {\n                Id = \"7\",\n                Index = \"index1\"\n            }\n        }\n    });"
     }
   ],
   "specification/_global/bulk/examples/request/BulkRequestExample2.yaml": [
@@ -4662,7 +4662,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Core.Bulk;\nusing Elastic.Clients.Elasticsearch.Core.Search;\nusing System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"1\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\"),\n                RetryOnConflict = 3\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"0\")\n            {\n                Index = \"index1\",\n                Upsert = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"counter\": 1\n                }\n                \"\"\"),\n                Script = new()\n                {\n                    Lang = ScriptLanguage.Painless,\n                    Params = new Dictionary<string, object>()\n                    {\n                        { \"param1\", 1 }\n                    },\n                    Source = \"ctx._source.counter += params.param1\"\n                },\n                RetryOnConflict = 3\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"2\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\"),\n                DocAsUpsert = true,\n                RetryOnConflict = 3\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"3\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\")\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"4\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\"),\n                Source = new global::Elastic.Clients.Elasticsearch.Union<bool, SourceFilter>(true)\n            }\n        }\n    });"
+      "code": "var response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"1\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\"),\n                RetryOnConflict = 3\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"0\")\n            {\n                Index = \"index1\",\n                Upsert = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"counter\": 1\n                }\n                \"\"\"),\n                Script = new()\n                {\n                    Lang = ScriptLanguage.Painless,\n                    Params = new Dictionary<string, object>()\n                    {\n                        { \"param1\", 1 }\n                    },\n                    Source = \"ctx._source.counter += params.param1\"\n                },\n                RetryOnConflict = 3\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"2\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\"),\n                DocAsUpsert = true,\n                RetryOnConflict = 3\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"3\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\")\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"4\")\n            {\n                Index = \"index1\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field\": \"value\"\n                }\n                \"\"\"),\n                Source = new global::Elastic.Clients.Elasticsearch.Union<bool, SourceFilter>(true)\n            }\n        }\n    });"
     }
   ],
   "specification/_global/bulk/examples/request/BulkRequestExample1.yaml": [
@@ -4688,7 +4688,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Core.Bulk;\nusing System.Text.Json;\n\nvar response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkIndexOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field1\": \"value1\"\n            }\n            \"\"\"))\n            {\n                Id = \"1\",\n                Index = \"test\"\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkDeleteOperation(\"2\")\n            {\n                Index = \"test\"\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkCreateOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field1\": \"value3\"\n            }\n            \"\"\"))\n            {\n                Id = \"3\",\n                Index = \"test\"\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"1\")\n            {\n                Index = \"test\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field2\": \"value2\"\n                }\n                \"\"\")\n            }\n        }\n    });"
+      "code": "var response = await client\n    .BulkAsync(new BulkRequest()\n    {\n        Operations = new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkOperationsCollection\n        {\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkIndexOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field1\": \"value1\"\n            }\n            \"\"\"))\n            {\n                Id = \"1\",\n                Index = \"test\"\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkDeleteOperation(\"2\")\n            {\n                Index = \"test\"\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkCreateOperation<object>(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"field1\": \"value3\"\n            }\n            \"\"\"))\n            {\n                Id = \"3\",\n                Index = \"test\"\n            },\n            new global::Elastic.Clients.Elasticsearch.Core.Bulk.BulkUpdateOperation<object, object>(\"1\")\n            {\n                Index = \"test\",\n                Doc = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"field2\": \"value2\"\n                }\n                \"\"\")\n            }\n        }\n    });"
     }
   ],
   "specification/_global/explain/examples/request/ExplainRequestExample1.yaml": [
@@ -4774,7 +4774,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client\n    .SearchTemplateAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"my-index\" })\n        .Id(\"my-search-template\")\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"hello world\" },\n            { \"from\", 0 },\n            { \"size\", 10 }\n        })\n    );"
+      "code": "var response = await client\n    .SearchTemplateAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"my-index\" })\n        .Id(\"my-search-template\")\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"hello world\" },\n            { \"from\", 0 },\n            { \"size\", 10 }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -4834,7 +4834,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"tag\", \"green\" }\n            })\n            .Source(\"if (ctx._source.tags.contains(params.tag)) { ctx.op = 'delete' } else { ctx.op = 'noop' }\")\n        )\n    );"
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"tag\", \"green\" }\n            })\n            .Source(\"if (ctx._source.tags.contains(params.tag)) { ctx.op = 'delete' } else { ctx.op = 'noop' }\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4894,7 +4894,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 4 }\n            })\n            .Source(\"ctx._source.counter += params.count\")\n        )\n    );"
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 4 }\n            })\n            .Source(\"ctx._source.counter += params.count\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4924,7 +4924,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"tag\", \"blue\" }\n            })\n            .Source(\"if (ctx._source.tags.contains(params.tag)) { ctx._source.tags.remove(ctx._source.tags.indexOf(params.tag)) }\")\n        )\n    );"
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"tag\", \"blue\" }\n            })\n            .Source(\"if (ctx._source.tags.contains(params.tag)) { ctx._source.tags.remove(ctx._source.tags.indexOf(params.tag)) }\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -4954,7 +4954,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"tag\", \"blue\" }\n            })\n            .Source(\"ctx._source.tags.add(params.tag)\")\n        )\n    );"
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"tag\", \"blue\" }\n            })\n            .Source(\"ctx._source.tags.add(params.tag)\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5014,7 +5014,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 4 }\n            })\n            .Source(\"\\n      if ( ctx.op == 'create' ) {\\n        ctx._source.counter = params.count\\n      } else {\\n        ctx._source.counter += params.count\\n      }\\n    \")\n        )\n        .ScriptedUpsert(true)\n        .Upsert(new MyDocument())\n    );"
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 4 }\n            })\n            .Source(\"\\n      if ( ctx.op == 'create' ) {\\n        ctx._source.counter = params.count\\n      } else {\\n        ctx._source.counter += params.count\\n      }\\n    \")\n        )\n        .ScriptedUpsert(true)\n        .Upsert(new MyDocument())\n    );"
     },
     {
       "language": "Java",
@@ -5044,7 +5044,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 4 }\n            })\n            .Source(\"ctx._source.counter += params.count\")\n        )\n        .Upsert(new MyDocument()\n        {\n            Counter = 1\n        })\n    );"
+      "code": "var response = await client\n    .UpdateAsync<MyDocument, MyDocument>(index: \"test\", id: \"1\", d1 => d1\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Params(new Dictionary<string, object>()\n            {\n                { \"count\", 4 }\n            })\n            .Source(\"ctx._source.counter += params.count\")\n        )\n        .Upsert(new MyDocument()\n        {\n            Counter = 1\n        })\n    );"
     },
     {
       "language": "Java",
@@ -5194,7 +5194,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client\n    .UpdateByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Refresh(true)\n        .Slices(new Slices(5))\n        .Script(d2 => d2\n            .Source(\"ctx._source['extra'] = 'test'\")\n        )\n    );"
+      "code": "var response = await client\n    .UpdateByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Refresh(true)\n        .Slices(new Slices(5))\n        .Script(d2 => d2\n            .Source(\"ctx._source['extra'] = 'test'\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5224,7 +5224,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client\n    .UpdateByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.User.Id)\n                .Value(\"kimchy\")\n            )\n        )\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Source(\"ctx._source.count++\")\n        )\n    );"
+      "code": "var response = await client\n    .UpdateByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.User.Id)\n                .Value(\"kimchy\")\n            )\n        )\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Source(\"ctx._source.count++\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5366,7 +5366,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client\n    .PutScriptAsync(new PutScriptRequest()\n    {\n        Id = \"my-stored-script\",\n        Script = new()\n        {\n            Language = ScriptLanguage.Painless,\n            Source = \"Math.log(_score * 2) + params['my_modifier']\"\n        }\n    });"
+      "code": "var response = await client\n    .PutScriptAsync(new PutScriptRequest()\n    {\n        Id = \"my-stored-script\",\n        Script = new()\n        {\n            Language = ScriptLanguage.Painless,\n            Source = \"Math.log(_score * 2) + params['my_modifier']\"\n        }\n    });"
     },
     {
       "language": "Java",
@@ -5486,7 +5486,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client\n    .TermvectorsAsync<MyDocument>(index: \"my-index-000001\", id: null, d1 => d1\n        .Doc(new MyDocument()\n        {\n            Fullname = \"John Doe\",\n            Text = \"test test test\"\n        })\n        .Fields(x => x.Fullname)\n        .PerFieldAnalyzer(new Dictionary<Field, string>()\n        {\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Fullname), \"keyword\" }\n        })\n    );"
+      "code": "var response = await client\n    .TermvectorsAsync<MyDocument>(index: \"my-index-000001\", id: null, d1 => d1\n        .Doc(new MyDocument()\n        {\n            Fullname = \"John Doe\",\n            Text = \"test test test\"\n        })\n        .Fields(x => x.Fullname)\n        .PerFieldAnalyzer(new Dictionary<Field, string>()\n        {\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Fullname), \"keyword\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -5606,7 +5606,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Core.SearchMvt;\n\nvar response = await client\n    .SearchMvtAsync(indices: new[] { \"museums\" }, field: global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Location), zoom: 13, x: 4207, y: 2692, d1 => d1\n        .Aggs(d2 => d2\n            .Add(\"min_price\", d3 => d3\n                .Min(d4 => d4\n                    .Field(x => x.Price)\n                )\n            )\n            .Add(\"max_price\", d3 => d3\n                .Max(d4 => d4\n                    .Field(x => x.Price)\n                )\n            )\n            .Add(\"avg_price\", d3 => d3\n                .Avg(d4 => d4\n                    .Field(x => x.Price)\n                )\n            )\n        )\n        .Fields(x => x.Name, x => x.Price)\n        .GridAgg(GridAggregationType.Geotile)\n        .GridPrecision(2)\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.Included)\n                .Value(true)\n            )\n        )\n    );"
+      "code": "var response = await client\n    .SearchMvtAsync(indices: new[] { \"museums\" }, field: global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Location), zoom: 13, x: 4207, y: 2692, d1 => d1\n        .Aggs(d2 => d2\n            .Add(\"min_price\", d3 => d3\n                .Min(d4 => d4\n                    .Field(x => x.Price)\n                )\n            )\n            .Add(\"max_price\", d3 => d3\n                .Max(d4 => d4\n                    .Field(x => x.Price)\n                )\n            )\n            .Add(\"avg_price\", d3 => d3\n                .Avg(d4 => d4\n                    .Field(x => x.Price)\n                )\n            )\n        )\n        .Fields(x => x.Name, x => x.Price)\n        .GridAgg(GridAggregationType.Geotile)\n        .GridPrecision(2)\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.Included)\n                .Value(true)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5696,7 +5696,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client\n    .RenderSearchTemplateAsync(d1 => d1\n        .Id(\"my-search-template\")\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"hello world\" },\n            { \"from\", 20 },\n            { \"size\", 10 }\n        })\n    );"
+      "code": "var response = await client\n    .RenderSearchTemplateAsync(d1 => d1\n        .Id(\"my-search-template\")\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"hello world\" },\n            { \"from\", 20 },\n            { \"size\", 10 }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -5846,7 +5846,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.QueryDsl;\n\nvar response = await client\n    .DeleteByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Query(d2 => d2\n            .Range(new UntypedRangeQuery()\n            {\n                Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Http.Response.Bytes),\n                Lt = 2000000\n            })\n        )\n        .Slice(d2 => d2\n            .Id(0L)\n            .Max(2)\n        )\n    );"
+      "code": "var response = await client\n    .DeleteByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Query(d2 => d2\n            .Range(new UntypedRangeQuery()\n            {\n                Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Http.Response.Bytes),\n                Lt = 2000000\n            })\n        )\n        .Slice(d2 => d2\n            .Id(0L)\n            .Max(2)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5876,7 +5876,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.QueryDsl;\n\nvar response = await client\n    .DeleteByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Refresh(true)\n        .Slices(new Slices(5))\n        .Query(d2 => d2\n            .Range(new UntypedRangeQuery()\n            {\n                Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Http.Response.Bytes),\n                Lt = 2000000\n            })\n        )\n    );"
+      "code": "var response = await client\n    .DeleteByQueryAsync(indices: new[] { \"my-index-000001\" }, d1 => d1\n        .Refresh(true)\n        .Slices(new Slices(5))\n        .Query(d2 => d2\n            .Range(new UntypedRangeQuery()\n            {\n                Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Http.Response.Bytes),\n                Lt = 2000000\n            })\n        )\n    );"
     },
     {
       "language": "Java",
@@ -5936,7 +5936,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.QueryDsl;\n\nvar response = await client\n    .FieldCapsAsync(d1 => d1\n        .Indices(new[] { \"my-index-*\" })\n        .IndexFilter(d2 => d2\n            .Range(new UntypedRangeQuery()\n            {\n                Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Timestamp),\n                Gte = \"2018\"\n            })\n        )\n    );"
+      "code": "var response = await client\n    .FieldCapsAsync(d1 => d1\n        .Indices(new[] { \"my-index-*\" })\n        .IndexFilter(d2 => d2\n            .Range(new UntypedRangeQuery()\n            {\n                Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Timestamp),\n                Gte = \"2018\"\n            })\n        )\n    );"
     },
     {
       "language": "Java",
@@ -6116,7 +6116,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Text.Json;\n\nvar response = await client\n    .MtermvectorsAsync(d1 => d1\n        .Docs(d2 => d2\n            .Doc(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"message\": \"test test test\"\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\"), d2 => d2\n            .Doc(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"message\": \"Another test ...\"\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\")\n        )\n    );"
+      "code": "var response = await client\n    .MtermvectorsAsync(d1 => d1\n        .Docs(d2 => d2\n            .Doc(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"message\": \"test test test\"\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\"), d2 => d2\n            .Doc(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"message\": \"Another test ...\"\n            }\n            \"\"\"))\n            .Index(\"my-index-000001\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -6296,7 +6296,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"metricbeat\")\n        )\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Source(\"ctx._index = 'metricbeat-' + (ctx._index.substring('metricbeat-'.length(), ctx._index.length())) + '-1'\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"metricbeat-*\" })\n        )\n    );"
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"metricbeat\")\n        )\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Source(\"ctx._index = 'metricbeat-' + (ctx._index.substring('metricbeat-'.length(), ctx._index.length())) + '-1'\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"metricbeat-*\" })\n        )\n    );"
     },
     {
       "language": "Java",
@@ -6356,7 +6356,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Core.Search;\n\nvar response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n            .SourceFields(new SourceConfig(new SourceFilter()\n            {\n                Includes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.User.Id, x => x.Doc)\n            }))\n        )\n    );"
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n            .SourceFields(new SourceConfig(new SourceFilter()\n            {\n                Includes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.User.Id, x => x.Doc)\n            }))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -6386,7 +6386,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client\n    .ReindexAsync(d1 => d1\n        .Refresh(true)\n        .Slices(new Slices(5))\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n        )\n    );"
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Refresh(true)\n        .Slices(new Slices(5))\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n        )\n    );"
     },
     {
       "language": "Java",
@@ -6566,7 +6566,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n            .VersionType(VersionType.External)\n        )\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Source(\"if (ctx._source.foo == 'bar') {ctx._version++; ctx._source.remove('foo')}\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n        )\n    );"
+      "code": "var response = await client\n    .ReindexAsync(d1 => d1\n        .Dest(d2 => d2\n            .Index(\"my-new-index-000001\")\n            .VersionType(VersionType.External)\n        )\n        .Script(d2 => d2\n            .Lang(ScriptLanguage.Painless)\n            .Source(\"if (ctx._source.foo == 'bar') {ctx._version++; ctx._source.remove('foo')}\")\n        )\n        .Source(d2 => d2\n            .Indices(new[] { \"my-index-000001\" })\n        )\n    );"
     },
     {
       "language": "Java",
@@ -6656,7 +6656,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Core.MSearch;\nusing Elastic.Clients.Elasticsearch.QueryDsl;\n\nvar response = await client\n    .MultiSearchAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Searches([new SearchRequestItem(new MultisearchHeader(), new MultisearchBody()\n        {\n            Query = new Query()\n            {\n                Match = new()\n                {\n                    Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Message),\n                    Query = \"this is a test\"\n                }\n            }\n        }), new SearchRequestItem(new MultisearchHeader()\n        {\n            Indices = new[] { \"my-index-000002\" }\n        }, new MultisearchBody()\n        {\n            Query = new Query()\n            {\n                MatchAll = new()\n            }\n        })])\n    );"
+      "code": "var response = await client\n    .MultiSearchAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Searches([new SearchRequestItem(new MultisearchHeader(), new MultisearchBody()\n        {\n            Query = new Query()\n            {\n                Match = new()\n                {\n                    Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Message),\n                    Query = \"this is a test\"\n                }\n            }\n        }), new SearchRequestItem(new MultisearchHeader()\n        {\n            Indices = new[] { \"my-index-000002\" }\n        }, new MultisearchBody()\n        {\n            Query = new Query()\n            {\n                MatchAll = new()\n            }\n        })])\n    );"
     }
   ],
   "specification/_global/delete_script/examples/request/DeleteScriptRequestExample1.yaml": [
@@ -6712,7 +6712,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Core.Search;\n\nvar response = await client\n    .MultiGetAsync<MyDocument>(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"1\")\n            .Index(\"test\")\n            .Source(new SourceConfig(false)), d2 => d2\n            .Id(\"2\")\n            .Index(\"test\")\n            .Source(new SourceConfig(new SourceFilter()\n            {\n                Includes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.Field3, x => x.Field4)\n            })), d2 => d2\n            .Id(\"3\")\n            .Index(\"test\")\n            .Source(new SourceConfig(new SourceFilter()\n            {\n                Excludes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.User.Location),\n                Includes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.User)\n            }))\n        )\n    );"
+      "code": "var response = await client\n    .MultiGetAsync<MyDocument>(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"1\")\n            .Index(\"test\")\n            .Source(new SourceConfig(false)), d2 => d2\n            .Id(\"2\")\n            .Index(\"test\")\n            .Source(new SourceConfig(new SourceFilter()\n            {\n                Includes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.Field3, x => x.Field4)\n            })), d2 => d2\n            .Id(\"3\")\n            .Index(\"test\")\n            .Source(new SourceConfig(new SourceFilter()\n            {\n                Excludes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.User.Location),\n                Includes = global::Elastic.Clients.Elasticsearch.Infer.Fields<MyDocument>(x => x.User)\n            }))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -6862,7 +6862,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Core.RankEval;\nusing System.Collections.Generic;\n\nvar response = await client\n    .RankEvalAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Metric(d2 => d2\n            .Precision(d3 => d3\n                .IgnoreUnlabeled(false)\n                .K(20)\n                .RelevantRatingThreshold(1)\n            )\n        )\n        .Requests(d2 => d2\n            .Id(\"JFK query\")\n            .Ratings(new List<DocumentRating>())\n            .Request(d3 => d3\n                .Query(d4 => d4\n                    .MatchAll()\n                )\n            )\n        )\n    );"
+      "code": "var response = await client\n    .RankEvalAsync(d1 => d1\n        .Indices(new[] { \"my-index-000001\" })\n        .Metric(d2 => d2\n            .Precision(d3 => d3\n                .IgnoreUnlabeled(false)\n                .K(20)\n                .RelevantRatingThreshold(1)\n            )\n        )\n        .Requests(d2 => d2\n            .Id(\"JFK query\")\n            .Ratings(new List<DocumentRating>())\n            .Request(d3 => d3\n                .Query(d4 => d4\n                    .MatchAll()\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -7420,7 +7420,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.LicenseManagement;\nusing System;\nusing System.Globalization;\n\nvar response = await client.LicenseManagement\n    .PostAsync(d1 => d1\n        .Licenses(d2 => d2\n            .ExpiryDateInMillis(DateTimeOffset.Parse(\"2030-08-29T23:59:59.9990000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .IssueDateInMillis(DateTimeOffset.Parse(\"2014-09-29T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .IssuedTo(\"issuedTo\")\n            .Issuer(\"issuer\")\n            .MaxNodes(1L)\n            .Signature(\"xx\")\n            .Type(LicenseType.Basic)\n            .Uid(\"893361dc-9749-4997-93cb-802e3d7fa4xx\")\n        )\n    );"
+      "code": "var response = await client.LicenseManagement\n    .PostAsync(d1 => d1\n        .Licenses(d2 => d2\n            .ExpiryDateInMillis(DateTimeOffset.Parse(\"2030-08-29T23:59:59.9990000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .IssueDateInMillis(DateTimeOffset.Parse(\"2014-09-29T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .IssuedTo(\"issuedTo\")\n            .Issuer(\"issuer\")\n            .MaxNodes(1L)\n            .Signature(\"xx\")\n            .Type(LicenseType.Basic)\n            .Uid(\"893361dc-9749-4997-93cb-802e3d7fa4xx\")\n        )\n    );"
     },
     {
       "language": "Java",
@@ -7858,7 +7858,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client.Security\n    .CreateApiKeyAsync(d1 => d1\n        .Expiration(\"1d\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"application\", \"my-application\" },\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 1,\n              \"trusted\": true,\n              \"tags\": [\n                \"dev\",\n                \"staging\"\n              ]\n            }\n            \"\"\") }\n        })\n        .Name(\"my-api-key\")\n        .RoleDescriptors(d2 => d2\n            .Add(\"role-a\", d3 => d3\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .Names([\"index-a*\"])\n                    .Privileges(IndexPrivilege.Read)\n                )\n            )\n            .Add(\"role-b\", d3 => d3\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .Names([\"index-b*\"])\n                    .Privileges(IndexPrivilege.All)\n                )\n            )\n        )\n    );"
+      "code": "var response = await client.Security\n    .CreateApiKeyAsync(d1 => d1\n        .Expiration(\"1d\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"application\", \"my-application\" },\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 1,\n              \"trusted\": true,\n              \"tags\": [\n                \"dev\",\n                \"staging\"\n              ]\n            }\n            \"\"\") }\n        })\n        .Name(\"my-api-key\")\n        .RoleDescriptors(d2 => d2\n            .Add(\"role-a\", d3 => d3\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .Names([\"index-a*\"])\n                    .Privileges(IndexPrivilege.Read)\n                )\n            )\n            .Add(\"role-b\", d3 => d3\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .Names([\"index-b*\"])\n                    .Privileges(IndexPrivilege.All)\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -7918,7 +7918,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Security\n    .UpdateCrossClusterApiKeyAsync(id: \"VuaCfGcBCdbkQm-e5aOx\", d1 => d1\n        .Access(d2 => d2\n            .Replication(d3 => d3\n                .Names([\"archive\"])\n            )\n        )\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"application\", \"replication\" }\n        })\n    );"
+      "code": "var response = await client.Security\n    .UpdateCrossClusterApiKeyAsync(id: \"VuaCfGcBCdbkQm-e5aOx\", d1 => d1\n        .Access(d2 => d2\n            .Replication(d3 => d3\n                .Names([\"archive\"])\n            )\n        )\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"application\", \"replication\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -8008,7 +8008,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\n\nvar response = await client.Security\n    .HasPrivilegesUserProfileAsync(d1 => d1\n        .Privileges(d2 => d2\n            .Application(d3 => d3\n                .Application(\"inventory_manager\")\n                .Privileges(\"read\", \"data:write/inventory\")\n                .Resources(\"product/1852563\")\n            )\n            .Cluster(ClusterPrivilege.Monitor, ClusterPrivilege.CreateSnapshot, ClusterPrivilege.ManageMl)\n            .Index(d3 => d3\n                .Names(new[] { \"suppliers\", \"products\" })\n                .Privileges(IndexPrivilege.CreateDoc), d3 => d3\n                .Names(new[] { \"inventory\" })\n                .Privileges(IndexPrivilege.Read, IndexPrivilege.Write)\n            )\n        )\n        .Uids(\"u_LQPnxDxEjIH0GOUoFkZr5Y57YUwSkL9Joiq-g4OCbPc_0\", \"u_rzRnxDgEHIH0GOUoFkZr5Y27YUwSk19Joiq=g4OCxxB_1\", \"u_does-not-exist_0\")\n    );"
+      "code": "var response = await client.Security\n    .HasPrivilegesUserProfileAsync(d1 => d1\n        .Privileges(d2 => d2\n            .Application(d3 => d3\n                .Application(\"inventory_manager\")\n                .Privileges(\"read\", \"data:write/inventory\")\n                .Resources(\"product/1852563\")\n            )\n            .Cluster(ClusterPrivilege.Monitor, ClusterPrivilege.CreateSnapshot, ClusterPrivilege.ManageMl)\n            .Index(d3 => d3\n                .Names(new[] { \"suppliers\", \"products\" })\n                .Privileges(IndexPrivilege.CreateDoc), d3 => d3\n                .Names(new[] { \"inventory\" })\n                .Privileges(IndexPrivilege.Read, IndexPrivilege.Write)\n            )\n        )\n        .Uids(\"u_LQPnxDxEjIH0GOUoFkZr5Y57YUwSkL9Joiq-g4OCbPc_0\", \"u_rzRnxDgEHIH0GOUoFkZr5Y27YUwSk19Joiq=g4OCxxB_1\", \"u_does-not-exist_0\")\n    );"
     },
     {
       "language": "Java",
@@ -8098,7 +8098,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\n\nvar response = await client.Security\n    .ActivateUserProfileAsync(d1 => d1\n        .GrantType(GrantType.Password)\n        .Password(\"l0ng-r4nd0m-p@ssw0rd\")\n        .Username(\"jacknich\")\n    );"
+      "code": "var response = await client.Security\n    .ActivateUserProfileAsync(d1 => d1\n        .GrantType(GrantType.Password)\n        .Password(\"l0ng-r4nd0m-p@ssw0rd\")\n        .Username(\"jacknich\")\n    );"
     },
     {
       "language": "Java",
@@ -8218,7 +8218,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\n\nvar response = await client.Security\n    .HasPrivilegesAsync(d1 => d1\n        .Application(d2 => d2\n            .Application(\"inventory_manager\")\n            .Privileges(\"read\", \"data:write/inventory\")\n            .Resources(\"product/1852563\")\n        )\n        .Cluster(ClusterPrivilege.Monitor, ClusterPrivilege.Manage)\n        .Index(d2 => d2\n            .Names(new[] { \"suppliers\", \"products\" })\n            .Privileges(IndexPrivilege.Read), d2 => d2\n            .Names(new[] { \"inventory\" })\n            .Privileges(IndexPrivilege.Read, IndexPrivilege.Write)\n        )\n    );"
+      "code": "var response = await client.Security\n    .HasPrivilegesAsync(d1 => d1\n        .Application(d2 => d2\n            .Application(\"inventory_manager\")\n            .Privileges(\"read\", \"data:write/inventory\")\n            .Resources(\"product/1852563\")\n        )\n        .Cluster(ClusterPrivilege.Monitor, ClusterPrivilege.Manage)\n        .Index(d2 => d2\n            .Names(new[] { \"suppliers\", \"products\" })\n            .Privileges(IndexPrivilege.Read), d2 => d2\n            .Names(new[] { \"inventory\" })\n            .Privileges(IndexPrivilege.Read, IndexPrivilege.Write)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -8458,7 +8458,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client.Security\n    .BulkUpdateApiKeysAsync(d1 => d1\n        .Expiration(\"30d\")\n        .Ids(\"VuaCfGcBCdbkQm-e5aOx\", \"H3_AhoIBA9hmeQJdg7ij\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 2,\n              \"trusted\": true,\n              \"tags\": [\n                \"production\"\n              ]\n            }\n            \"\"\") }\n        })\n        .RoleDescriptors(d2 => d2\n            .Add(\"role-a\", d3 => d3\n                .Indices(d4 => d4\n                    .Names([\"*\"])\n                    .Privileges(IndexPrivilege.Write)\n                )\n            )\n        )\n    );"
+      "code": "var response = await client.Security\n    .BulkUpdateApiKeysAsync(d1 => d1\n        .Expiration(\"30d\")\n        .Ids(\"VuaCfGcBCdbkQm-e5aOx\", \"H3_AhoIBA9hmeQJdg7ij\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 2,\n              \"trusted\": true,\n              \"tags\": [\n                \"production\"\n              ]\n            }\n            \"\"\") }\n        })\n        .RoleDescriptors(d2 => d2\n            .Add(\"role-a\", d3 => d3\n                .Indices(d4 => d4\n                    .Names([\"*\"])\n                    .Privileges(IndexPrivilege.Write)\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -8518,7 +8518,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Security\n    .SuggestUserProfilesAsync(d1 => d1\n        .Hint(d2 => d2\n            .Labels(new Dictionary<string, ICollection<string>>()\n            {\n                { \"direction\", [\"north\", \"east\"] }\n            })\n            .Uids(\"u_8RKO7AKfEbSiIHZkZZ2LJy2MUSDPWDr3tMI_CkIGApU_0\", \"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\")\n        )\n        .Name(\"jack\")\n    );"
+      "code": "var response = await client.Security\n    .SuggestUserProfilesAsync(d1 => d1\n        .Hint(d2 => d2\n            .Labels(new Dictionary<string, ICollection<string>>()\n            {\n                { \"direction\", [\"north\", \"east\"] }\n            })\n            .Uids(\"u_8RKO7AKfEbSiIHZkZZ2LJy2MUSDPWDr3tMI_CkIGApU_0\", \"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\")\n        )\n        .Name(\"jack\")\n    );"
     },
     {
       "language": "Java",
@@ -8578,7 +8578,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client.Security\n    .QueryApiKeysAsync(d1 => d1\n        .From(20)\n        .Query(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Wildcard(d5 => d5\n                        .Field(x => x.Username)\n                        .Value(\"org-*-user\")\n                    ), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Metadata.Environment)\n                        .Value(\"production\")\n                    )\n                )\n                .Must(d4 => d4\n                    .Prefix(d5 => d5\n                        .Field(x => x.Name)\n                        .Value(\"app1-key-\")\n                    ), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Invalidated)\n                        .Value(\"false\")\n                    )\n                )\n                .MustNot(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Name)\n                        .Value(\"app1-key-01\")\n                    )\n                )\n            )\n        )\n        .Size(10)\n        .Sort(d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Creation)\n                .Format(\"date_time\")\n                .Order(SortOrder.Desc)\n            ), d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Name)\n            )\n        )\n    );"
+      "code": "var response = await client.Security\n    .QueryApiKeysAsync(d1 => d1\n        .From(20)\n        .Query(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Wildcard(d5 => d5\n                        .Field(x => x.Username)\n                        .Value(\"org-*-user\")\n                    ), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Metadata.Environment)\n                        .Value(\"production\")\n                    )\n                )\n                .Must(d4 => d4\n                    .Prefix(d5 => d5\n                        .Field(x => x.Name)\n                        .Value(\"app1-key-\")\n                    ), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Invalidated)\n                        .Value(\"false\")\n                    )\n                )\n                .MustNot(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Name)\n                        .Value(\"app1-key-01\")\n                    )\n                )\n            )\n        )\n        .Size(10)\n        .Sort(d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Creation)\n                .Format(\"date_time\")\n                .Order(SortOrder.Desc)\n            ), d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Name)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -8638,7 +8638,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client.Security\n    .CreateCrossClusterApiKeyAsync(d1 => d1\n        .Access(d2 => d2\n            .Replication(d3 => d3\n                .Names([\"archive*\"])\n            )\n            .Search(d3 => d3\n                .Names([\"logs*\"])\n            )\n        )\n        .Expiration(\"1d\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"description\", \"phase one\" },\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 1,\n              \"trusted\": true,\n              \"tags\": [\n                \"dev\",\n                \"staging\"\n              ]\n            }\n            \"\"\") }\n        })\n        .Name(\"my-cross-cluster-api-key\")\n    );"
+      "code": "var response = await client.Security\n    .CreateCrossClusterApiKeyAsync(d1 => d1\n        .Access(d2 => d2\n            .Replication(d3 => d3\n                .Names([\"archive*\"])\n            )\n            .Search(d3 => d3\n                .Names([\"logs*\"])\n            )\n        )\n        .Expiration(\"1d\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"description\", \"phase one\" },\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 1,\n              \"trusted\": true,\n              \"tags\": [\n                \"dev\",\n                \"staging\"\n              ]\n            }\n            \"\"\") }\n        })\n        .Name(\"my-cross-cluster-api-key\")\n    );"
     },
     {
       "language": "Java",
@@ -8968,7 +8968,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\n\nvar response = await client.Security\n    .CreateServiceTokenAsync(new CreateServiceTokenRequest()\n    {\n        Name = \"token1\",\n        Namespace = \"elastic\",\n        Service = \"fleet-server\"\n    });"
+      "code": "var response = await client.Security\n    .CreateServiceTokenAsync(new CreateServiceTokenRequest()\n    {\n        Name = \"token1\",\n        Namespace = \"elastic\",\n        Service = \"fleet-server\"\n    });"
     },
     {
       "language": "Java",
@@ -9088,7 +9088,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client.Security\n    .UpdateUserProfileDataAsync(uid: \"u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0\", d1 => d1\n        .Data(new Dictionary<string, object>()\n        {\n            { \"app1\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"theme\": \"default\"\n            }\n            \"\"\") }\n        })\n        .Labels(new Dictionary<string, object>()\n        {\n            { \"direction\", \"east\" }\n        })\n    );"
+      "code": "var response = await client.Security\n    .UpdateUserProfileDataAsync(uid: \"u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0\", d1 => d1\n        .Data(new Dictionary<string, object>()\n        {\n            { \"app1\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"theme\": \"default\"\n            }\n            \"\"\") }\n        })\n        .Labels(new Dictionary<string, object>()\n        {\n            { \"direction\", \"east\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -9178,7 +9178,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Security\n    .PutUserAsync(username: \"jacknich\", d1 => d1\n        .Email(\"jacknich@example.com\")\n        .FullName(\"Jack Nicholson\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"intelligence\", 7 }\n        })\n        .Password(\"l0ng-r4nd0m-p@ssw0rd\")\n        .Roles(\"admin\", \"other_role1\")\n    );"
+      "code": "var response = await client.Security\n    .PutUserAsync(username: \"jacknich\", d1 => d1\n        .Email(\"jacknich@example.com\")\n        .FullName(\"Jack Nicholson\")\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"intelligence\", 7 }\n        })\n        .Password(\"l0ng-r4nd0m-p@ssw0rd\")\n        .Roles(\"admin\", \"other_role1\")\n    );"
     },
     {
       "language": "Java",
@@ -9328,7 +9328,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping7\", d1 => d1\n        .Enabled(true)\n        .Roles(\"ldap-example-user\")\n        .Rules(d2 => d2\n            .All(d3 => d3\n                .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Dn), [\"*,ou=subtree,dc=example,dc=com\"])), d3 => d3\n                .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Realm.Name), [\"ldap1\"]))\n            )\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping7\", d1 => d1\n        .Enabled(true)\n        .Roles(\"ldap-example-user\")\n        .Rules(d2 => d2\n            .All(d3 => d3\n                .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Dn), [\"*,ou=subtree,dc=example,dc=com\"])), d3 => d3\n                .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Realm.Name), [\"ldap1\"]))\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9358,7 +9358,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping6\", d1 => d1\n        .Enabled(true)\n        .RoleTemplates(d2 => d2\n            .Format(TemplateFormat.Json)\n            .Template(d3 => d3\n                .Source(\"{{#tojson}}groups{{/tojson}}\")\n            )\n        )\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Realm.Name), [\"saml1\"]))\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping6\", d1 => d1\n        .Enabled(true)\n        .RoleTemplates(d2 => d2\n            .Format(TemplateFormat.Json)\n            .Template(d3 => d3\n                .Source(\"{{#tojson}}groups{{/tojson}}\")\n            )\n        )\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Realm.Name), [\"saml1\"]))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9388,7 +9388,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping1\", d1 => d1\n        .Enabled(true)\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"version\", 1 }\n        })\n        .Roles(\"user\")\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Username), [\"*\"]))\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping1\", d1 => d1\n        .Enabled(true)\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"version\", 1 }\n        })\n        .Roles(\"user\")\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Username), [\"*\"]))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9418,7 +9418,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping3\", d1 => d1\n        .Enabled(true)\n        .Roles(\"ldap-user\")\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Realm.Name), [\"ldap1\"]))\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping3\", d1 => d1\n        .Enabled(true)\n        .Roles(\"ldap-user\")\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Realm.Name), [\"ldap1\"]))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9448,7 +9448,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping2\", d1 => d1\n        .Enabled(true)\n        .Roles(\"user\", \"admin\")\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Username), [\"esadmin01\", \"esadmin02\"]))\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping2\", d1 => d1\n        .Enabled(true)\n        .Roles(\"user\", \"admin\")\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Username), [\"esadmin01\", \"esadmin02\"]))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9478,7 +9478,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping9\", d1 => d1\n        .Enabled(true)\n        .RoleTemplates(d2 => d2\n            .Template(d3 => d3\n                .Source(\"saml_user\")\n            ), d2 => d2\n            .Template(d3 => d3\n                .Source(\"_user_{{username}}\")\n            )\n        )\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Realm.Name), [\"cloud-saml\"]))\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping9\", d1 => d1\n        .Enabled(true)\n        .RoleTemplates(d2 => d2\n            .Template(d3 => d3\n                .Source(\"saml_user\")\n            ), d2 => d2\n            .Template(d3 => d3\n                .Source(\"_user_{{username}}\")\n            )\n        )\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Realm.Name), [\"cloud-saml\"]))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9508,7 +9508,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping5\", d1 => d1\n        .Enabled(true)\n        .RoleTemplates(d2 => d2\n            .Format(TemplateFormat.Json)\n            .Template(d3 => d3\n                .Source(\"{{#tojson}}groups{{/tojson}}\")\n            )\n        )\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Realm.Name), [\"saml1\"]))\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping5\", d1 => d1\n        .Enabled(true)\n        .RoleTemplates(d2 => d2\n            .Format(TemplateFormat.Json)\n            .Template(d3 => d3\n                .Source(\"{{#tojson}}groups{{/tojson}}\")\n            )\n        )\n        .Rules(d2 => d2\n            .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Realm.Name), [\"saml1\"]))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9538,7 +9538,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping4\", d1 => d1\n        .Enabled(true)\n        .Roles(\"superuser\")\n        .Rules(d2 => d2\n            .Any(d3 => d3\n                .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Username), [\"esadmin\"])), d3 => d3\n                .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Groups), [\"cn=admins,dc=example,dc=com\"]))\n            )\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleMappingAsync(name: \"mapping4\", d1 => d1\n        .Enabled(true)\n        .Roles(\"superuser\")\n        .Rules(d2 => d2\n            .Any(d3 => d3\n                .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Username), [\"esadmin\"])), d3 => d3\n                .Field(new KeyValuePair<Field,ICollection<FieldValue>>(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Groups), [\"cn=admins,dc=example,dc=com\"]))\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9684,7 +9684,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\n\nvar response = await client.Security\n    .GetTokenAsync(d1 => d1\n        .GrantType(AccessTokenGrantType.ClientCredentials)\n    );"
+      "code": "var response = await client.Security\n    .GetTokenAsync(d1 => d1\n        .GrantType(AccessTokenGrantType.ClientCredentials)\n    );"
     },
     {
       "language": "Java",
@@ -9714,7 +9714,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\n\nvar response = await client.Security\n    .GetTokenAsync(d1 => d1\n        .GrantType(AccessTokenGrantType.Password)\n        .Password(\"x-pack-test-password\")\n        .Username(\"test_admin\")\n    );"
+      "code": "var response = await client.Security\n    .GetTokenAsync(d1 => d1\n        .GrantType(AccessTokenGrantType.Password)\n        .Password(\"x-pack-test-password\")\n        .Username(\"test_admin\")\n    );"
     },
     {
       "language": "Java",
@@ -9744,7 +9744,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .BulkPutRoleAsync(d1 => d1\n        .Roles(d2 => d2\n            .Add(\"my_admin_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\", \"index2\"])\n                    .Privileges(IndexPrivilege.All)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n            .Add(\"my_user_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\"])\n                    .Privileges(IndexPrivilege.Read)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n        )\n    );"
+      "code": "var response = await client.Security\n    .BulkPutRoleAsync(d1 => d1\n        .Roles(d2 => d2\n            .Add(\"my_admin_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\", \"index2\"])\n                    .Privileges(IndexPrivilege.All)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n            .Add(\"my_user_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\"])\n                    .Privileges(IndexPrivilege.Read)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9774,7 +9774,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\n\nvar response = await client.Security\n    .PutRoleAsync(name: \"only_remote_access_role\", d1 => d1\n        .RemoteCluster(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Privileges(RemoteClusterPrivilege.MonitorStats)\n        )\n        .RemoteIndices(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Names([\"logs*\"])\n            .Privileges(IndexPrivilege.Read, IndexPrivilege.ReadCrossCluster, IndexPrivilege.ViewIndexMetadata)\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleAsync(name: \"only_remote_access_role\", d1 => d1\n        .RemoteCluster(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Privileges(RemoteClusterPrivilege.MonitorStats)\n        )\n        .RemoteIndices(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Names([\"logs*\"])\n            .Privileges(IndexPrivilege.Read, IndexPrivilege.ReadCrossCluster, IndexPrivilege.ViewIndexMetadata)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -9804,7 +9804,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .BulkPutRoleAsync(d1 => d1\n        .Roles(d2 => d2\n            .Add(\"my_admin_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(new ClusterPrivilege(\"bad_cluster_privilege\"))\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\", \"index2\"])\n                    .Privileges(IndexPrivilege.All)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n            .Add(\"my_user_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\"])\n                    .Privileges(IndexPrivilege.Read)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n        )\n    );"
+      "code": "var response = await client.Security\n    .BulkPutRoleAsync(d1 => d1\n        .Roles(d2 => d2\n            .Add(\"my_admin_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(new ClusterPrivilege(\"bad_cluster_privilege\"))\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\", \"index2\"])\n                    .Privileges(IndexPrivilege.All)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n            .Add(\"my_user_role\", d3 => d3\n                .Applications(d4 => d4\n                    .Application(\"myapp\")\n                    .Privileges(\"admin\", \"read\")\n                    .Resources(\"*\")\n                )\n                .Cluster(ClusterPrivilege.All)\n                .Indices(d4 => d4\n                    .FieldSecurity(d5 => d5\n                        .Grant(x => x.Title, x => x.Body)\n                    )\n                    .Names([\"index1\"])\n                    .Privileges(IndexPrivilege.Read)\n                    .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n                )\n                .Metadata(new Dictionary<string, object>()\n                {\n                    { \"version\", 1 }\n                })\n                .RunAs(\"other_user\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -10044,7 +10044,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\n\nvar response = await client.Security\n    .QueryUserAsync(d1 => d1\n        .From(1)\n        .Query(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Wildcard(d5 => d5\n                        .Field(x => x.Roles)\n                        .Value(\"*other*\")\n                    )\n                )\n                .Must(d4 => d4\n                    .Wildcard(d5 => d5\n                        .Field(x => x.Email)\n                        .Value(\"*example.com\")\n                    ), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Enabled)\n                        .Value(true)\n                    )\n                )\n            )\n        )\n        .Size(2)\n        .Sort(d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Username)\n                .Order(SortOrder.Desc)\n            )\n        )\n    );"
+      "code": "var response = await client.Security\n    .QueryUserAsync(d1 => d1\n        .From(1)\n        .Query(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Wildcard(d5 => d5\n                        .Field(x => x.Roles)\n                        .Value(\"*other*\")\n                    )\n                )\n                .Must(d4 => d4\n                    .Wildcard(d5 => d5\n                        .Field(x => x.Email)\n                        .Value(\"*example.com\")\n                    ), d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Enabled)\n                        .Value(true)\n                    )\n                )\n            )\n        )\n        .Size(2)\n        .Sort(d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Username)\n                .Order(SortOrder.Desc)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -10134,7 +10134,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client.Security\n    .UpdateApiKeyAsync(id: \"VuaCfGcBCdbkQm-e5aOx\", d1 => d1\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 2,\n              \"trusted\": true,\n              \"tags\": [\n                \"production\"\n              ]\n            }\n            \"\"\") }\n        })\n        .RoleDescriptors(d2 => d2\n            .Add(\"role-a\", d3 => d3\n                .Indices(d4 => d4\n                    .Names([\"*\"])\n                    .Privileges(IndexPrivilege.Write)\n                )\n            )\n        )\n    );"
+      "code": "var response = await client.Security\n    .UpdateApiKeyAsync(id: \"VuaCfGcBCdbkQm-e5aOx\", d1 => d1\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"level\": 2,\n              \"trusted\": true,\n              \"tags\": [\n                \"production\"\n              ]\n            }\n            \"\"\") }\n        })\n        .RoleDescriptors(d2 => d2\n            .Add(\"role-a\", d3 => d3\n                .Indices(d4 => d4\n                    .Names([\"*\"])\n                    .Privileges(IndexPrivilege.Write)\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -10284,7 +10284,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\n\nvar response = await client.Security\n    .GrantApiKeyAsync(d1 => d1\n        .ApiKey(d2 => d2\n            .Name(\"another-api-key\")\n        )\n        .GrantType(ApiKeyGrantType.Password)\n        .Password(\"x-pack-test-password\")\n        .RunAs(\"test_user\")\n        .Username(\"test_admin\")\n    );"
+      "code": "var response = await client.Security\n    .GrantApiKeyAsync(d1 => d1\n        .ApiKey(d2 => d2\n            .Name(\"another-api-key\")\n        )\n        .GrantType(ApiKeyGrantType.Password)\n        .Password(\"x-pack-test-password\")\n        .RunAs(\"test_user\")\n        .Username(\"test_admin\")\n    );"
     },
     {
       "language": "Java",
@@ -10314,7 +10314,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client.Security\n    .GrantApiKeyAsync(d1 => d1\n        .ApiKey(d2 => d2\n            .Expiration(\"1d\")\n            .Metadata(new Dictionary<string, object>()\n            {\n                { \"application\", \"my-application\" },\n                { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"level\": 1,\n                  \"trusted\": true,\n                  \"tags\": [\n                    \"dev\",\n                    \"staging\"\n                  ]\n                }\n                \"\"\") }\n            })\n            .Name(\"my-api-key\")\n            .RoleDescriptors([new Dictionary<string, RoleDescriptor>()\n            {\n                { \"role-a\", new()\n                {\n                    Cluster = [ClusterPrivilege.All],\n                    Indices = [new()\n                    {\n                        Names = [\"index-a*\"],\n                        Privileges = [IndexPrivilege.Read]\n                    }]\n                } },\n                { \"role-b\", new()\n                {\n                    Cluster = [ClusterPrivilege.All],\n                    Indices = [new()\n                    {\n                        Names = [\"index-b*\"],\n                        Privileges = [IndexPrivilege.All]\n                    }]\n                } }\n            }])\n        )\n        .GrantType(ApiKeyGrantType.Password)\n        .Password(\"x-pack-test-password\")\n        .Username(\"test_admin\")\n    );"
+      "code": "var response = await client.Security\n    .GrantApiKeyAsync(d1 => d1\n        .ApiKey(d2 => d2\n            .Expiration(\"1d\")\n            .Metadata(new Dictionary<string, object>()\n            {\n                { \"application\", \"my-application\" },\n                { \"environment\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"level\": 1,\n                  \"trusted\": true,\n                  \"tags\": [\n                    \"dev\",\n                    \"staging\"\n                  ]\n                }\n                \"\"\") }\n            })\n            .Name(\"my-api-key\")\n            .RoleDescriptors([new Dictionary<string, RoleDescriptor>()\n            {\n                { \"role-a\", new()\n                {\n                    Cluster = [ClusterPrivilege.All],\n                    Indices = [new()\n                    {\n                        Names = [\"index-a*\"],\n                        Privileges = [IndexPrivilege.Read]\n                    }]\n                } },\n                { \"role-b\", new()\n                {\n                    Cluster = [ClusterPrivilege.All],\n                    Indices = [new()\n                    {\n                        Names = [\"index-b*\"],\n                        Privileges = [IndexPrivilege.All]\n                    }]\n                } }\n            }])\n        )\n        .GrantType(ApiKeyGrantType.Password)\n        .Password(\"x-pack-test-password\")\n        .Username(\"test_admin\")\n    );"
     },
     {
       "language": "Java",
@@ -10404,7 +10404,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\n\nvar response = await client.Security\n    .PutRoleAsync(name: \"only_remote_access_role\", d1 => d1\n        .RemoteCluster(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Privileges(RemoteClusterPrivilege.MonitorStats)\n        )\n        .RemoteIndices(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Names([\"logs*\"])\n            .Privileges(IndexPrivilege.Read, IndexPrivilege.ReadCrossCluster, IndexPrivilege.ViewIndexMetadata)\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleAsync(name: \"only_remote_access_role\", d1 => d1\n        .RemoteCluster(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Privileges(RemoteClusterPrivilege.MonitorStats)\n        )\n        .RemoteIndices(d2 => d2\n            .Clusters(new[] { \"my_remote\" })\n            .Names([\"logs*\"])\n            .Privileges(IndexPrivilege.Read, IndexPrivilege.ReadCrossCluster, IndexPrivilege.ViewIndexMetadata)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -10434,7 +10434,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\n\nvar response = await client.Security\n    .PutRoleAsync(name: \"cli_or_drivers_minimal\", d1 => d1\n        .Cluster(new ClusterPrivilege(\"cluster:monitor/main\"))\n        .Indices(d2 => d2\n            .Names([\"test\"])\n            .Privileges(IndexPrivilege.Read, new IndexPrivilege(\"indices:admin/get\"))\n        )\n    );"
+      "code": "var response = await client.Security\n    .PutRoleAsync(name: \"cli_or_drivers_minimal\", d1 => d1\n        .Cluster(new ClusterPrivilege(\"cluster:monitor/main\"))\n        .Indices(d2 => d2\n            .Names([\"test\"])\n            .Privileges(IndexPrivilege.Read, new IndexPrivilege(\"indices:admin/get\"))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -10464,7 +10464,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutRoleAsync(name: \"my_admin_role\", d1 => d1\n        .Applications(d2 => d2\n            .Application(\"myapp\")\n            .Privileges(\"admin\", \"read\")\n            .Resources(\"*\")\n        )\n        .Cluster(ClusterPrivilege.All)\n        .Description(\"Grants full access to all management features within the cluster.\")\n        .Indices(d2 => d2\n            .FieldSecurity(d3 => d3\n                .Grant(x => x.Title, x => x.Body)\n            )\n            .Names([\"index1\", \"index2\"])\n            .Privileges(IndexPrivilege.All)\n            .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n        )\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"version\", 1 }\n        })\n        .RunAs(\"other_user\")\n    );"
+      "code": "var response = await client.Security\n    .PutRoleAsync(name: \"my_admin_role\", d1 => d1\n        .Applications(d2 => d2\n            .Application(\"myapp\")\n            .Privileges(\"admin\", \"read\")\n            .Resources(\"*\")\n        )\n        .Cluster(ClusterPrivilege.All)\n        .Description(\"Grants full access to all management features within the cluster.\")\n        .Indices(d2 => d2\n            .FieldSecurity(d3 => d3\n                .Grant(x => x.Title, x => x.Body)\n            )\n            .Names([\"index1\", \"index2\"])\n            .Privileges(IndexPrivilege.All)\n            .Query(\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\")\n        )\n        .Metadata(new Dictionary<string, object>()\n        {\n            { \"version\", 1 }\n        })\n        .RunAs(\"other_user\")\n    );"
     },
     {
       "language": "Java",
@@ -10524,7 +10524,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutPrivilegesAsync(d1 => d1\n        .Privileges(new Dictionary<string, IDictionary<string,PrivilegeActions>>()\n        {\n            { \"myapp\", new Dictionary<string, PrivilegeActions>()\n            {\n                { \"read\", new()\n                {\n                    Actions = [\"data:read/*\", \"action:login\"],\n                    Metadata = new Dictionary<string, object>()\n                    {\n                        { \"description\", \"Read access to myapp\" }\n                    }\n                } }\n            } }\n        })\n    );"
+      "code": "var response = await client.Security\n    .PutPrivilegesAsync(d1 => d1\n        .Privileges(new Dictionary<string, IDictionary<string,PrivilegeActions>>()\n        {\n            { \"myapp\", new Dictionary<string, PrivilegeActions>()\n            {\n                { \"read\", new()\n                {\n                    Actions = [\"data:read/*\", \"action:login\"],\n                    Metadata = new Dictionary<string, object>()\n                    {\n                        { \"description\", \"Read access to myapp\" }\n                    }\n                } }\n            } }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -10554,7 +10554,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Security;\nusing System.Collections.Generic;\n\nvar response = await client.Security\n    .PutPrivilegesAsync(d1 => d1\n        .Privileges(new Dictionary<string, IDictionary<string,PrivilegeActions>>()\n        {\n            { \"app01\", new Dictionary<string, PrivilegeActions>()\n            {\n                { \"read\", new()\n                {\n                    Actions = [\"action:login\", \"data:read/*\"]\n                } },\n                { \"write\", new()\n                {\n                    Actions = [\"action:login\", \"data:write/*\"]\n                } }\n            } },\n            { \"app02\", new Dictionary<string, PrivilegeActions>()\n            {\n                { \"all\", new()\n                {\n                    Actions = [\"*\"]\n                } }\n            } }\n        })\n    );"
+      "code": "var response = await client.Security\n    .PutPrivilegesAsync(d1 => d1\n        .Privileges(new Dictionary<string, IDictionary<string,PrivilegeActions>>()\n        {\n            { \"app01\", new Dictionary<string, PrivilegeActions>()\n            {\n                { \"read\", new()\n                {\n                    Actions = [\"action:login\", \"data:read/*\"]\n                } },\n                { \"write\", new()\n                {\n                    Actions = [\"action:login\", \"data:write/*\"]\n                } }\n            } },\n            { \"app02\", new Dictionary<string, PrivilegeActions>()\n            {\n                { \"all\", new()\n                {\n                    Actions = [\"*\"]\n                } }\n            } }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -10644,7 +10644,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Nodes;\n\nvar response = await client.Nodes\n    .InfoAsync(d1 => d1\n        .Metric(NodesInfoMetric.Jvm)\n        .NodeId(\"_all\")\n    );"
+      "code": "var response = await client.Nodes\n    .InfoAsync(d1 => d1\n        .Metric(NodesInfoMetric.Jvm)\n        .NodeId(\"_all\")\n    );"
     },
     {
       "language": "Java",
@@ -10734,7 +10734,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Nodes;\n\nvar response = await client.Nodes\n    .StatsAsync(d1 => d1\n        .Metric(NodeStatsMetric.Process)\n    );"
+      "code": "var response = await client.Nodes\n    .StatsAsync(d1 => d1\n        .Metric(NodeStatsMetric.Process)\n    );"
     },
     {
       "language": "Java",
@@ -10824,7 +10824,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client.Ingest\n    .PutPipelineAsync(id: \"my-pipeline-id\", d1 => d1\n        .Description(\"My optional pipeline description\")\n        .Meta(new Dictionary<string, object>()\n        {\n            { \"reason\", \"set my-keyword-field to foo\" },\n            { \"serialization\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"class\": \"MyPipeline\",\n              \"id\": 10\n            }\n            \"\"\") }\n        })\n        .Processors(d2 => d2\n            .Set(d3 => d3\n                .Description(\"My optional processor description\")\n                .Field(x => x.MyKeywordField)\n                .Value(\"foo\")\n            )\n        )\n    );"
+      "code": "var response = await client.Ingest\n    .PutPipelineAsync(id: \"my-pipeline-id\", d1 => d1\n        .Description(\"My optional pipeline description\")\n        .Meta(new Dictionary<string, object>()\n        {\n            { \"reason\", \"set my-keyword-field to foo\" },\n            { \"serialization\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"class\": \"MyPipeline\",\n              \"id\": 10\n            }\n            \"\"\") }\n        })\n        .Processors(d2 => d2\n            .Set(d3 => d3\n                .Description(\"My optional processor description\")\n                .Field(x => x.MyKeywordField)\n                .Value(\"foo\")\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -10854,7 +10854,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Text.Json;\n\nvar response = await client.Ingest\n    .SimulateAsync(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"id\")\n            .Index(\"index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"id\")\n            .Index(\"index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n        .Pipeline(d2 => d2\n            .Description(\"_description\")\n            .Processors(d3 => d3\n                .Set(d4 => d4\n                    .Field(x => x.Field2)\n                    .Value(\"_value\")\n                )\n            )\n        )\n    );"
+      "code": "var response = await client.Ingest\n    .SimulateAsync(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"id\")\n            .Index(\"index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"id\")\n            .Index(\"index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n        .Pipeline(d2 => d2\n            .Description(\"_description\")\n            .Processors(d3 => d3\n                .Set(d4 => d4\n                    .Field(x => x.Field2)\n                    .Value(\"_value\")\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -11064,7 +11064,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Text.Json;\n\nvar response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"123\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"456\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n        .PipelineSubstitutions(d2 => d2\n            .Add(\"my-pipeline\", d3 => d3\n                .Processors(d4 => d4\n                    .Uppercase(d5 => d5\n                        .Field(x => x.Foo)\n                    )\n                )\n            )\n        )\n    );"
+      "code": "var response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"123\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"456\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n        .PipelineSubstitutions(d2 => d2\n            .Add(\"my-pipeline\", d3 => d3\n                .Processors(d4 => d4\n                    .Uppercase(d5 => d5\n                        .Field(x => x.Foo)\n                    )\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -11094,7 +11094,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Mapping;\nusing System.Text.Json;\n\nvar response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .ComponentTemplateSubstitutions(d2 => d2\n            .Add(\"my-mappings_template\", d3 => d3\n                .Template(d4 => d4\n                    .Mappings(d5 => d5\n                        .Dynamic(DynamicMapping.Strict)\n                        .Properties(d6 => d6\n                            .Keyword(x => x.Foo)\n                            .Keyword(x => x.Bar)\n                        )\n                    )\n                )\n            )\n        )\n        .Docs(d2 => d2\n            .Id(\"123\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"foo\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"456\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"bar\": \"rab\"\n            }\n            \"\"\"))\n        )\n    );"
+      "code": "var response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .ComponentTemplateSubstitutions(d2 => d2\n            .Add(\"my-mappings_template\", d3 => d3\n                .Template(d4 => d4\n                    .Mappings(d5 => d5\n                        .Dynamic(DynamicMapping.Strict)\n                        .Properties(d6 => d6\n                            .Keyword(x => x.Foo)\n                            .Keyword(x => x.Bar)\n                        )\n                    )\n                )\n            )\n        )\n        .Docs(d2 => d2\n            .Id(\"123\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"foo\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"456\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"bar\": \"rab\"\n            }\n            \"\"\"))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -11124,7 +11124,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Mapping;\nusing System.Text.Json;\n\nvar response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .ComponentTemplateSubstitutions(d2 => d2\n            .Add(\"my-component-template\", d3 => d3\n                .Template(d4 => d4\n                    .Mappings(d5 => d5\n                        .Dynamic(DynamicMapping.True)\n                        .Properties(d6 => d6\n                            .Keyword(x => x.Field3)\n                        )\n                    )\n                    .Settings(d5 => d5\n                        .Add(\"index\", d6 => d6\n                            .DefaultPipeline(\"my-pipeline\")\n                        )\n                    )\n                )\n            )\n        )\n        .Docs(d2 => d2\n            .Id(\"id\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"id\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n        .IndexTemplateSubstitutions(d2 => d2\n            .Add(\"my-index-template\", d3 => d3\n                .ComposedOf([\"component_template_1\", \"component_template_2\"])\n                .IndexPatterns(new[] { \"my-index-*\" })\n            )\n        )\n        .MappingAddition(d2 => d2\n            .Dynamic(DynamicMapping.Strict)\n            .Properties(d3 => d3\n                .Keyword(x => x.Foo)\n            )\n        )\n        .PipelineSubstitutions(d2 => d2\n            .Add(\"my-pipeline\", d3 => d3\n                .Processors(d4 => d4\n                    .Set(d5 => d5\n                        .Field(x => x.Field3)\n                        .Value(\"value3\")\n                    )\n                )\n            )\n        )\n    );"
+      "code": "var response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .ComponentTemplateSubstitutions(d2 => d2\n            .Add(\"my-component-template\", d3 => d3\n                .Template(d4 => d4\n                    .Mappings(d5 => d5\n                        .Dynamic(DynamicMapping.True)\n                        .Properties(d6 => d6\n                            .Keyword(x => x.Field3)\n                        )\n                    )\n                    .Settings(d5 => d5\n                        .Add(\"index\", d6 => d6\n                            .DefaultPipeline(\"my-pipeline\")\n                        )\n                    )\n                )\n            )\n        )\n        .Docs(d2 => d2\n            .Id(\"id\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"id\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n        .IndexTemplateSubstitutions(d2 => d2\n            .Add(\"my-index-template\", d3 => d3\n                .ComposedOf([\"component_template_1\", \"component_template_2\"])\n                .IndexPatterns(new[] { \"my-index-*\" })\n            )\n        )\n        .MappingAddition(d2 => d2\n            .Dynamic(DynamicMapping.Strict)\n            .Properties(d3 => d3\n                .Keyword(x => x.Foo)\n            )\n        )\n        .PipelineSubstitutions(d2 => d2\n            .Add(\"my-pipeline\", d3 => d3\n                .Processors(d4 => d4\n                    .Set(d5 => d5\n                        .Field(x => x.Field3)\n                        .Value(\"value3\")\n                    )\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -11154,7 +11154,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Text.Json;\n\nvar response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"123\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"456\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n    );"
+      "code": "var response = await client.Simulate\n    .IngestAsync(d1 => d1\n        .Docs(d2 => d2\n            .Id(\"123\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"bar\"\n            }\n            \"\"\")), d2 => d2\n            .Id(\"456\")\n            .Index(\"my-index\")\n            .Source(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"foo\": \"rab\"\n            }\n            \"\"\"))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -12136,7 +12136,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.MachineLearning\n    .InferTrainedModelAsync(modelId: \"lang_ident_model_1\", d1 => d1\n        .Docs([new Dictionary<string, object>()\n        {\n            { \"text\", \"The fool doth think he is wise, but the wise man knows himself to be a fool.\" }\n        }])\n    );"
+      "code": "var response = await client.MachineLearning\n    .InferTrainedModelAsync(modelId: \"lang_ident_model_1\", d1 => d1\n        .Docs([new Dictionary<string, object>()\n        {\n            { \"text\", \"The fool doth think he is wise, but the wise man knows himself to be a fool.\" }\n        }])\n    );"
     },
     {
       "language": "Java",
@@ -12372,7 +12372,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client.MachineLearning\n    .EstimateModelMemoryAsync(d1 => d1\n        .AnalysisConfig(d2 => d2\n            .BucketSpan(\"5m\")\n            .Detectors(d3 => d3\n                .ByFieldName(x => x.Status)\n                .FieldName(x => x.Bytes)\n                .Function(\"sum\")\n                .PartitionFieldName(x => x.App)\n            )\n            .Influencers(x => x.SourceIp, x => x.DestIp)\n        )\n        .MaxBucketCardinality(new Dictionary<Field, long>()\n        {\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.SourceIp), 300L },\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.DestIp), 30L }\n        })\n        .OverallCardinality(new Dictionary<Field, long>()\n        {\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Status), 10L },\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.App), 50L }\n        })\n    );"
+      "code": "var response = await client.MachineLearning\n    .EstimateModelMemoryAsync(d1 => d1\n        .AnalysisConfig(d2 => d2\n            .BucketSpan(\"5m\")\n            .Detectors(d3 => d3\n                .ByFieldName(x => x.Status)\n                .FieldName(x => x.Bytes)\n                .Function(\"sum\")\n                .PartitionFieldName(x => x.App)\n            )\n            .Influencers(x => x.SourceIp, x => x.DestIp)\n        )\n        .MaxBucketCardinality(new Dictionary<Field, long>()\n        {\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.SourceIp), 300L },\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.DestIp), 30L }\n        })\n        .OverallCardinality(new Dictionary<Field, long>()\n        {\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.Status), 10L },\n            { global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.App), 50L }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -12402,7 +12402,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.MachineLearning;\n\nvar response = await client.MachineLearning\n    .GetCategoriesAsync(new GetCategoriesRequest()\n    {\n        JobId = \"esxi_log\",\n        Page = new()\n        {\n            Size = 1\n        }\n    });"
+      "code": "var response = await client.MachineLearning\n    .GetCategoriesAsync(new GetCategoriesRequest()\n    {\n        JobId = \"esxi_log\",\n        Page = new()\n        {\n            Size = 1\n        }\n    });"
     },
     {
       "language": "Java",
@@ -12432,7 +12432,7 @@
     },
     {
       "language": "C#",
-      "code": "using System;\nusing System.Globalization;\n\nvar response = await client.MachineLearning\n    .PostCalendarEventsAsync(calendarId: \"planned-outages\", d1 => d1\n        .Events(d2 => d2\n            .Description(\"event 1\")\n            .EndTime(DateTimeOffset.Parse(\"2017-12-20T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .StartTime(DateTimeOffset.Parse(\"2017-12-19T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)), d2 => d2\n            .Description(\"event 2\")\n            .EndTime(DateTimeOffset.Parse(\"2017-12-22T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .StartTime(DateTimeOffset.Parse(\"2017-12-21T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)), d2 => d2\n            .Description(\"event 3\")\n            .EndTime(DateTimeOffset.Parse(\"2017-12-26T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .StartTime(DateTimeOffset.Parse(\"2017-12-25T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n        )\n    );"
+      "code": "var response = await client.MachineLearning\n    .PostCalendarEventsAsync(calendarId: \"planned-outages\", d1 => d1\n        .Events(d2 => d2\n            .Description(\"event 1\")\n            .EndTime(DateTimeOffset.Parse(\"2017-12-20T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .StartTime(DateTimeOffset.Parse(\"2017-12-19T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)), d2 => d2\n            .Description(\"event 2\")\n            .EndTime(DateTimeOffset.Parse(\"2017-12-22T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .StartTime(DateTimeOffset.Parse(\"2017-12-21T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)), d2 => d2\n            .Description(\"event 3\")\n            .EndTime(DateTimeOffset.Parse(\"2017-12-26T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n            .StartTime(DateTimeOffset.Parse(\"2017-12-25T00:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n        )\n    );"
     },
     {
       "language": "Java",
@@ -12492,7 +12492,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Mapping;\n\nvar response = await client.MachineLearning\n    .PutJobAsync(jobId: \"job-01\", d1 => d1\n        .AnalysisConfig(d2 => d2\n            .BucketSpan(\"15m\")\n            .Detectors(d3 => d3\n                .DetectorDescription(\"Sum of bytes\")\n                .FieldName(x => x.Bytes)\n                .Function(\"sum\")\n            )\n        )\n        .AnalysisLimits(d2 => d2\n            .ModelMemoryLimit(new ByteSize(\"11MB\"))\n        )\n        .DataDescription(d2 => d2\n            .TimeField(x => x.Timestamp)\n            .TimeFormat(\"epoch_ms\")\n        )\n        .DatafeedConfig(d2 => d2\n            .DatafeedId(\"datafeed-test-job1\")\n            .Indices(new[] { \"kibana_sample_data_logs\" })\n            .Query(d3 => d3\n                .Bool(d4 => d4\n                    .Must(d5 => d5\n                        .MatchAll()\n                    )\n                )\n            )\n            .RuntimeMappings(d3 => d3\n                .Add(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.HourOfDay), d4 => d4\n                    .Script(d5 => d5\n                        .Source(\"emit(doc['timestamp'].value.getHour());\")\n                    )\n                    .Type(RuntimeFieldType.Long)\n                )\n            )\n        )\n        .ModelPlotConfig(d2 => d2\n            .AnnotationsEnabled(true)\n            .Enabled(true)\n        )\n        .ResultsIndexName(\"test-job1\")\n    );"
+      "code": "var response = await client.MachineLearning\n    .PutJobAsync(jobId: \"job-01\", d1 => d1\n        .AnalysisConfig(d2 => d2\n            .BucketSpan(\"15m\")\n            .Detectors(d3 => d3\n                .DetectorDescription(\"Sum of bytes\")\n                .FieldName(x => x.Bytes)\n                .Function(\"sum\")\n            )\n        )\n        .AnalysisLimits(d2 => d2\n            .ModelMemoryLimit(new ByteSize(\"11MB\"))\n        )\n        .DataDescription(d2 => d2\n            .TimeField(x => x.Timestamp)\n            .TimeFormat(\"epoch_ms\")\n        )\n        .DatafeedConfig(d2 => d2\n            .DatafeedId(\"datafeed-test-job1\")\n            .Indices(new[] { \"kibana_sample_data_logs\" })\n            .Query(d3 => d3\n                .Bool(d4 => d4\n                    .Must(d5 => d5\n                        .MatchAll()\n                    )\n                )\n            )\n            .RuntimeMappings(d3 => d3\n                .Add(global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.HourOfDay), d4 => d4\n                    .Script(d5 => d5\n                        .Source(\"emit(doc['timestamp'].value.getHour());\")\n                    )\n                    .Type(RuntimeFieldType.Long)\n                )\n            )\n        )\n        .ModelPlotConfig(d2 => d2\n            .AnnotationsEnabled(true)\n            .Enabled(true)\n        )\n        .ResultsIndexName(\"test-job1\")\n    );"
     },
     {
       "language": "Java",
@@ -12522,7 +12522,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .Regression(d3 => d3\n                .ActualField(x => x.Price)\n                .Metrics(d4 => d4\n                    .Huber()\n                    .Mse(new Dictionary<string, object>() { })\n                    .Msle()\n                    .RSquared(new Dictionary<string, object>() { })\n                )\n                .PredictedField(x => x.Ml.PricePrediction)\n            )\n        )\n        .Index(\"house_price_predictions\")\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.Ml.IsTraining)\n                .Value(true)\n            )\n        )\n    );"
+      "code": "var response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .Regression(d3 => d3\n                .ActualField(x => x.Price)\n                .Metrics(d4 => d4\n                    .Huber()\n                    .Mse(new Dictionary<string, object>() { })\n                    .Msle()\n                    .RSquared(new Dictionary<string, object>() { })\n                )\n                .PredictedField(x => x.Ml.PricePrediction)\n            )\n        )\n        .Index(\"house_price_predictions\")\n        .Query(d2 => d2\n            .Term(d3 => d3\n                .Field(x => x.Ml.IsTraining)\n                .Value(true)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -12552,7 +12552,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .Regression(d3 => d3\n                .ActualField(x => x.Price)\n                .Metrics(d4 => d4\n                    .Huber(d5 => d5\n                        .Delta(1.5d)\n                    )\n                    .Mse(new Dictionary<string, object>() { })\n                    .Msle(d5 => d5\n                        .Offset(10d)\n                    )\n                    .RSquared(new Dictionary<string, object>() { })\n                )\n                .PredictedField(x => x.Ml.PricePrediction)\n            )\n        )\n        .Index(\"house_price_predictions\")\n        .Query(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Ml.IsTraining)\n                        .Value(false)\n                    )\n                )\n            )\n        )\n    );"
+      "code": "var response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .Regression(d3 => d3\n                .ActualField(x => x.Price)\n                .Metrics(d4 => d4\n                    .Huber(d5 => d5\n                        .Delta(1.5d)\n                    )\n                    .Mse(new Dictionary<string, object>() { })\n                    .Msle(d5 => d5\n                        .Offset(10d)\n                    )\n                    .RSquared(new Dictionary<string, object>() { })\n                )\n                .PredictedField(x => x.Ml.PricePrediction)\n            )\n        )\n        .Index(\"house_price_predictions\")\n        .Query(d2 => d2\n            .Bool(d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.Ml.IsTraining)\n                        .Value(false)\n                    )\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -12642,7 +12642,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .Classification(d3 => d3\n                .ActualField(x => x.AnimalClass)\n                .Metrics(d4 => d4\n                    .MulticlassConfusionMatrix(new Dictionary<string, object>() { })\n                )\n                .PredictedField(x => x.Ml.AnimalClassPrediction)\n            )\n        )\n        .Index(\"animal_classification\")\n    );"
+      "code": "var response = await client.MachineLearning\n    .EvaluateDataFrameAsync(d1 => d1\n        .Evaluation(d2 => d2\n            .Classification(d3 => d3\n                .ActualField(x => x.AnimalClass)\n                .Metrics(d4 => d4\n                    .MulticlassConfusionMatrix(new Dictionary<string, object>() { })\n                )\n                .PredictedField(x => x.Ml.AnimalClassPrediction)\n            )\n        )\n        .Index(\"animal_classification\")\n    );"
     },
     {
       "language": "Java",
@@ -12672,7 +12672,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.MachineLearning;\n\nvar response = await client.MachineLearning\n    .DeleteForecastAsync(new DeleteForecastRequest()\n    {\n        ForecastId = \"_all\",\n        JobId = \"total-requests\"\n    });"
+      "code": "var response = await client.MachineLearning\n    .DeleteForecastAsync(new DeleteForecastRequest()\n    {\n        ForecastId = \"_all\",\n        JobId = \"total-requests\"\n    });"
     },
     {
       "language": "Java",
@@ -13182,7 +13182,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.MachineLearning;\nusing System;\nusing System.Globalization;\n\nvar response = await client.MachineLearning\n    .GetBucketsAsync(new GetBucketsRequest()\n    {\n        JobId = \"low_request_rate\",\n        AnomalyScore = 80d,\n        Start = DateTimeOffset.Parse(\"2016-02-03T20:10:00.0010000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)\n    });"
+      "code": "var response = await client.MachineLearning\n    .GetBucketsAsync(new GetBucketsRequest()\n    {\n        JobId = \"low_request_rate\",\n        AnomalyScore = 80d,\n        Start = DateTimeOffset.Parse(\"2016-02-03T20:10:00.0010000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)\n    });"
     },
     {
       "language": "Java",
@@ -13212,7 +13212,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.MachineLearning;\n\nvar response = await client.MachineLearning\n    .StartTrainedModelDeploymentAsync(modelId: \"elastic__distilbert-base-uncased-finetuned-conll03-english\", d1 => d1\n        .Timeout(\"1m\")\n        .WaitFor(DeploymentAllocationState.Started)\n    );"
+      "code": "var response = await client.MachineLearning\n    .StartTrainedModelDeploymentAsync(modelId: \"elastic__distilbert-base-uncased-finetuned-conll03-english\", d1 => d1\n        .Timeout(\"1m\")\n        .WaitFor(DeploymentAllocationState.Started)\n    );"
     },
     {
       "language": "Java",
@@ -13272,7 +13272,7 @@
     },
     {
       "language": "C#",
-      "code": "using System;\nusing System.Globalization;\n\nvar response = await client.MachineLearning\n    .GetRecordsAsync(jobId: \"low_request_rate\", d1 => d1\n        .Desc(true)\n        .Sort(x => x.RecordScore)\n        .Start(DateTimeOffset.Parse(\"2016-02-08T15:08:20.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n    );"
+      "code": "var response = await client.MachineLearning\n    .GetRecordsAsync(jobId: \"low_request_rate\", d1 => d1\n        .Desc(true)\n        .Sort(x => x.RecordScore)\n        .Start(DateTimeOffset.Parse(\"2016-02-08T15:08:20.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n    );"
     },
     {
       "language": "Java",
@@ -13332,7 +13332,7 @@
     },
     {
       "language": "C#",
-      "code": "using System;\nusing System.Globalization;\n\nvar response = await client.MachineLearning\n    .StartDatafeedAsync(datafeedId: \"datafeed-low_request_rate\", d1 => d1\n        .Start(DateTimeOffset.Parse(\"2019-04-07T18:22:16.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n    );"
+      "code": "var response = await client.MachineLearning\n    .StartDatafeedAsync(datafeedId: \"datafeed-low_request_rate\", d1 => d1\n        .Start(DateTimeOffset.Parse(\"2019-04-07T18:22:16.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n    );"
     },
     {
       "language": "Java",
@@ -13422,7 +13422,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.MachineLearning;\nusing System;\nusing System.Globalization;\n\nvar response = await client.MachineLearning\n    .GetModelSnapshotsAsync(new GetModelSnapshotsRequest()\n    {\n        JobId = \"high_sum_total_sales\",\n        Start = DateTimeOffset.Parse(\"2019-12-03T19:43:56.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)\n    });"
+      "code": "var response = await client.MachineLearning\n    .GetModelSnapshotsAsync(new GetModelSnapshotsRequest()\n    {\n        JobId = \"high_sum_total_sales\",\n        Start = DateTimeOffset.Parse(\"2019-12-03T19:43:56.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)\n    });"
     },
     {
       "language": "Java",
@@ -13542,7 +13542,7 @@
     },
     {
       "language": "C#",
-      "code": "using System;\nusing System.Globalization;\n\nvar response = await client.MachineLearning\n    .GetOverallBucketsAsync(jobId: \"job-*\", d1 => d1\n        .OverallScore(80d)\n        .Start(DateTimeOffset.Parse(\"2014-06-23T14:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n    );"
+      "code": "var response = await client.MachineLearning\n    .GetOverallBucketsAsync(jobId: \"job-*\", d1 => d1\n        .OverallScore(80d)\n        .Start(DateTimeOffset.Parse(\"2014-06-23T14:00:00.0000000+00:00\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind))\n    );"
     },
     {
       "language": "Java",
@@ -13778,7 +13778,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.QueryDsl;\n\nvar response = await client.MachineLearning\n    .PutDataFrameAnalyticsAsync(id: \"model-flight-delays-pre\", d1 => d1\n        .Analysis(d2 => d2\n            .Regression(d3 => d3\n                .DependentVariable(\"FlightDelayMin\")\n                .TrainingPercent(new Percentage(90f))\n            )\n        )\n        .AnalyzedFields(d2 => d2\n            .Excludes(\"FlightNum\")\n            .Includes()\n        )\n        .Dest(d2 => d2\n            .Index(\"df-flight-delays\")\n            .ResultsField(x => x.MlResults)\n        )\n        .ModelMemoryLimit(\"100mb\")\n        .Source(d2 => d2\n            .Indices(new[] { \"kibana_sample_data_flights\" })\n            .Query(d3 => d3\n                .Range(new UntypedRangeQuery()\n                {\n                    Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.DistanceKilometers),\n                    Gt = 0\n                })\n            )\n            .Source(d3 => d3\n                .Excludes(\"FlightDelay\", \"FlightDelayType\")\n                .Includes()\n            )\n        )\n    );"
+      "code": "var response = await client.MachineLearning\n    .PutDataFrameAnalyticsAsync(id: \"model-flight-delays-pre\", d1 => d1\n        .Analysis(d2 => d2\n            .Regression(d3 => d3\n                .DependentVariable(\"FlightDelayMin\")\n                .TrainingPercent(new Percentage(90f))\n            )\n        )\n        .AnalyzedFields(d2 => d2\n            .Excludes(\"FlightNum\")\n            .Includes()\n        )\n        .Dest(d2 => d2\n            .Index(\"df-flight-delays\")\n            .ResultsField(x => x.MlResults)\n        )\n        .ModelMemoryLimit(\"100mb\")\n        .Source(d2 => d2\n            .Indices(new[] { \"kibana_sample_data_flights\" })\n            .Query(d3 => d3\n                .Range(new UntypedRangeQuery()\n                {\n                    Field = global::Elastic.Clients.Elasticsearch.Infer.Field<MyDocument>(x => x.DistanceKilometers),\n                    Gt = 0\n                })\n            )\n            .Source(d3 => d3\n                .Excludes(\"FlightDelay\", \"FlightDelayType\")\n                .Includes()\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -14280,7 +14280,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Rollup;\n\nvar response = await client.Rollup\n    .PutJobAsync(id: \"sensor\", d1 => d1\n        .Cron(\"*/30 * * * * ?\")\n        .Groups(d2 => d2\n            .DateHistogram(d3 => d3\n                .Delay(\"7d\")\n                .Field(x => x.Timestamp)\n                .FixedInterval(\"1h\")\n            )\n            .Terms(d3 => d3\n                .Fields(x => x.Node)\n            )\n        )\n        .IndexPattern(\"sensor-*\")\n        .Metrics(d2 => d2\n            .Field(x => x.Temperature)\n            .Metrics(Metric.Min, Metric.Max, Metric.Sum), d2 => d2\n            .Field(x => x.Voltage)\n            .Metrics(Metric.Avg)\n        )\n        .PageSize(1000)\n        .RollupIndex(\"sensor_rollup\")\n    );"
+      "code": "var response = await client.Rollup\n    .PutJobAsync(id: \"sensor\", d1 => d1\n        .Cron(\"*/30 * * * * ?\")\n        .Groups(d2 => d2\n            .DateHistogram(d3 => d3\n                .Delay(\"7d\")\n                .Field(x => x.Timestamp)\n                .FixedInterval(\"1h\")\n            )\n            .Terms(d3 => d3\n                .Fields(x => x.Node)\n            )\n        )\n        .IndexPattern(\"sensor-*\")\n        .Metrics(d2 => d2\n            .Field(x => x.Temperature)\n            .Metrics(Metric.Min, Metric.Max, Metric.Sum), d2 => d2\n            .Field(x => x.Voltage)\n            .Metrics(Metric.Avg)\n        )\n        .PageSize(1000)\n        .RollupIndex(\"sensor_rollup\")\n    );"
     },
     {
       "language": "Java",
@@ -15172,7 +15172,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"mistral-embeddings-test\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"mistral\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Mistral-API-Key\",\n              \"model\": \"mistral-embed\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"mistral-embeddings-test\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"mistral\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Mistral-API-Key\",\n              \"model\": \"mistral-embed\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15318,7 +15318,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"jinaai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"jinaai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"jina-embeddings-v3\",\n              \"api_key\": \"JinaAi-Api-key\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"jinaai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"jinaai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"jina-embeddings-v3\",\n              \"api_key\": \"JinaAi-Api-key\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15348,7 +15348,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"jinaai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"jinaai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"JinaAI-Api-key\",\n              \"model_id\": \"jina-reranker-v2-base-multilingual\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"top_n\": 10,\n              \"return_documents\": true\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"jinaai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"jinaai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"JinaAI-Api-key\",\n              \"model_id\": \"jina-reranker-v2-base-multilingual\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"top_n\": 10,\n              \"return_documents\": true\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15378,7 +15378,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .UpdateAsync(new UpdateInferenceRequest()\n    {\n        InferenceId = \"my-inference-endpoint\",\n        InferenceConfig = new()\n        {\n            Service = \"example-service\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"\\u003CAPI_KEY\\u003E\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .UpdateAsync(new UpdateInferenceRequest()\n    {\n        InferenceId = \"my-inference-endpoint\",\n        InferenceConfig = new()\n        {\n            Service = \"example-service\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"\\u003CAPI_KEY\\u003E\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15408,7 +15408,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elser\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"num_allocations\": 1,\n              \"num_threads\": 1\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elser\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"num_allocations\": 1,\n              \"num_threads\": 1\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15438,7 +15438,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elser\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 3,\n                \"max_number_of_allocations\": 10\n              },\n              \"num_threads\": 1\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elser\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 3,\n                \"max_number_of_allocations\": 10\n              },\n              \"num_threads\": 1\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15468,7 +15468,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\n\nvar response = await client.Inference\n    .DeleteAsync(new DeleteInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding\n    });"
+      "code": "var response = await client.Inference\n    .DeleteAsync(new DeleteInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding\n    });"
     },
     {
       "language": "Java",
@@ -15498,7 +15498,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"cohere-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Cohere-Api-key\",\n              \"model_id\": \"embed-english-light-v3.0\",\n              \"embedding_type\": \"byte\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"cohere-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Cohere-Api-key\",\n              \"model_id\": \"embed-english-light-v3.0\",\n              \"embedding_type\": \"byte\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15528,7 +15528,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"cohere-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Cohere-API-key\",\n              \"model_id\": \"rerank-english-v3.0\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"top_n\": 10,\n              \"return_documents\": true\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"cohere-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Cohere-API-key\",\n              \"model_id\": \"rerank-english-v3.0\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"top_n\": 10,\n              \"return_documents\": true\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15558,7 +15558,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_ai_studio_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googleaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"api-key\",\n              \"model_id\": \"model-id\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_ai_studio_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googleaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"api-key\",\n              \"model_id\": \"model-id\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15588,7 +15588,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-rerank-model\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"rerank-english-v3.0\",\n              \"api_key\": \"{{COHERE_API_KEY}}\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-rerank-model\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"rerank-english-v3.0\",\n              \"api_key\": \"{{COHERE_API_KEY}}\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15618,7 +15618,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"voyageai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"voyageai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"rerank-2\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"voyageai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"voyageai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"rerank-2\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15648,7 +15648,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"voyageai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"voyage-3-large\",\n              \"dimensions\": 512\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"voyageai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"voyage-3-large\",\n              \"dimensions\": 512\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15678,7 +15678,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"watsonx-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"watsonxai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Watsonx-API-Key\",\n              \"url\": \"Wastonx-URL\",\n              \"model_id\": \"ibm/slate-30m-english-rtrvr\",\n              \"project_id\": \"IBM-Cloud-ID\",\n              \"api_version\": \"2024-03-14\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"watsonx-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"watsonxai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Watsonx-API-Key\",\n              \"url\": \"Wastonx-URL\",\n              \"model_id\": \"ibm/slate-30m-english-rtrvr\",\n              \"project_id\": \"IBM-Cloud-ID\",\n              \"api_version\": \"2024-03-14\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15738,7 +15738,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\n\nvar response = await client.Inference\n    .GetAsync(d1 => d1\n        .InferenceId(\"my-elser-model\")\n        .TaskType(TaskType.SparseEmbedding)\n    );"
+      "code": "var response = await client.Inference\n    .GetAsync(d1 => d1\n        .InferenceId(\"my-elser-model\")\n        .TaskType(TaskType.SparseEmbedding)\n    );"
     },
     {
       "language": "Java",
@@ -15768,7 +15768,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"anthropic_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"anthropic\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Anthropic-Api-Key\",\n              \"model_id\": \"Model-ID\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"max_tokens\": 1024\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"anthropic_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"anthropic\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Anthropic-Api-Key\",\n              \"model_id\": \"Model-ID\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"max_tokens\": 1024\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15828,7 +15828,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_vertex_ai_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"service_account_json\": \"service-account-json\",\n              \"project_id\": \"project-id\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_vertex_ai_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"service_account_json\": \"service-account-json\",\n              \"project_id\": \"project-id\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15858,7 +15858,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_vertex_ai_embeddingss\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"service_account_json\": \"service-account-json\",\n              \"model_id\": \"model-id\",\n              \"location\": \"location\",\n              \"project_id\": \"project-id\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_vertex_ai_embeddingss\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"service_account_json\": \"service-account-json\",\n              \"model_id\": \"model-id\",\n              \"location\": \"location\",\n              \"project_id\": \"project-id\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15888,7 +15888,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"hugging-face-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"hugging_face\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"hugging-face-access-token\",\n              \"url\": \"url-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"hugging-face-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"hugging_face\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"hugging-face-access-token\",\n              \"url\": \"url-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15918,7 +15918,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"hugging-face-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"hugging_face\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"hugging-face-access-token\",\n              \"url\": \"url-endpoint\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"return_documents\": true,\n              \"top_n\": 3\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"hugging-face-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"hugging_face\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"hugging-face-access-token\",\n              \"url\": \"url-endpoint\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"return_documents\": true,\n              \"top_n\": 3\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15948,7 +15948,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_bedrock_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"amazonbedrock\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"provider\": \"amazontitan\",\n              \"model\": \"amazon.titan-embed-text-v2:0\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_bedrock_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"amazonbedrock\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"provider\": \"amazontitan\",\n              \"model\": \"amazon.titan-embed-text-v2:0\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -15978,7 +15978,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_bedrock_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"amazonbedrock\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"provider\": \"amazontitan\",\n              \"model\": \"amazon.titan-text-premier-v1:0\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_bedrock_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"amazonbedrock\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"provider\": \"amazontitan\",\n              \"model\": \"amazon.titan-text-premier-v1:0\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16008,7 +16008,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"openai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"OpenAI-API-Key\",\n              \"model_id\": \"gpt-3.5-turbo\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"openai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"OpenAI-API-Key\",\n              \"model_id\": \"gpt-3.5-turbo\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16038,7 +16038,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"openai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"OpenAI-API-Key\",\n              \"model_id\": \"text-embedding-3-small\",\n              \"dimensions\": 128\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"openai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"OpenAI-API-Key\",\n              \"model_id\": \"text-embedding-3-small\",\n              \"dimensions\": 128\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16158,7 +16158,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-text-embedding-001\",\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-text-embedding-001\",\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16188,7 +16188,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_sparse\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-text-sparse-embedding-001\",\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_sparse\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-text-sparse-embedding-001\",\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16218,7 +16218,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-bge-reranker-larger\",\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-bge-reranker-larger\",\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16248,7 +16248,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-qwen-turbo\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"alibabacloud_ai_search_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"alibabacloud-ai-search\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"host\": \"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\n              \"api_key\": \"AlibabaCloud-API-Key\",\n              \"service_id\": \"ops-qwen-turbo\",\n              \"workspace\": \"default\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16278,7 +16278,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_openai_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"azureopenai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Api-Key\",\n              \"resource_name\": \"Resource-name\",\n              \"deployment_id\": \"Deployment-id\",\n              \"api_version\": \"2024-02-01\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_openai_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"azureopenai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Api-Key\",\n              \"resource_name\": \"Resource-name\",\n              \"deployment_id\": \"Deployment-id\",\n              \"api_version\": \"2024-02-01\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16308,7 +16308,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_openai_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"azureopenai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Api-Key\",\n              \"resource_name\": \"Resource-name\",\n              \"deployment_id\": \"Deployment-id\",\n              \"api_version\": \"2024-02-01\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_openai_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"azureopenai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Api-Key\",\n              \"resource_name\": \"Resource-name\",\n              \"deployment_id\": \"Deployment-id\",\n              \"api_version\": \"2024-02-01\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16368,7 +16368,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-e5-model\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 3,\n                \"max_number_of_allocations\": 10\n              },\n              \"num_threads\": 1,\n              \"model_id\": \".multilingual-e5-small\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-e5-model\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 3,\n                \"max_number_of_allocations\": 10\n              },\n              \"num_threads\": 1,\n              \"model_id\": \".multilingual-e5-small\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16398,7 +16398,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-msmarco-minilm-model\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"num_allocations\": 1,\n              \"num_threads\": 1,\n              \"model_id\": \"msmarco-MiniLM-L12-cos-v5\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-msmarco-minilm-model\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"num_allocations\": 1,\n              \"num_threads\": 1,\n              \"model_id\": \"msmarco-MiniLM-L12-cos-v5\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16428,7 +16428,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-e5-model\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"num_allocations\": 1,\n              \"num_threads\": 1,\n              \"model_id\": \".multilingual-e5-small\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-e5-model\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"num_allocations\": 1,\n              \"num_threads\": 1,\n              \"model_id\": \".multilingual-e5-small\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16458,7 +16458,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elastic-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \".rerank-v1\",\n              \"num_threads\": 1,\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 1,\n                \"max_number_of_allocations\": 4\n              }\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elastic-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \".rerank-v1\",\n              \"num_threads\": 1,\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 1,\n                \"max_number_of_allocations\": 4\n              }\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16488,7 +16488,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 1,\n                \"max_number_of_allocations\": 4\n              },\n              \"num_threads\": 1,\n              \"model_id\": \".elser_model_2\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-elser-model\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"adaptive_allocations\": {\n                \"enabled\": true,\n                \"min_number_of_allocations\": 1,\n                \"max_number_of_allocations\": 4\n              },\n              \"num_threads\": 1,\n              \"model_id\": \".elser_model_2\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16518,7 +16518,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"use_existing_deployment\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"deployment_id\": \".elser_model_2\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"use_existing_deployment\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"elasticsearch\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"deployment_id\": \".elser_model_2\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16548,7 +16548,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_ai_studio_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"azureaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Azure-AI-Studio-API-key\",\n              \"target\": \"Target-URI\",\n              \"provider\": \"databricks\",\n              \"endpoint_type\": \"realtime\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_ai_studio_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"azureaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Azure-AI-Studio-API-key\",\n              \"target\": \"Target-URI\",\n              \"provider\": \"databricks\",\n              \"endpoint_type\": \"realtime\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16578,7 +16578,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_ai_studio_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"azureaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Azure-AI-Studio-API-key\",\n              \"target\": \"Target-Uri\",\n              \"provider\": \"openai\",\n              \"endpoint_type\": \"token\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_ai_studio_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"azureaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Azure-AI-Studio-API-key\",\n              \"target\": \"Target-Uri\",\n              \"provider\": \"openai\",\n              \"endpoint_type\": \"token\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -16638,7 +16638,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.QueryRules;\n\nvar response = await client.QueryRules\n    .PutRulesetAsync(rulesetId: \"my-ruleset\", d1 => d1\n        .Rules(d2 => d2\n            .Actions(d3 => d3\n                .Ids([\"id1\", \"id2\"])\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Contains)\n                .Values([\"pugs\", \"puggles\"]), d3 => d3\n                .Metadata(\"user_country\")\n                .Type(QueryRuleCriteriaType.Exact)\n                .Values([\"us\"])\n            )\n            .RuleId(\"my-rule1\")\n            .Type(QueryRuleType.Pinned), d2 => d2\n            .Actions(d3 => d3\n                .Docs(d4 => d4\n                    .Id(\"id3\")\n                    .Index(\"index1\"), d4 => d4\n                    .Id(\"id4\")\n                    .Index(\"index2\")\n                )\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Fuzzy)\n                .Values([\"rescue dogs\"])\n            )\n            .RuleId(\"my-rule2\")\n            .Type(QueryRuleType.Pinned)\n        )\n    );"
+      "code": "var response = await client.QueryRules\n    .PutRulesetAsync(rulesetId: \"my-ruleset\", d1 => d1\n        .Rules(d2 => d2\n            .Actions(d3 => d3\n                .Ids([\"id1\", \"id2\"])\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Contains)\n                .Values([\"pugs\", \"puggles\"]), d3 => d3\n                .Metadata(\"user_country\")\n                .Type(QueryRuleCriteriaType.Exact)\n                .Values([\"us\"])\n            )\n            .RuleId(\"my-rule1\")\n            .Type(QueryRuleType.Pinned), d2 => d2\n            .Actions(d3 => d3\n                .Docs(d4 => d4\n                    .Id(\"id3\")\n                    .Index(\"index1\"), d4 => d4\n                    .Id(\"id4\")\n                    .Index(\"index2\")\n                )\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Fuzzy)\n                .Values([\"rescue dogs\"])\n            )\n            .RuleId(\"my-rule2\")\n            .Type(QueryRuleType.Pinned)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -16668,7 +16668,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.QueryRules\n    .TestAsync(rulesetId: \"my-ruleset\", d1 => d1\n        .MatchCriteria(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"puggles\" }\n        })\n    );"
+      "code": "var response = await client.QueryRules\n    .TestAsync(rulesetId: \"my-ruleset\", d1 => d1\n        .MatchCriteria(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"puggles\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -16818,7 +16818,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.QueryRules;\n\nvar response = await client.QueryRules\n    .PutRulesetAsync(rulesetId: \"my-ruleset\", d1 => d1\n        .Rules(d2 => d2\n            .Actions(d3 => d3\n                .Ids([\"id1\", \"id2\"])\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Contains)\n                .Values([\"pugs\", \"puggles\"]), d3 => d3\n                .Metadata(\"user_country\")\n                .Type(QueryRuleCriteriaType.Exact)\n                .Values([\"us\"])\n            )\n            .RuleId(\"my-rule1\")\n            .Type(QueryRuleType.Pinned), d2 => d2\n            .Actions(d3 => d3\n                .Docs(d4 => d4\n                    .Id(\"id3\")\n                    .Index(\"index1\"), d4 => d4\n                    .Id(\"id4\")\n                    .Index(\"index2\")\n                )\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Fuzzy)\n                .Values([\"rescue dogs\"])\n            )\n            .RuleId(\"my-rule2\")\n            .Type(QueryRuleType.Pinned)\n        )\n    );"
+      "code": "var response = await client.QueryRules\n    .PutRulesetAsync(rulesetId: \"my-ruleset\", d1 => d1\n        .Rules(d2 => d2\n            .Actions(d3 => d3\n                .Ids([\"id1\", \"id2\"])\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Contains)\n                .Values([\"pugs\", \"puggles\"]), d3 => d3\n                .Metadata(\"user_country\")\n                .Type(QueryRuleCriteriaType.Exact)\n                .Values([\"us\"])\n            )\n            .RuleId(\"my-rule1\")\n            .Type(QueryRuleType.Pinned), d2 => d2\n            .Actions(d3 => d3\n                .Docs(d4 => d4\n                    .Id(\"id3\")\n                    .Index(\"index1\"), d4 => d4\n                    .Id(\"id4\")\n                    .Index(\"index2\")\n                )\n            )\n            .Criteria(d3 => d3\n                .Metadata(\"user_query\")\n                .Type(QueryRuleCriteriaType.Fuzzy)\n                .Values([\"rescue dogs\"])\n            )\n            .RuleId(\"my-rule2\")\n            .Type(QueryRuleType.Pinned)\n        )\n    );"
     },
     {
       "language": "Java",
@@ -16998,7 +16998,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing Elastic.Clients.Elasticsearch.Aggregations;\n\nvar response = await client.AsyncSearch\n    .SubmitAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"sales*\" })\n        .Aggregations(d2 => d2\n            .Add(\"sale_date\", d3 => d3\n                .DateHistogram(d4 => d4\n                    .CalendarInterval(CalendarInterval.Day)\n                    .Field(x => x.Date)\n                )\n            )\n        )\n        .Sort(d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Date)\n                .Order(SortOrder.Asc)\n            )\n        )\n    );"
+      "code": "var response = await client.AsyncSearch\n    .SubmitAsync<MyDocument>(d1 => d1\n        .Indices(new[] { \"sales*\" })\n        .Aggregations(d2 => d2\n            .Add(\"sale_date\", d3 => d3\n                .DateHistogram(d4 => d4\n                    .CalendarInterval(CalendarInterval.Day)\n                    .Field(x => x.Date)\n                )\n            )\n        )\n        .Sort(d2 => d2\n            .Field(d3 => d3\n                .Field(x => x.Date)\n                .Order(SortOrder.Asc)\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -17532,7 +17532,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client.SearchApplication\n    .RenderQueryAsync(name: \"my-app\", d1 => d1\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"my first query\" },\n            { \"text_fields\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            [\n              {\n                \"name\": \"title\",\n                \"boost\": 5\n              },\n              {\n                \"name\": \"description\",\n                \"boost\": 1\n              }\n            ]\n            \"\"\") }\n        })\n    );"
+      "code": "var response = await client.SearchApplication\n    .RenderQueryAsync(name: \"my-app\", d1 => d1\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"my first query\" },\n            { \"text_fields\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            [\n              {\n                \"name\": \"title\",\n                \"boost\": 5\n              },\n              {\n                \"name\": \"description\",\n                \"boost\": 1\n              }\n            ]\n            \"\"\") }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -17648,7 +17648,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.SearchApplication;\nusing System.Text.Json;\n\nvar response = await client.SearchApplication\n    .PostBehavioralAnalyticsEventAsync(collectionName: \"my_analytics_collection\", eventType: EventType.SearchClick, d1 => d1\n        .Payload(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n        {\n          \"session\": {\n            \"id\": \"1797ca95-91c9-4e2e-b1bd-9c38e6f386a9\"\n          },\n          \"user\": {\n            \"id\": \"5f26f01a-bbee-4202-9298-81261067abbd\"\n          },\n          \"search\": {\n            \"query\": \"search term\",\n            \"results\": {\n              \"items\": [\n                {\n                  \"document\": {\n                    \"id\": \"123\",\n                    \"index\": \"products\"\n                  }\n                }\n              ],\n              \"total_results\": 10\n            },\n            \"sort\": {\n              \"name\": \"relevance\"\n            },\n            \"search_application\": \"website\"\n          },\n          \"document\": {\n            \"id\": \"123\",\n            \"index\": \"products\"\n          }\n        }\n        \"\"\"))\n    );"
+      "code": "var response = await client.SearchApplication\n    .PostBehavioralAnalyticsEventAsync(collectionName: \"my_analytics_collection\", eventType: EventType.SearchClick, d1 => d1\n        .Payload(JsonSerializer.Deserialize<JsonElement>(\"\"\"\n        {\n          \"session\": {\n            \"id\": \"1797ca95-91c9-4e2e-b1bd-9c38e6f386a9\"\n          },\n          \"user\": {\n            \"id\": \"5f26f01a-bbee-4202-9298-81261067abbd\"\n          },\n          \"search\": {\n            \"query\": \"search term\",\n            \"results\": {\n              \"items\": [\n                {\n                  \"document\": {\n                    \"id\": \"123\",\n                    \"index\": \"products\"\n                  }\n                }\n              ],\n              \"total_results\": 10\n            },\n            \"sort\": {\n              \"name\": \"relevance\"\n            },\n            \"search_application\": \"website\"\n          },\n          \"document\": {\n            \"id\": \"123\",\n            \"index\": \"products\"\n          }\n        }\n        \"\"\"))\n    );"
     },
     {
       "language": "Java",
@@ -17768,7 +17768,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client.SearchApplication\n    .SearchAsync<MyDocument>(name: \"my-app\", d1 => d1\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"my first query\" },\n            { \"text_fields\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            [\n              {\n                \"name\": \"title\",\n                \"boost\": 5\n              },\n              {\n                \"name\": \"description\",\n                \"boost\": 1\n              }\n            ]\n            \"\"\") }\n        })\n    );"
+      "code": "var response = await client.SearchApplication\n    .SearchAsync<MyDocument>(name: \"my-app\", d1 => d1\n        .Params(new Dictionary<string, object>()\n        {\n            { \"query_string\", \"my first query\" },\n            { \"text_fields\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            [\n              {\n                \"name\": \"title\",\n                \"boost\": 5\n              },\n              {\n                \"name\": \"description\",\n                \"boost\": 1\n              }\n            ]\n            \"\"\") }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -18442,7 +18442,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch;\nusing System.Collections.Generic;\n\nvar response = await client.CrossClusterReplication\n    .PutAutoFollowPatternAsync(name: \"my_auto_follow_pattern\", d1 => d1\n        .FollowIndexPattern(\"{{leader_index}}-follower\")\n        .LeaderIndexPatterns(\"leader_index*\")\n        .MaxOutstandingReadRequests(16)\n        .MaxOutstandingWriteRequests(8)\n        .MaxReadRequestOperationCount(1024)\n        .MaxReadRequestSize(new ByteSize(\"1024k\"))\n        .MaxRetryDelay(\"10s\")\n        .MaxWriteBufferCount(512)\n        .MaxWriteBufferSize(new ByteSize(\"512k\"))\n        .MaxWriteRequestOperationCount(32768)\n        .MaxWriteRequestSize(new ByteSize(\"16k\"))\n        .ReadPollTimeout(\"30s\")\n        .RemoteCluster(\"remote_cluster\")\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.number_of_replicas\", 0 }\n        })\n    );"
+      "code": "var response = await client.CrossClusterReplication\n    .PutAutoFollowPatternAsync(name: \"my_auto_follow_pattern\", d1 => d1\n        .FollowIndexPattern(\"{{leader_index}}-follower\")\n        .LeaderIndexPatterns(\"leader_index*\")\n        .MaxOutstandingReadRequests(16)\n        .MaxOutstandingWriteRequests(8)\n        .MaxReadRequestOperationCount(1024)\n        .MaxReadRequestSize(new ByteSize(\"1024k\"))\n        .MaxRetryDelay(\"10s\")\n        .MaxWriteBufferCount(512)\n        .MaxWriteBufferSize(new ByteSize(\"512k\"))\n        .MaxWriteRequestOperationCount(32768)\n        .MaxWriteRequestSize(new ByteSize(\"16k\"))\n        .ReadPollTimeout(\"30s\")\n        .RemoteCluster(\"remote_cluster\")\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"index.number_of_replicas\", 0 }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -18978,7 +18978,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\nusing System.Text.Json;\n\nvar response = await client.IndexLifecycleManagement\n    .PutLifecycleAsync(name: \"my_policy\", d1 => d1\n        .Policy(d2 => d2\n            .Meta(new Dictionary<string, object>()\n            {\n                { \"description\", \"used for nginx log\" },\n                { \"project\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"name\": \"myProject\",\n                  \"department\": \"myDepartment\"\n                }\n                \"\"\") }\n            })\n            .Phases(d3 => d3\n                .Delete(d4 => d4\n                    .Actions(d5 => d5\n                        .Delete()\n                    )\n                    .MinAge(\"30d\")\n                )\n                .Warm(d4 => d4\n                    .Actions(d5 => d5\n                        .Forcemerge(d6 => d6\n                            .MaxNumSegments(1)\n                        )\n                    )\n                    .MinAge(\"10d\")\n                )\n            )\n        )\n    );"
+      "code": "var response = await client.IndexLifecycleManagement\n    .PutLifecycleAsync(name: \"my_policy\", d1 => d1\n        .Policy(d2 => d2\n            .Meta(new Dictionary<string, object>()\n            {\n                { \"description\", \"used for nginx log\" },\n                { \"project\", JsonSerializer.Deserialize<JsonElement>(\"\"\"\n                {\n                  \"name\": \"myProject\",\n                  \"department\": \"myDepartment\"\n                }\n                \"\"\") }\n            })\n            .Phases(d3 => d3\n                .Delete(d4 => d4\n                    .Actions(d5 => d5\n                        .Delete()\n                    )\n                    .MinAge(\"30d\")\n                )\n                .Warm(d4 => d4\n                    .Actions(d5 => d5\n                        .Forcemerge(d6 => d6\n                            .MaxNumSegments(1)\n                        )\n                    )\n                    .MinAge(\"10d\")\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -19158,7 +19158,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Sql;\n\nvar response = await client.Sql\n    .QueryAsync(d1 => d1\n        .Format(SqlFormat.Txt)\n        .Query(\"SELECT * FROM library ORDER BY page_count DESC LIMIT 5\")\n    );"
+      "code": "var response = await client.Sql\n    .QueryAsync(d1 => d1\n        .Format(SqlFormat.Txt)\n        .Query(\"SELECT * FROM library ORDER BY page_count DESC LIMIT 5\")\n    );"
     },
     {
       "language": "Java",
@@ -19218,7 +19218,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"cohere-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Cohere-API-key\",\n              \"model_id\": \"command-a-03-2025\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"cohere-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"cohere\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Cohere-API-key\",\n              \"model_id\": \"command-a-03-2025\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19248,7 +19248,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\",\n              \"dimensions\": 384,\n              \"element_type\": \"float\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\",\n              \"dimensions\": 384,\n              \"element_type\": \"float\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19278,7 +19278,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19308,7 +19308,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19338,7 +19338,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_sparse_embedding\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_sparse_embedding\",\n        TaskType = TaskType.SparseEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19368,7 +19368,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_sagemaker_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"amazon_sagemaker\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"api\": \"elastic\",\n              \"endpoint_name\": \"my-endpoint\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19398,7 +19398,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"ai21-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"ai21\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"ai21-api-key\",\n              \"model_id\": \"jamba-large\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"ai21-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"ai21\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"ai21-api-key\",\n              \"model_id\": \"jamba-large\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19428,7 +19428,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"ai21-chat-completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"ai21\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"ai21-api-key\",\n              \"model_id\": \"jamba-mini\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"ai21-chat-completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"ai21\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"ai21-api-key\",\n              \"model_id\": \"jamba-mini\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19458,7 +19458,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.openai.com/v1/embeddings\",\n              \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json;charset=utf-8\"\n              },\n              \"request\": \"{\\u0022input\\u0022: ${input}, \\u0022model\\u0022: \\u0022text-embedding-3-small\\u0022}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.openai.com/v1/embeddings\",\n              \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json;charset=utf-8\"\n              },\n              \"request\": \"{\\u0022input\\u0022: ${input}, \\u0022model\\u0022: \\u0022text-embedding-3-small\\u0022}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19488,7 +19488,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.cohere.com/v2/embed\",\n              \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n              },\n              \"request\": \"{\\u0022texts\\u0022: ${input}, \\u0022model\\u0022: \\u0022embed-v4.0\\u0022, \\u0022input_type\\u0022: ${input_type}}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"text_embeddings\": \"$.embeddings.float[*]\"\n                }\n              },\n              \"input_type\": {\n                \"translation\": {\n                  \"ingest\": \"search_document\",\n                  \"search\": \"search_query\"\n                },\n                \"default\": \"search_document\"\n              }\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.cohere.com/v2/embed\",\n              \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n              },\n              \"request\": \"{\\u0022texts\\u0022: ${input}, \\u0022model\\u0022: \\u0022embed-v4.0\\u0022, \\u0022input_type\\u0022: ${input_type}}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"text_embeddings\": \"$.embeddings.float[*]\"\n                }\n              },\n              \"input_type\": {\n                \"translation\": {\n                  \"ingest\": \"search_document\",\n                  \"search\": \"search_query\"\n                },\n                \"default\": \"search_document\"\n              }\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19518,7 +19518,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.cohere.com/v2/rerank\",\n              \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n              },\n              \"request\": \"{\\u0022documents\\u0022: ${input}, \\u0022query\\u0022: ${query}, \\u0022model\\u0022: \\u0022rerank-v3.5\\u0022}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"reranked_index\": \"$.results[*].index\",\n                  \"relevance_score\": \"$.results[*].relevance_score\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.cohere.com/v2/rerank\",\n              \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n              },\n              \"request\": \"{\\u0022documents\\u0022: ${input}, \\u0022query\\u0022: ${query}, \\u0022model\\u0022: \\u0022rerank-v3.5\\u0022}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"reranked_index\": \"$.results[*].index\",\n                  \"relevance_score\": \"$.results[*].relevance_score\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19548,7 +19548,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-text-embedding-hf\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"\\u003Cdedicated inference endpoint on HF\\u003E/v1/embeddings\",\n              \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n              },\n              \"request\": \"{\\u0022input\\u0022: ${input}}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-text-embedding-hf\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"\\u003Cdedicated inference endpoint on HF\\u003E/v1/embeddings\",\n              \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n              },\n              \"request\": \"{\\u0022input\\u0022: ${input}}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19578,7 +19578,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-rerank-jina\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.jina.ai/v1/rerank\",\n              \"headers\": {\n                \"Content-Type\": \"application/json\",\n                \"Authorization\": \"Bearer ${api_key}\"\n              },\n              \"request\": \"{\\u0022model\\u0022: \\u0022jina-reranker-v2-base-multilingual\\u0022,\\u0022query\\u0022: ${query},\\u0022documents\\u0022:${input}}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"relevance_score\": \"$.results[*].relevance_score\",\n                  \"reranked_index\": \"$.results[*].index\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"custom-rerank-jina\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"custom\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"secret_parameters\": {\n                \"api_key\": \"\\u003Capi key\\u003E\"\n              },\n              \"url\": \"https://api.jina.ai/v1/rerank\",\n              \"headers\": {\n                \"Content-Type\": \"application/json\",\n                \"Authorization\": \"Bearer ${api_key}\"\n              },\n              \"request\": \"{\\u0022model\\u0022: \\u0022jina-reranker-v2-base-multilingual\\u0022,\\u0022query\\u0022: ${query},\\u0022documents\\u0022:${input}}\",\n              \"response\": {\n                \"json_parser\": {\n                  \"relevance_score\": \"$.results[*].relevance_score\",\n                  \"reranked_index\": \"$.results[*].index\"\n                }\n              }\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19608,7 +19608,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_ai_studio_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"azureaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Azure-AI-Studio-API-key\",\n              \"target\": \"Target-URI\",\n              \"provider\": \"cohere\",\n              \"endpoint_type\": \"token\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_ai_studio_rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"azureaistudio\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Azure-AI-Studio-API-key\",\n              \"target\": \"Target-URI\",\n              \"provider\": \"cohere\",\n              \"endpoint_type\": \"token\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19660,7 +19660,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices\n    .RolloverAsync(new RolloverRequest()\n    {\n        Alias = \"my-data-stream\"\n    });"
+      "code": "var response = await client.Indices\n    .RolloverAsync(new RolloverRequest()\n    {\n        Alias = \"my-data-stream\"\n    });"
     },
     {
       "language": "Java",
@@ -19712,7 +19712,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"llama-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"llama\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"http://localhost:8321/v1/openai/v1/chat/completions\",\n              \"model_id\": \"llama3.2:3b\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"llama-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"llama\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"http://localhost:8321/v1/openai/v1/chat/completions\",\n              \"model_id\": \"llama3.2:3b\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19742,7 +19742,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"llama-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"llama\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"http://localhost:8321/v1/inference/embeddings\",\n              \"dimensions\": 384,\n              \"model_id\": \"all-MiniLM-L6-v2\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"llama-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"llama\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"http://localhost:8321/v1/inference/embeddings\",\n              \"dimensions\": 384,\n              \"model_id\": \"all-MiniLM-L6-v2\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19862,7 +19862,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Streams;\n\nvar response = await client.Streams.LogsEnableAsync(name: StreamType.LogsOtel);"
+      "code": "var response = await client.Streams.LogsEnableAsync(name: StreamType.LogsOtel);"
     },
     {
       "language": "Java",
@@ -19892,7 +19892,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Streams;\n\nvar response = await client.Streams.LogsDisableAsync(name: StreamType.LogsOtel);"
+      "code": "var response = await client.Streams.LogsDisableAsync(name: StreamType.LogsOtel);"
     },
     {
       "language": "Java",
@@ -19952,7 +19952,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_anthropic_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"anthropic\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/anthropic/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"max_tokens\": 128\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_anthropic_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"anthropic\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/anthropic/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"max_tokens\": 128\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -19982,7 +19982,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_anthropic_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"anthropic\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/anthropic/models/%MODEL_ID%:rawPredict\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/anthropic/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"max_tokens\": 128\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_anthropic_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"anthropic\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/anthropic/models/%MODEL_ID%:rawPredict\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/anthropic/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"max_tokens\": 128\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20012,7 +20012,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"contextualai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"contextualai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"ContextualAI-Api-key\",\n              \"model_id\": \"ctxl-rerank-v2-instruct-multilingual-mini\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"instruction\": \"Rerank the following documents based on their relevance to the query.\",\n              \"top_k\": 3\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"contextualai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"contextualai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"ContextualAI-Api-key\",\n              \"model_id\": \"ctxl-rerank-v2-instruct-multilingual-mini\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"instruction\": \"Rerank the following documents based on their relevance to the query.\",\n              \"top_k\": 3\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20146,7 +20146,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openshift-ai-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"openshift_ai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"openshift-ai-embeddings-url\",\n              \"api_key\": \"openshift-ai-embeddings-token\",\n              \"model_id\": \"gritlm-7b\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openshift-ai-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"openshift_ai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"openshift-ai-embeddings-url\",\n              \"api_key\": \"openshift-ai-embeddings-token\",\n              \"model_id\": \"gritlm-7b\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20176,7 +20176,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openshift-ai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"openshift_ai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"openshift-ai-rerank-url\",\n              \"api_key\": \"openshift-ai-rerank-token\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"return_documents\": true,\n              \"top_n\": 2\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openshift-ai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"openshift_ai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"openshift-ai-rerank-url\",\n              \"api_key\": \"openshift-ai-rerank-token\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"return_documents\": true,\n              \"top_n\": 2\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20206,7 +20206,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openshift-ai-chat-completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"openshift_ai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"openshift-ai-chat-completion-url\",\n              \"api_key\": \"openshift-ai-chat-completion-token\",\n              \"model_id\": \"llama-31-8b-instruct\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openshift-ai-chat-completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"openshift_ai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"openshift-ai-chat-completion-url\",\n              \"api_key\": \"openshift-ai-chat-completion-token\",\n              \"model_id\": \"llama-31-8b-instruct\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20236,7 +20236,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openshift-ai-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"openshift_ai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"openshift-ai-completion-url\",\n              \"api_key\": \"openshift-ai-completion-token\",\n              \"model_id\": \"llama-31-8b-instruct\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openshift-ai-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"openshift_ai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"openshift-ai-completion-url\",\n              \"api_key\": \"openshift-ai-completion-token\",\n              \"model_id\": \"llama-31-8b-instruct\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20266,7 +20266,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openshift-ai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"openshift_ai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"openshift-ai-rerank-url\",\n              \"api_key\": \"openshift-ai-rerank-token\",\n              \"model_id\": \"bge-reranker-v2-m3\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openshift-ai-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"openshift_ai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"openshift-ai-rerank-url\",\n              \"api_key\": \"openshift-ai-rerank-token\",\n              \"model_id\": \"bge-reranker-v2-m3\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20296,7 +20296,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-%PROJECT_ID%.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-%PROJECT_ID%.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20326,7 +20326,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-fasttryout.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-fasttryout.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20356,7 +20356,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-%PROJECT_ID%.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-%PROJECT_ID%.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20386,7 +20386,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20416,7 +20416,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_hugging_face_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"hugging_face\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_hugging_face_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"hugging_face\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20446,7 +20446,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_ai21_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"ai21\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/ai21/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_ai21_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"ai21\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/ai21/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20476,7 +20476,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"model_id\": \"meta/llama-3.3-70b-instruct-maas\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/openapi/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"model_id\": \"meta/llama-3.3-70b-instruct-maas\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/openapi/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20506,7 +20506,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20536,7 +20536,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_hugging_face_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"hugging_face\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_hugging_face_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"hugging_face\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20566,7 +20566,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"model_id\": \"meta/llama-3.3-70b-instruct-maas\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/openapi/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"model_id\": \"meta/llama-3.3-70b-instruct-maas\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/openapi/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20596,7 +20596,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-fasttryout.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-fasttryout.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20626,7 +20626,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_meta_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"meta\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20656,7 +20656,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_hugging_face_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"hugging_face\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-%PROJECT_ID%.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_hugging_face_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"hugging_face\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-%PROJECT_ID%.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20686,7 +20686,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_hugging_face_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"hugging_face\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-%PROJECT_ID%.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_hugging_face_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"hugging_face\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%ENDPOINT_ID%.%LOCATION_ID%-%PROJECT_ID%.prediction.vertexai.goog/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20716,7 +20716,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_ai21_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"ai21\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/ai21/models/%MODEL_ID%:rawPredict\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/ai21/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_ai21_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"ai21\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/ai21/models/%MODEL_ID%:rawPredict\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/ai21/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20746,7 +20746,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/endpoints/%ENDPOINT_ID%/chat/completions\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20776,7 +20776,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"model_id\": \"mistral-small-2503\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/mistralai/models/%MODEL_ID%:rawPredict\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/mistralai/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"model_id\": \"mistral-small-2503\",\n              \"service_account_json\": \"service-account-json\",\n              \"url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/mistralai/models/%MODEL_ID%:rawPredict\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/mistralai/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -20806,7 +20806,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"model_id\": \"mistral-small-2503\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/mistralai/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_model_garden_mistral_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"provider\": \"mistral\",\n              \"model_id\": \"mistral-small-2503\",\n              \"service_account_json\": \"service-account-json\",\n              \"streaming_url\": \"https://%LOCATION_ID%-aiplatform.googleapis.com/v1/projects/%PROJECT_ID%/locations/%LOCATION_ID%/publishers/mistralai/models/%MODEL_ID%:streamRawPredict\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21056,7 +21056,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"jinaai-embeddings-multimodal\",\n        TaskType = TaskType.Embedding,\n        InferenceConfig = new()\n        {\n            Service = \"jinaai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"jina-embeddings-v4\",\n              \"api_key\": \"JinaAi-Api-key\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"jinaai-embeddings-multimodal\",\n        TaskType = TaskType.Embedding,\n        InferenceConfig = new()\n        {\n            Service = \"jinaai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"jina-embeddings-v4\",\n              \"api_key\": \"JinaAi-Api-key\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21086,7 +21086,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"jinaai-embeddings-text-only\",\n        TaskType = TaskType.Embedding,\n        InferenceConfig = new()\n        {\n            Service = \"jinaai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"jina-embeddings-v3\",\n              \"api_key\": \"JinaAi-Api-key\",\n              \"multimodal_model\": false\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"jinaai-embeddings-text-only\",\n        TaskType = TaskType.Embedding,\n        InferenceConfig = new()\n        {\n            Service = \"jinaai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"jina-embeddings-v3\",\n              \"api_key\": \"JinaAi-Api-key\",\n              \"multimodal_model\": false\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21168,7 +21168,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"nvidia-completion-url\",\n              \"api_key\": \"nvidia-completion-token\",\n              \"model_id\": \"microsoft/phi-3-mini-128k-instruct\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"nvidia-completion-url\",\n              \"api_key\": \"nvidia-completion-token\",\n              \"model_id\": \"microsoft/phi-3-mini-128k-instruct\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21198,7 +21198,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"nvidia/llama-3.2-nv-embedqa-1b-v2\",\n              \"api_key\": \"nvidia-text-embeddings-token\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"input_type\": \"ingest\",\n              \"truncate\": \"start\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"nvidia/llama-3.2-nv-embedqa-1b-v2\",\n              \"api_key\": \"nvidia-text-embeddings-token\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"input_type\": \"ingest\",\n              \"truncate\": \"start\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21228,7 +21228,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-chat-completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"nvidia-chat-completion-url\",\n              \"api_key\": \"nvidia-chat-completion-token\",\n              \"model_id\": \"microsoft/phi-3-mini-128k-instruct\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-chat-completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"nvidia-chat-completion-url\",\n              \"api_key\": \"nvidia-chat-completion-token\",\n              \"model_id\": \"microsoft/phi-3-mini-128k-instruct\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21258,7 +21258,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"nvidia-completion-token\",\n              \"model_id\": \"microsoft/phi-3-mini-128k-instruct\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"nvidia-completion-token\",\n              \"model_id\": \"microsoft/phi-3-mini-128k-instruct\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21288,7 +21288,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"nvidia-rerank-token\",\n              \"model_id\": \"nv-rerank-qa-mistral-4b:1\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"nvidia-rerank-token\",\n              \"model_id\": \"nv-rerank-qa-mistral-4b:1\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21318,7 +21318,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"nvidia-rerank-url\",\n              \"api_key\": \"nvidia-rerank-token\",\n              \"model_id\": \"nv-rerank-qa-mistral-4b:1\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-rerank\",\n        TaskType = TaskType.Rerank,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"nvidia-rerank-url\",\n              \"api_key\": \"nvidia-rerank-token\",\n              \"model_id\": \"nv-rerank-qa-mistral-4b:1\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21348,7 +21348,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-chat-completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"nvidia-chat-completion-token\",\n              \"model_id\": \"microsoft/phi-3-mini-128k-instruct\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-chat-completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"nvidia-chat-completion-token\",\n              \"model_id\": \"microsoft/phi-3-mini-128k-instruct\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21378,7 +21378,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"nvidia-embeddings-url\",\n              \"api_key\": \"nvidia-embeddings-token\",\n              \"model_id\": \"nvidia/llama-3.2-nv-embedqa-1b-v2\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"nvidia-text-embedding\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"nvidia\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"url\": \"nvidia-embeddings-url\",\n              \"api_key\": \"nvidia-embeddings-token\",\n              \"model_id\": \"nvidia/llama-3.2-nv-embedqa-1b-v2\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21408,7 +21408,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"groq-chat-completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"groq\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"groq-api-key\",\n              \"model_id\": \"llama-3.3-70b-versatile\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"groq-chat-completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"groq\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"groq-api-key\",\n              \"model_id\": \"llama-3.3-70b-versatile\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21438,7 +21438,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_openai_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"azureopenai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Api-Key\",\n              \"resource_name\": \"Resource-name\",\n              \"deployment_id\": \"Deployment-id\",\n              \"api_version\": \"2024-02-01\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_openai_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"azureopenai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Api-Key\",\n              \"resource_name\": \"Resource-name\",\n              \"deployment_id\": \"Deployment-id\",\n              \"api_version\": \"2024-02-01\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21618,7 +21618,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_bedrock_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"amazonbedrock\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"provider\": \"amazontitan\",\n              \"model\": \"amazon.titan-text-premier-v1:0\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"amazon_bedrock_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"amazonbedrock\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"access_key\": \"AWS-access-key\",\n              \"secret_key\": \"AWS-secret-key\",\n              \"region\": \"us-east-1\",\n              \"provider\": \"amazontitan\",\n              \"model\": \"amazon.titan-text-premier-v1:0\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21648,7 +21648,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-fireworks-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"fireworksai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"your-api-key\",\n              \"model_id\": \"fireworks/qwen3-embedding-8b\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-fireworks-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"fireworksai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"your-api-key\",\n              \"model_id\": \"fireworks/qwen3-embedding-8b\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21678,7 +21678,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-fireworks-chat\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"fireworksai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"your-api-key\",\n              \"model_id\": \"accounts/fireworks/models/deepseek-v3p1\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-fireworks-chat\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"fireworksai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"your-api-key\",\n              \"model_id\": \"accounts/fireworks/models/deepseek-v3p1\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21708,7 +21708,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-fireworks-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"fireworksai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"your-api-key\",\n              \"model_id\": \"fireworks/qwen3-embedding-8b\",\n              \"dimensions\": 1024,\n              \"similarity\": \"cosine\",\n              \"rate_limit\": {\n                \"requests_per_minute\": 6000\n              }\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-fireworks-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"fireworksai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"your-api-key\",\n              \"model_id\": \"fireworks/qwen3-embedding-8b\",\n              \"dimensions\": 1024,\n              \"similarity\": \"cosine\",\n              \"rate_limit\": {\n                \"requests_per_minute\": 6000\n              }\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21738,7 +21738,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-fireworks-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"fireworksai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"your-api-key\",\n              \"model_id\": \"accounts/fireworks/models/deepseek-v3p1\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"my-fireworks-completion\",\n        TaskType = TaskType.Completion,\n        InferenceConfig = new()\n        {\n            Service = \"fireworksai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"your-api-key\",\n              \"model_id\": \"accounts/fireworks/models/deepseek-v3p1\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -21820,7 +21820,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_openai_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"azureopenai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_version\": \"2023-05-15\",\n              \"client_id\": \"12345\",\n              \"client_secret\": \"secret\",\n              \"deployment_id\": \"Deployment-id\",\n              \"resource_name\": \"Resource-name\",\n              \"scopes\": [\n                \"Scope-1\",\n                \"Scope-2\"\n              ],\n              \"tenant_id\": \"tenant id\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"headers\": {\n                \"Custom-Header-Key\": \"Custom header value\"\n              }\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"azure_openai_embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"azureopenai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_version\": \"2023-05-15\",\n              \"client_id\": \"12345\",\n              \"client_secret\": \"secret\",\n              \"deployment_id\": \"Deployment-id\",\n              \"resource_name\": \"Resource-name\",\n              \"scopes\": [\n                \"Scope-1\",\n                \"Scope-2\"\n              ],\n              \"tenant_id\": \"tenant id\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"headers\": {\n                \"Custom-Header-Key\": \"Custom header value\"\n              }\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -22116,7 +22116,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"anthropic_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"anthropic\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Anthropic-Api-Key\",\n              \"model_id\": \"claude-sonnet-4-5\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"max_tokens\": 1024\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"anthropic_chat_completion\",\n        TaskType = TaskType.ChatCompletion,\n        InferenceConfig = new()\n        {\n            Service = \"anthropic\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"api_key\": \"Anthropic-Api-Key\",\n              \"model_id\": \"claude-sonnet-4-5\"\n            }\n            \"\"\"),\n            TaskSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"max_tokens\": 1024\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -22146,7 +22146,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_vertex_ai_embeddings_global\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"service_account_json\": \"service-account-json\",\n              \"model_id\": \"model-id\",\n              \"project_id\": \"project-id\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"google_vertex_ai_embeddings_global\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"googlevertexai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"service_account_json\": \"service-account-json\",\n              \"model_id\": \"model-id\",\n              \"project_id\": \"project-id\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -22176,7 +22176,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.Inference;\nusing System.Text.Json;\n\nvar response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"openai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"text-embedding-3-small\",\n              \"client_id\": \"test_client_id\",\n              \"scopes\": [\n                \"scope1\",\n                \"scope2\"\n              ],\n              \"client_secret\": \"secret\",\n              \"token_url\": \"http://localhost:8080/token\",\n              \"url\": \"https://api.openai.com/v1/embeddings\"\n            }\n            \"\"\")\n        }\n    });"
+      "code": "var response = await client.Inference\n    .PutAsync(new PutInferenceRequest()\n    {\n        InferenceId = \"openai-embeddings\",\n        TaskType = TaskType.TextEmbedding,\n        InferenceConfig = new()\n        {\n            Service = \"openai\",\n            ServiceSettings = JsonSerializer.Deserialize<JsonElement>(\"\"\"\n            {\n              \"model_id\": \"text-embedding-3-small\",\n              \"client_id\": \"test_client_id\",\n              \"scopes\": [\n                \"scope1\",\n                \"scope2\"\n              ],\n              \"client_secret\": \"secret\",\n              \"token_url\": \"http://localhost:8080/token\",\n              \"url\": \"https://api.openai.com/v1/embeddings\"\n            }\n            \"\"\")\n        }\n    });"
     },
     {
       "language": "Java",
@@ -22266,7 +22266,7 @@
     },
     {
       "language": "C#",
-      "code": "using Elastic.Clients.Elasticsearch.IndexManagement;\n\nvar response = await client.Indices\n    .CreateAsync(index: \"test\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"alias_1\", new Alias())\n            .Add(\"alias_2\", d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n            )\n        )\n    );"
+      "code": "var response = await client.Indices\n    .CreateAsync(index: \"test\", d1 => d1\n        .Aliases(d2 => d2\n            .Add(\"alias_1\", new Alias())\n            .Add(\"alias_2\", d3 => d3\n                .Filter(d4 => d4\n                    .Term(d5 => d5\n                        .Field(x => x.User.Id)\n                        .Value(\"kimchy\")\n                    )\n                )\n            )\n        )\n    );"
     },
     {
       "language": "Java",
@@ -22416,7 +22416,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Esql\n    .PutDatasetAsync(name: \"access_logs\", d1 => d1\n        .DataSource(\"prod_s3_logs\")\n        .Description(\"Production access logs\")\n        .Resource(\"s3://logs-bucket/access/**/*.parquet\")\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"partition_detection\", \"hive\" }\n        })\n    );"
+      "code": "var response = await client.Esql\n    .PutDatasetAsync(name: \"access_logs\", d1 => d1\n        .DataSource(\"prod_s3_logs\")\n        .Description(\"Production access logs\")\n        .Resource(\"s3://logs-bucket/access/**/*.parquet\")\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"partition_detection\", \"hive\" }\n        })\n    );"
     },
     {
       "language": "Java",
@@ -22446,7 +22446,7 @@
     },
     {
       "language": "C#",
-      "code": "using System.Collections.Generic;\n\nvar response = await client.Esql\n    .PutDataSourceAsync(name: \"prod_s3_logs\", d1 => d1\n        .Description(\"Production S3 logs bucket\")\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"region\", \"us-east-1\" },\n            { \"auth\", \"static_credentials\" },\n            { \"access_key\", \"<AWS_ACCESS_KEY_ID>\" },\n            { \"secret_key\", \"<AWS_SECRET_ACCESS_KEY>\" }\n        })\n        .Type(\"s3\")\n    );"
+      "code": "var response = await client.Esql\n    .PutDataSourceAsync(name: \"prod_s3_logs\", d1 => d1\n        .Description(\"Production S3 logs bucket\")\n        .Settings(new Dictionary<string, object>()\n        {\n            { \"region\", \"us-east-1\" },\n            { \"auth\", \"static_credentials\" },\n            { \"access_key\", \"<AWS_ACCESS_KEY_ID>\" },\n            { \"secret_key\", \"<AWS_SECRET_ACCESS_KEY>\" }\n        })\n        .Type(\"s3\")\n    );"
     },
     {
       "language": "Java",

--- a/docs/examples/package-lock.json
+++ b/docs/examples/package-lock.json
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@elastic/request-converter-dotnet": {
-      "version": "0.0.0-main.g1cd4e5e34530",
-      "resolved": "https://registry.npmjs.org/@elastic/request-converter-dotnet/-/request-converter-dotnet-0.0.0-main.g1cd4e5e34530.tgz",
-      "integrity": "sha512-ipGCCmaJSowkcVL07iSYk7jrDC2qbQfn9cwTojyoaXvgN7xwsVSBXRuf5pqZUoT2/qn5rH6sSMHj7LJsgCzmOA==",
+      "version": "0.0.0-main.g9784f393693d",
+      "resolved": "https://registry.npmjs.org/@elastic/request-converter-dotnet/-/request-converter-dotnet-0.0.0-main.g9784f393693d.tgz",
+      "integrity": "sha512-mUrAw9DT98KdCFtxUh5ESTH+X600YunzIfUBTWVSVho8JfGrL5QAhTYBuIkciL9SxDBWCYT3v3mRdo9z83gk/g==",
       "license": "Apache-2.0"
     },
     "node_modules/@emotion/is-prop-valid": {


### PR DESCRIPTION
Follow-up to #6528: the C# examples carried stray `using` directives because the `latest-main` request-converter-dotnet build predated the `emit_usings` option - like elastic/elasticsearch-net#8951, elastic/elasticsearch-net#8953 had only merged to the staging branch and the release branches, never to main. Forward-ported in elastic/elasticsearch-net#8971 and republished as `0.0.0-main.g9784f393693d` (current `latest-main`, pinned in the lock).

This regeneration removes the `using` lines from 242 C# examples; the inline client-call format with multi-line wrapping is unchanged.