### PR TITLE
[ML] Add _force_rekeying to Update API

### DIFF
--- a/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
@@ -169,5 +169,13 @@ export interface Request extends RequestBase {
      * @server_default 1000
      */
     scroll_size?: integer
+    /**
+     * When true, force reminting of the datafeed's internal cloud API key from the
+     * caller's cloud credential without requiring other configuration changes.
+     * Requires a cloud-authenticated caller and an environment that supports
+     * cross-project calls. Rejected with 400 otherwise. The datafeed must be stopped.
+     * @availability serverless
+     */
+    _force_rekeying?: boolean
   }
 }

--- a/specification/transform/update_transform/UpdateTransformRequest.ts
+++ b/specification/transform/update_transform/UpdateTransformRequest.ts
@@ -112,5 +112,13 @@ export interface Request extends RequestBase {
      * criteria is deleted from the destination index.
      */
     retention_policy?: RetentionPolicyContainer | null
+    /**
+     * When true, force reminting of the transform's internal cloud API key from the
+     * caller's cloud credential without requiring other configuration changes.
+     * Requires a cloud-authenticated caller and an environment that supports
+     * cross-project calls. Rejected with 400 otherwise.
+     * @availability serverless
+     */
+    _force_rekeying?: boolean
   }
 }


### PR DESCRIPTION
Both ML and Transform now have _force_rekeying as a payload field for the update API.

