### PR TITLE
[8.19] Mark custom routing as stack-only on bulk, index, delete, update APIs (#6564)

### DIFF
--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -197,7 +197,6 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
     /**
      * A custom value that is used to route operations to a specific shard.
      * @availability stack stability=stable
-     * @ext_doc_id search-shard-routing
      */
     routing?: Routing
     /**

--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -196,6 +196,8 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
     refresh?: Refresh
     /**
      * A custom value that is used to route operations to a specific shard.
+     * @availability stack stability=stable
+     * @ext_doc_id search-shard-routing
      */
     routing?: Routing
     /**

--- a/specification/_global/bulk/types.ts
+++ b/specification/_global/bulk/types.ts
@@ -108,6 +108,7 @@ export class OperationBase {
   _index?: IndexName
   /**
    * A custom value used to route operations to a specific shard.
+   * @availability stack stability=stable
    */
   routing?: Routing
   if_primary_term?: long

--- a/specification/_global/delete/DeleteRequest.ts
+++ b/specification/_global/delete/DeleteRequest.ts
@@ -117,6 +117,7 @@ export interface Request extends RequestBase {
     refresh?: Refresh
     /**
      * A custom value used to route operations to a specific shard.
+     * @availability stack stability=stable
      */
     routing?: Routing
     /**

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -228,6 +228,7 @@ export interface Request extends RequestBase {
     requests_per_second?: float
     /**
      * A custom value used to route operations to a specific shard.
+     * @availability stack stability=stable
      */
     routing?: Routing
     /**

--- a/specification/_global/index/IndexRequest.ts
+++ b/specification/_global/index/IndexRequest.ts
@@ -228,6 +228,8 @@ export interface Request<TDocument> extends RequestBase {
     refresh?: Refresh
     /**
      * A custom value that is used to route operations to a specific shard.
+     * @availability stack stability=stable
+     * @ext_doc_id search-shard-routing
      */
     routing?: Routing
     /**

--- a/specification/_global/index/IndexRequest.ts
+++ b/specification/_global/index/IndexRequest.ts
@@ -229,7 +229,6 @@ export interface Request<TDocument> extends RequestBase {
     /**
      * A custom value that is used to route operations to a specific shard.
      * @availability stack stability=stable
-     * @ext_doc_id search-shard-routing
      */
     routing?: Routing
     /**

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -123,6 +123,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
     retry_on_conflict?: integer
     /**
      * A custom value used to route operations to a specific shard.
+     * @availability stack stability=stable
      */
     routing?: Routing
     /**

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -241,6 +241,7 @@ export interface Request extends RequestBase {
     requests_per_second?: float
     /**
      * A custom value used to route operations to a specific shard.
+     * @availability stack stability=stable
      */
     routing?: Routing
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Mark custom routing as stack-only on bulk, index, delete, update APIs (#6564)](https://github.com/elastic/elasticsearch-specification/pull/6564)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)