### PR TITLE
Add missing bbq_disk index_options and fix InnerRetriever optionality

### DIFF
--- a/specification/_types/Retriever.ts
+++ b/specification/_types/Retriever.ts
@@ -86,9 +86,21 @@ export class PinnedRetriever extends RetrieverBase {
 }
 
 export class InnerRetriever {
+  /** The nested retriever configuration. */
   retriever: RetrieverContainer
-  weight: float
-  normalizer: ScoreNormalizer
+  /**
+   * Weight multiplier for this retriever's contribution to the linear combination.
+   * Must be non-negative.
+   * @server_default 1.0
+   */
+  weight?: float
+  /**
+   * Score normalizer to apply to this retriever's results before weighting.
+   * Falls back to the top-level `normalizer` on the linear retriever if unset,
+   * then to `none` (identity) if neither is set.
+   * @server_default none
+   */
+  normalizer?: ScoreNormalizer
 }
 
 export enum ScoreNormalizer {

--- a/specification/_types/mapping/DenseVectorProperty.ts
+++ b/specification/_types/mapping/DenseVectorProperty.ts
@@ -144,6 +144,7 @@ export class DenseVectorIndexOptions {
    * Defaults to `1/(dims + 1)` for `int8` quantized vectors and `0` for `int4` for dynamic quantile calculation.
    *
    * Only applicable to `int8_hnsw`, `int4_hnsw`, `int8_flat`, and `int4_flat` index types.
+   * @deprecated 9.5.0
    */
   confidence_interval?: float
   /**
@@ -181,11 +182,49 @@ export class DenseVectorIndexOptions {
    * search. `-1` (default) defers to format defaults: `300` for `bbq_hnsw`, `150` for `hnsw`, `int8_hnsw`, and
    * `int4_hnsw`. `0` always builds the graph. A positive value overrides the format default.
    *
-   * Only applicable to `hnsw`, `int8_hnsw`, `int4_hnsw`, and `bbq_hnsw` index types.
+   * Only applicable to `hnsw`, `int8_hnsw`, `int4_hnsw`, `bbq_hnsw`, and `bbq_disk` index types.
    * @server_default -1
    * @availability stack since=9.4.0 stability=stable
    */
   flat_index_threshold?: integer
+  /**
+   * Only applicable to `bbq_disk`. The number of vectors per cluster. Must be between 64 and 65536.
+   * @server_default 384
+   * @availability stack since=9.2.0 stability=stable
+   */
+  cluster_size?: integer
+  /**
+   * Only applicable to `bbq_disk`. The percentage of clusters to visit during search. Must be between 0 and 100.
+   * A value of 0 defaults to using `num_candidates` for calculating the visit percentage.
+   * @server_default 0
+   * @availability stack since=9.2.0 stability=stable
+   */
+  default_visit_percentage?: float
+  /**
+   * Only applicable to `bbq_disk`. The number of bits per dimension for quantization encoding.
+   * Valid values are `1`, `2`, `4`, or `7`. When no `rescore_vector` is explicitly set,
+   * the default oversampling is automatically adjusted based on the bits value.
+   * This setting can be changed without reindexing.
+   * @server_default 1
+   * @availability stack since=9.4.0 stability=stable
+   */
+  bits?: integer
+  /**
+   * Only applicable to `bbq_disk`. When `true`, transforms indexed vectors using a random orthogonal
+   * projection before quantization, which can improve accuracy when vector components are not normally
+   * distributed. Cannot be changed after the field is created.
+   * @server_default false
+   * @availability stack since=9.4.0 stability=stable
+   */
+  precondition?: boolean
+  /**
+   * Only applicable to `bbq_disk`. When `true`, Elasticsearch automatically selects the optimal
+   * quantization encoding, oversampling factor, and preconditioning for each merged segment based
+   * on estimated recall characteristics. Cannot be changed after the field is created.
+   * @server_default false
+   * @availability stack since=9.5.0 stability=stable
+   */
+  auto_calibrate?: boolean
 }
 
 export enum DenseVectorIndexOptionsType {


### PR DESCRIPTION
## Summary

This PR brings the elasticsearch-specification up to date with the Elasticsearch server for `bbq_disk` index options and fixes an `InnerRetriever` optionality mismatch.

### Dense vector `index_options` — 5 missing `bbq_disk` properties

The following fields are fully implemented and GA in Elasticsearch but were absent from the specification:

| Field | Type | Default | GA Since |
|---|---|---|---|
| `cluster_size` | integer | 384 | 9.2.0 |
| `default_visit_percentage` | float | 0 | 9.2.0 |
| `bits` | integer | 1 | 9.4.0 |
| `precondition` | boolean | false | 9.4.0 |
| `auto_calibrate` | boolean | false | 9.5.0 |

Server-side source: `DenseVectorFieldMapper.java`, `BBQIVFIndexOptions` (lines 2113-2243).

### Additional fixes

- **`flat_index_threshold` docstring**: Updated to include `bbq_disk` in the list of applicable index types (the server parses it for `bbq_disk` at line 2139).
- **`confidence_interval` deprecation**: Added `@deprecated 9.5.0` annotation. The server emits a deprecation warning for this parameter since `IndexVersions.UPGRADE_TO_LUCENE_10_4_0`.

### `InnerRetriever` — `weight` and `normalizer` should be optional

The `InnerRetriever` class (used by `LinearRetriever.retrievers[]`) declared `weight` and `normalizer` as required, but the server parses both with `optionalConstructorArg()`:

- `weight` defaults to `1.0f` (`LinearRetrieverComponent.java:30`)
- `normalizer` falls back to the top-level `LinearRetriever.normalizer`, then to `none`/identity (`LinearRetrieverBuilder.java:129-137`)

Fixes both fields to optional with `@server_default` annotations.