### PR TITLE
Add missing bbq_disk cluster_size and default_visit_percentage

### DIFF
--- a/specification/_types/mapping/DenseVectorProperty.ts
+++ b/specification/_types/mapping/DenseVectorProperty.ts
@@ -186,6 +186,19 @@ export class DenseVectorIndexOptions {
    * @availability stack since=9.4.0 stability=stable
    */
   flat_index_threshold?: integer
+  /**
+   * Only applicable to `bbq_disk`. The number of vectors per cluster. Must be between 64 and 65536.
+   * @server_default 384
+   * @availability stack since=9.2.0 stability=stable
+   */
+  cluster_size?: integer
+  /**
+   * Only applicable to `bbq_disk`. The percentage of clusters to visit during search. Must be between 0 and 100.
+   * A value of 0 defaults to using `num_candidates` for calculating the visit percentage.
+   * @server_default 0
+   * @availability stack since=9.2.0 stability=stable
+   */
+  default_visit_percentage?: float
 }
 
 export enum DenseVectorIndexOptionsType {


### PR DESCRIPTION
## Summary

Add two missing `bbq_disk`-specific properties to `DenseVectorIndexOptions`:

| Field | Type | Default | GA Since |
|---|---|---|---|
| `cluster_size` | integer | 384 | 9.2.0 |
| `default_visit_percentage` | float | 0 | 9.2.0 |

Both have been in the server since `bbq_disk` was introduced in 9.2 but were missing from the specification.

Split from #6583 for targeted backporting per @margaretgu's feedback.