### PR TITLE
Include failure count in recovery APIs

### DIFF
--- a/specification/cat/_types/CatBase.ts
+++ b/specification/cat/_types/CatBase.ts
@@ -2367,6 +2367,13 @@ export enum CatRecoveryColumn {
    */
   stage,
   /**
+   * The number of times this recovery has failed in a way which is retried locally (i.e. on the data node).
+   * @aliases lr
+   * @availability stack since=9.6.0
+   * @availability serverless
+   */
+  local_retries,
+  /**
    * The recovery priority.
    * @aliases pr
    * @availability stack since=9.6.0

--- a/specification/cat/recovery/types.ts
+++ b/specification/cat/recovery/types.ts
@@ -18,7 +18,7 @@
  */
 
 import { IndexName } from '@_types/common'
-import { Percentage } from '@_types/Numeric'
+import { integer, Percentage } from '@_types/Numeric'
 import { DateTime, Duration, EpochTime, UnitMillis } from '@_types/Time'
 
 export class RecoveryRecord {
@@ -72,6 +72,13 @@ export class RecoveryRecord {
    * @aliases st
    */
   'stage'?: string
+  /**
+   * The number of times this recovery has failed in a way which is retried locally (i.e. on the data node).
+   * @aliases lr
+   * @availability stack since=9.6.0
+   * @availability serverless
+   */
+  'local_retries'?: integer
   /**
    * The recovery priority.
    * @aliases pr

--- a/specification/indices/recovery/types.ts
+++ b/specification/indices/recovery/types.ts
@@ -26,7 +26,7 @@ import {
   VersionString
 } from '@_types/common'
 import { Host, Ip, TransportAddress } from '@_types/Networking'
-import { long, Percentage } from '@_types/Numeric'
+import { integer, long, Percentage } from '@_types/Numeric'
 import {
   DateTime,
   Duration,
@@ -175,6 +175,13 @@ export class ShardRecovery {
   source: RecoveryOrigin
   /** The recovery stage. */
   stage: RecoveryStage
+  /**
+   * The number of times this recovery has failed in a way which is retried locally (i.e. on the data node).
+   *
+   * @availability stack since=9.6.0
+   * @availability serverless
+   */
+  local_retries?: integer
   /**
    * The recovery priority.
    *


### PR DESCRIPTION
This updates the spec for the API changes made in
elastic/elasticsearch#158311.

Closes elastic/elasticsearch-team#5042
