### PR TITLE
Add @index_privileges to some ES|QL APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -11484,7 +11484,7 @@
           "esql"
         ],
         "summary": "Get async ES|QL query results",
-        "description": "Get the current status and available results or stored results for an ES|QL asynchronous query.\nIf the Elasticsearch security features are enabled, only the user who first submitted the ES|QL query can retrieve the results using this API.",
+        "description": "Get the current status and available results or stored results for an ES|QL asynchronous query.\nIf the Elasticsearch security features are enabled, only the user who first submitted the ES|QL query can retrieve the results using this API.\n\n## Required authorization\n\n* Index privileges: `read`\n",
         "externalDocs": {
           "description": "More about ES|QL reference",
           "url": "https://www.elastic.co/docs/explore-analyze/query-filter/languages/esql",
@@ -11617,7 +11617,7 @@
           "esql"
         ],
         "summary": "Stop async ES|QL query",
-        "description": "This API interrupts the query execution and returns the results so far.\nIf the Elasticsearch security features are enabled, only the user who first submitted the ES|QL query can stop it.",
+        "description": "This API interrupts the query execution and returns the results so far.\nIf the Elasticsearch security features are enabled, only the user who first submitted the ES|QL query can stop it.\n\n## Required authorization\n\n* Index privileges: `read`\n",
         "externalDocs": {
           "description": "More about ES|QL reference",
           "url": "https://www.elastic.co/docs/explore-analyze/query-filter/languages/esql"
@@ -12496,7 +12496,7 @@
           "esql"
         ],
         "summary": "Run an ES|QL query",
-        "description": "Get search results for an ES|QL (Elasticsearch query language) query.",
+        "description": "Get search results for an ES|QL (Elasticsearch query language) query.\n\n## Required authorization\n\n* Index privileges: `read`\n",
         "externalDocs": {
           "description": "More about ES|QL reference",
           "url": "https://www.elastic.co/docs/explore-analyze/query-filter/languages/esql"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -6899,7 +6899,7 @@
           "esql"
         ],
         "summary": "Run an ES|QL query",
-        "description": "Get search results for an ES|QL (Elasticsearch query language) query.",
+        "description": "Get search results for an ES|QL (Elasticsearch query language) query.\n\n## Required authorization\n\n* Index privileges: `read`\n",
         "externalDocs": {
           "description": "More about ES|QL reference",
           "url": "https://www.elastic.co/docs/explore-analyze/query-filter/languages/esql"

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -5483,6 +5483,11 @@
       "extDocUrl": "https://www.elastic.co/docs/explore-analyze/query-filter/languages/esql",
       "extPreviousVersionDocUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/8.19/esql-async-query-get-api.html",
       "name": "esql.async_query_get",
+      "privileges": {
+        "index": [
+          "read"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "esql.async_query_get"
@@ -5520,6 +5525,11 @@
       "extDocId": "esql",
       "extDocUrl": "https://www.elastic.co/docs/explore-analyze/query-filter/languages/esql",
       "name": "esql.async_query_stop",
+      "privileges": {
+        "index": [
+          "read"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "esql.async_query_stop"
@@ -6068,6 +6078,11 @@
       "extDocId": "esql",
       "extDocUrl": "https://www.elastic.co/docs/explore-analyze/query-filter/languages/esql",
       "name": "esql.query",
+      "privileges": {
+        "index": [
+          "read"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "esql.query"
@@ -151939,7 +151954,7 @@
           }
         }
       ],
-      "specLocation": "esql/async_query_get/AsyncQueryGetRequest.ts#L25-L75"
+      "specLocation": "esql/async_query_get/AsyncQueryGetRequest.ts#L25-L76"
     },
     {
       "kind": "response",
@@ -152039,7 +152054,7 @@
           }
         }
       ],
-      "specLocation": "esql/async_query_stop/AsyncQueryStopRequest.ts#L23-L57"
+      "specLocation": "esql/async_query_stop/AsyncQueryStopRequest.ts#L23-L58"
     },
     {
       "kind": "response",
@@ -153766,7 +153781,7 @@
           }
         }
       ],
-      "specLocation": "esql/query/QueryRequest.ts#L28-L154"
+      "specLocation": "esql/query/QueryRequest.ts#L28-L155"
     },
     {
       "kind": "response",

--- a/specification/esql/async_query_get/AsyncQueryGetRequest.ts
+++ b/specification/esql/async_query_get/AsyncQueryGetRequest.ts
@@ -31,6 +31,7 @@ import { EsqlFormat } from '@esql/_types/QueryParameters'
  * @availability stack since=8.13.0 stability=stable visibility=public
  * @doc_id esql-async-query-get
  * @ext_doc_id esql
+ * @index_privileges read
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/esql/async_query_stop/AsyncQueryStopRequest.ts
+++ b/specification/esql/async_query_stop/AsyncQueryStopRequest.ts
@@ -29,6 +29,7 @@ import { Id, MediaType } from '@_types/common'
  * @availability stack since=8.18.0 stability=stable visibility=public
  * @doc_id esql-async-query-stop
  * @ext_doc_id esql
+ * @index_privileges read
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -34,6 +34,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
  * @availability serverless
  * @doc_id esql-query
  * @ext_doc_id esql
+ * @index_privileges read
  */
 export interface Request extends RequestBase {
   urls: [


### PR DESCRIPTION
While trying out some quickstarts with ES|QL queries, I noticed that some of the APIs were missing `@index_privileges`. 
This PR adds that missing information.