### PR TITLE
num_candidates optional in retriever API

### DIFF
--- a/specification/_types/Retriever.ts
+++ b/specification/_types/Retriever.ts
@@ -125,7 +125,7 @@ export class KnnRetriever extends RetrieverBase {
   /** Number of nearest neighbors to return as top hits. */
   k: integer
   /** Number of nearest neighbor candidates to consider per shard. */
-  num_candidates: integer
+  num_candidates?: integer
   /**
    * The percentage of vectors to explore per shard while doing knn search with bbq_disk
    * @availability stack since=9.2.0


### PR DESCRIPTION
Retriever API was recently updated so that num_candidates is optional, making in coherent with the other various KNN implementations. [server code](https://github.com/elastic/elasticsearch/blob/fe08f52473d1d1bae2eb5629ce21d5672216df44/server/src/main/java/org/elasticsearch/search/retriever/KnnRetrieverBuilder.java#L86).
