### PR TITLE
Mark custom routing as stack-only (not supported on Serverless)

### DIFF
--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -197,6 +197,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
     /**
      * A custom value that is used to route operations to a specific shard.
      * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
+     * @availability stack stability=stable
      * @ext_doc_id search-shard-routing
      */
     routing?: Routing

--- a/specification/_global/bulk/types.ts
+++ b/specification/_global/bulk/types.ts
@@ -107,6 +107,7 @@ export class OperationBase {
   _index?: IndexName
   /**
    * A custom value used to route operations to a specific shard, or multiple comma separated values.
+   * @availability stack stability=stable
    */
   routing?: string
   if_primary_term?: long

--- a/specification/_global/delete/DeleteRequest.ts
+++ b/specification/_global/delete/DeleteRequest.ts
@@ -118,6 +118,7 @@ export interface Request extends RequestBase {
     /**
      * A custom value used to route operations to a specific shard.
      * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
+     * @availability stack stability=stable
      */
     routing?: Routing
     /**

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -237,6 +237,7 @@ export interface Request extends RequestBase {
     /**
      * A custom value used to route operations to a specific shard.
      * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
+     * @availability stack stability=stable
      */
     routing?: Routing
     /**

--- a/specification/_global/index/IndexRequest.ts
+++ b/specification/_global/index/IndexRequest.ts
@@ -231,6 +231,7 @@ export interface Request<TDocument> extends RequestBase {
     /**
      * A custom value that is used to route operations to a specific shard.
      * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
+     * @availability stack stability=stable
      * @ext_doc_id search-shard-routing
      */
     routing?: Routing

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -126,6 +126,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
     /**
      * A custom value used to route operations to a specific shard.
      * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
+     * @availability stack stability=stable
      */
     routing?: Routing
     /**

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -251,6 +251,7 @@ export interface Request extends RequestBase {
     /**
      * A custom value used to route operations to a specific shard.
      * Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
+     * @availability stack stability=stable
      */
     routing?: Routing
     /**


### PR DESCRIPTION
## Summary

Custom routing is not supported on Elasticsearch Serverless. The `routing` parameter is currently present in the serverless OpenAPI spec for several write APIs, which misleads customers into thinking it works — it doesn't, and using it can cause data consistency and search reliability issues.

This PR adds `@availability stack stability=stable` to the `routing` parameter on the six affected APIs, which removes it from the generated `elasticsearch-serverless-openapi.json` and therefore the rendered serverless API reference pages.

## Affected APIs

- `POST /_bulk` (query param + per-operation body field in `OperationBase`)
- `PUT /{index}/_doc/{id}` (index)
- `DELETE /{index}/_doc/{id}` (delete)
- `POST /{index}/_delete_by_query`
- `POST /{index}/_update/{id}`
- `POST /{index}/_update_by_query`

## References

- elastic/docs-content-internal#1598 — customer-facing docs issue tracking this
- https://github.com/elastic/elasticsearch-team/issues/3908
- Pattern follows existing stack-only fields (e.g. `rank` in `SearchRequestBody.ts`)

## Test plan

- [ ] Confirm `routing` no longer appears in `elasticsearch-serverless-openapi.json` for the six affected endpoints after spec compilation
- [ ] Confirm `routing` still appears in `elasticsearch-openapi.json` (stack spec unchanged)
- [ ] Verify with @ppf2 / @pete-naylor that this matches the intended serverless behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)