### PR TITLE
Make InnerRetriever weight and normalizer optional

### DIFF
--- a/specification/_types/Retriever.ts
+++ b/specification/_types/Retriever.ts
@@ -86,9 +86,21 @@ export class PinnedRetriever extends RetrieverBase {
 }
 
 export class InnerRetriever {
+  /** The nested retriever configuration. */
   retriever: RetrieverContainer
-  weight: float
-  normalizer: ScoreNormalizer
+  /**
+   * Weight multiplier for this retriever's contribution to the linear combination.
+   * Must be non-negative.
+   * @server_default 1.0
+   */
+  weight?: float
+  /**
+   * Score normalizer to apply to this retriever's results before weighting.
+   * Falls back to the top-level `normalizer` on the linear retriever if unset,
+   * then to `none` (identity) if neither is set.
+   * @server_default none
+   */
+  normalizer?: ScoreNormalizer
 }
 
 export enum ScoreNormalizer {


### PR DESCRIPTION
## Summary

Make `InnerRetriever.weight` and `InnerRetriever.normalizer` optional to match the server-side parsing.

The server (`LinearRetrieverComponent.java`) parses both fields with `optionalConstructorArg()`:
- `weight` defaults to `1.0f`
- `normalizer` falls back to the top-level `LinearRetriever.normalizer`, then to `none` (identity)

TypeScript users currently get type errors when omitting these fields, even though the server accepts the request.

Reported by @brittany-elastic in [this Slack thread](https://elastic.slack.com/archives/C0D8Y4ZJ9/p1787935395478489).

Split from #6583 for targeted backporting per @margaretgu's feedback.