### PR TITLE
Make ES|QL data federation APIs publicly visible again

### DIFF
--- a/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
+++ b/specification/esql/delete_data_source/DeleteDataSourceRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.delete_data_source
  * @cluster_privileges manage
- * @availability stack stability=experimental visibility=private
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-delete-data-source
  */

--- a/specification/esql/delete_dataset/DeleteDatasetRequest.ts
+++ b/specification/esql/delete_dataset/DeleteDatasetRequest.ts
@@ -29,7 +29,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.delete_dataset
  * @index_privileges manage
- * @availability stack stability=experimental visibility=private
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-delete-dataset
  */

--- a/specification/esql/get_data_source/GetDataSourceRequest.ts
+++ b/specification/esql/get_data_source/GetDataSourceRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.get_data_source
  * @cluster_privileges manage
- * @availability stack stability=experimental visibility=private
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-get-data-source
  */

--- a/specification/esql/get_dataset/GetDatasetRequest.ts
+++ b/specification/esql/get_dataset/GetDatasetRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name esql.get_dataset
  * @index_privileges manage
- * @availability stack stability=experimental visibility=private
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-get-dataset
  */

--- a/specification/esql/put_data_source/PutDataSourceRequest.ts
+++ b/specification/esql/put_data_source/PutDataSourceRequest.ts
@@ -32,7 +32,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  *
  * @rest_spec_name esql.put_data_source
  * @cluster_privileges manage
- * @availability stack stability=experimental visibility=private
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-put-data-source
  */

--- a/specification/esql/put_dataset/PutDatasetRequest.ts
+++ b/specification/esql/put_dataset/PutDatasetRequest.ts
@@ -33,7 +33,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  *
  * @rest_spec_name esql.put_dataset
  * @index_privileges manage
- * @availability stack stability=experimental visibility=private
+ * @availability stack stability=experimental visibility=public
  * @ext_doc_id esql-data-federation
  * @doc_id esql-put-dataset
  */


### PR DESCRIPTION
Update visibility from `private` to `public` for the ES|QL data source and dataset APIs so that API docs are published alongside the rest of the data federation documentation.

Reverses the visibility restriction from #6510 while keeping experimental stability and stack-only availability.

**APIs updated:**
- `esql.put_data_source`
- `esql.get_data_source`
- `esql.delete_data_source`
- `esql.put_dataset`
- `esql.get_dataset`
- `esql.delete_dataset`

Contributes to https://github.com/elastic/docs-content-internal/issues/1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)