### PR TITLE
Add 'columnar_stored' option to SourceFieldMode enum

### DIFF
--- a/specification/_types/mapping/meta-fields.ts
+++ b/specification/_types/mapping/meta-fields.ts
@@ -65,6 +65,7 @@ export class SourceField {
 export enum SourceFieldMode {
   disabled,
   stored,
+  columnar_stored,
   /**
    *  Instead of storing source documents on disk exactly as you send them,
    *  Elasticsearch can reconstruct source content on the fly upon retrieval.


### PR DESCRIPTION
Without setting this, strict clients reject templates (and likely index mappings) that try to use this value in 9.5.0+.
