### PR TITLE
[Backport 9.4] Add bbq_disk bits and precondition, deprecate confidence_interval - Fixes from bad merge

### DIFF
--- a/specification/_types/mapping/DenseVectorProperty.ts
+++ b/specification/_types/mapping/DenseVectorProperty.ts
@@ -144,7 +144,6 @@ export class DenseVectorIndexOptions {
    * Defaults to `1/(dims + 1)` for `int8` quantized vectors and `0` for `int4` for dynamic quantile calculation.
    *
    * Only applicable to `int8_hnsw`, `int4_hnsw`, `int8_flat`, and `int4_flat` index types.
-   * @deprecated 9.5.0
    */
   confidence_interval?: float
   /**
@@ -204,14 +203,6 @@ export class DenseVectorIndexOptions {
    * @availability stack since=9.4.0 stability=stable
    */
   precondition?: boolean
-  /**
-   * Only applicable to `bbq_disk`. When `true`, Elasticsearch automatically selects the optimal
-   * quantization encoding, oversampling factor, and preconditioning for each merged segment based
-   * on estimated recall characteristics. Cannot be changed after the field is created.
-   * @server_default false
-   * @availability stack since=9.5.0 stability=stable
-   */
-  auto_calibrate?: boolean
 }
 
 export enum DenseVectorIndexOptionsType {


### PR DESCRIPTION
Backport b0c0483 from #6585.