### PR TITLE
Gate ML datafeed project_routing behind CPS feature flag

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -19875,10 +19875,6 @@
                     "default": 1000.0,
                     "type": "number"
                   },
-                  "project_routing": {
-                    "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
-                    "type": "string"
-                  },
                   "headers": {
                     "allOf": [
                       {
@@ -19999,10 +19995,6 @@
                     },
                     "scroll_size": {
                       "type": "number"
-                    },
-                    "project_routing": {
-                      "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
-                      "type": "string"
                     }
                   },
                   "required": [
@@ -24169,10 +24161,6 @@
                     "default": 1000.0,
                     "type": "number"
                   },
-                  "project_routing": {
-                    "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
-                    "type": "string"
-                  },
                   "_force_rekeying": {
                     "description": "When true, force reminting of the datafeed's internal cloud API key from the\ncaller's cloud credential without requiring other configuration changes.\nRequires a cloud-authenticated caller and an environment that supports\ncross-project calls. Rejected with 400 otherwise. The datafeed must be stopped.",
                     "type": "boolean"
@@ -24291,10 +24279,6 @@
                     },
                     "scroll_size": {
                       "type": "number"
-                    },
-                    "project_routing": {
-                      "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
-                      "type": "string"
                     }
                   },
                   "required": [
@@ -80176,10 +80160,6 @@
                 "$ref": "#/components/schemas/_types.IndicesOptions"
               }
             ]
-          },
-          "project_routing": {
-            "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
-            "type": "string"
           }
         },
         "required": [
@@ -83016,10 +82996,6 @@
                 "$ref": "#/components/schemas/_types.IndicesOptions"
               }
             ]
-          },
-          "project_routing": {
-            "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
-            "type": "string"
           },
           "job_id": {
             "allOf": [

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -214272,7 +214272,11 @@
         },
         {
           "availability": {
-            "serverless": {}
+            "serverless": {
+              "featureFlag": "serverless.cross_project.enabled",
+              "stability": "stable",
+              "visibility": "feature_flag"
+            }
           },
           "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
           "name": "project_routing",
@@ -214447,7 +214451,11 @@
         },
         {
           "availability": {
-            "serverless": {}
+            "serverless": {
+              "featureFlag": "serverless.cross_project.enabled",
+              "stability": "stable",
+              "visibility": "feature_flag"
+            }
           },
           "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
           "name": "project_routing",
@@ -234287,7 +234295,11 @@
           },
           {
             "availability": {
-              "serverless": {}
+              "serverless": {
+                "featureFlag": "serverless.cross_project.enabled",
+                "stability": "stable",
+                "visibility": "feature_flag"
+              }
             },
             "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
             "name": "project_routing",
@@ -234638,7 +234650,11 @@
           },
           {
             "availability": {
-              "serverless": {}
+              "serverless": {
+                "featureFlag": "serverless.cross_project.enabled",
+                "stability": "stable",
+                "visibility": "feature_flag"
+              }
             },
             "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
             "name": "project_routing",
@@ -238593,7 +238609,11 @@
           },
           {
             "availability": {
-              "serverless": {}
+              "serverless": {
+                "featureFlag": "serverless.cross_project.enabled",
+                "stability": "stable",
+                "visibility": "feature_flag"
+              }
             },
             "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
             "name": "project_routing",
@@ -238943,7 +238963,11 @@
           },
           {
             "availability": {
-              "serverless": {}
+              "serverless": {
+                "featureFlag": "serverless.cross_project.enabled",
+                "stability": "stable",
+                "visibility": "feature_flag"
+              }
             },
             "description": "A Lucene-style expression that limits which linked projects the datafeed\nsearches when cross-project search is enabled. Examples: `_alias:_origin`,\n`_alias:prod-*`. If omitted, searches all linked projects within the cross-project\nsearch scope. Rejected when CPS is not enabled for datafeeds.",
             "name": "project_routing",

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -66,7 +66,7 @@ export class Datafeed {
    * searches when cross-project search is enabled. Examples: `_alias:_origin`,
    * `_alias:prod-*`. If omitted, searches all linked projects within the cross-project
    * search scope. Rejected when CPS is not enabled for datafeeds.
-   * @availability serverless
+   * @availability serverless stability=stable visibility=feature_flag feature_flag=serverless.cross_project.enabled
    */
   project_routing?: string
 }
@@ -108,7 +108,7 @@ export class DatafeedConfig {
    * searches when cross-project search is enabled. Examples: `_alias:_origin`,
    * `_alias:prod-*`. If omitted, searches all linked projects within the cross-project
    * search scope. Rejected when CPS is not enabled for datafeeds.
-   * @availability serverless
+   * @availability serverless stability=stable visibility=feature_flag feature_flag=serverless.cross_project.enabled
    */
   project_routing?: string
   job_id?: Id

--- a/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
@@ -190,7 +190,7 @@ export interface Request extends RequestBase {
      * searches when cross-project search is enabled. Examples: `_alias:_origin`,
      * `_alias:prod-*`. If omitted, searches all linked projects within the cross-project
      * search scope. Rejected when CPS is not enabled for datafeeds.
-     * @availability serverless
+     * @availability serverless stability=stable visibility=feature_flag feature_flag=serverless.cross_project.enabled
      */
     project_routing?: string
     /**

--- a/specification/ml/put_datafeed/MlPutDatafeedResponse.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedResponse.ts
@@ -50,7 +50,7 @@ export class Response {
      * searches when cross-project search is enabled. Examples: `_alias:_origin`,
      * `_alias:prod-*`. If omitted, searches all linked projects within the cross-project
      * search scope. Rejected when CPS is not enabled for datafeeds.
-     * @availability serverless
+     * @availability serverless stability=stable visibility=feature_flag feature_flag=serverless.cross_project.enabled
      */
     project_routing?: string
   }

--- a/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
@@ -174,7 +174,7 @@ export interface Request extends RequestBase {
      * searches when cross-project search is enabled. Examples: `_alias:_origin`,
      * `_alias:prod-*`. If omitted, searches all linked projects within the cross-project
      * search scope. Rejected when CPS is not enabled for datafeeds.
-     * @availability serverless
+     * @availability serverless stability=stable visibility=feature_flag feature_flag=serverless.cross_project.enabled
      */
     project_routing?: string
     /**

--- a/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
@@ -53,7 +53,7 @@ export class Response {
      * searches when cross-project search is enabled. Examples: `_alias:_origin`,
      * `_alias:prod-*`. If omitted, searches all linked projects within the cross-project
      * search scope. Rejected when CPS is not enabled for datafeeds.
-     * @availability serverless
+     * @availability serverless stability=stable visibility=feature_flag feature_flag=serverless.cross_project.enabled
      */
     project_routing?: string
   }


### PR DESCRIPTION
## Summary

- Align ML datafeed `project_routing` `@availability` with other CPS surfaces (search, transform, esql): `@availability serverless stability=stable visibility=feature_flag feature_flag=serverless.cross_project.enabled`.
- Regenerated OpenAPI: `project_routing` is removed from the public serverless schema for datafeed put/update and `ml._types.Datafeed` / `DatafeedConfig` (same treatment as `transform._types.Source`).
- Follow-up to #6611, which used a bare `@availability serverless` on datafeed only.