### PR TITLE
Add bbq_disk auto_calibrate property

### DIFF
--- a/specification/_types/mapping/DenseVectorProperty.ts
+++ b/specification/_types/mapping/DenseVectorProperty.ts
@@ -186,6 +186,14 @@ export class DenseVectorIndexOptions {
    * @availability stack since=9.4.0 stability=stable
    */
   flat_index_threshold?: integer
+  /**
+   * Only applicable to `bbq_disk`. When `true`, Elasticsearch automatically selects the optimal
+   * quantization encoding, oversampling factor, and preconditioning for each merged segment based
+   * on estimated recall characteristics. Cannot be changed after the field is created.
+   * @server_default false
+   * @availability stack since=9.5.0 stability=stable
+   */
+  auto_calibrate?: boolean
 }
 
 export enum DenseVectorIndexOptionsType {


### PR DESCRIPTION
## Summary

Add the `auto_calibrate` property to `DenseVectorIndexOptions` for `bbq_disk`:

| Field | Type | Default | GA Since |
|---|---|---|---|
| `auto_calibrate` | boolean | false | 9.5.0 |

When enabled, Elasticsearch automatically selects the optimal quantization encoding, oversampling factor, and preconditioning for each merged segment based on estimated recall characteristics.

Split from #6583 for targeted backporting per @margaretgu's feedback.