### PR TITLE
[Backport 9.3] Add missing bbq_disk cluster_size and default_visit_percentage - fix bad merge

### DIFF
--- a/specification/_types/mapping/DenseVectorProperty.ts
+++ b/specification/_types/mapping/DenseVectorProperty.ts
@@ -177,16 +177,6 @@ export class DenseVectorIndexOptions {
    */
   on_disk_rescore?: boolean
   /**
-   * The segment document count threshold below which HNSW graph construction is skipped in favor of brute-force flat
-   * search. `-1` (default) defers to format defaults: `300` for `bbq_hnsw`, `150` for `hnsw`, `int8_hnsw`, and
-   * `int4_hnsw`. `0` always builds the graph. A positive value overrides the format default.
-   *
-   * Only applicable to `hnsw`, `int8_hnsw`, `int4_hnsw`, `bbq_hnsw`, and `bbq_disk` index types.
-   * @server_default -1
-   * @availability stack since=9.4.0 stability=stable
-   */
-  flat_index_threshold?: integer
-  /**
    * Only applicable to `bbq_disk`. The number of vectors per cluster. Must be between 64 and 65536.
    * @server_default 384
    * @availability stack since=9.2.0 stability=stable


### PR DESCRIPTION
Backport b0c0483 from #6585.