### PR TITLE
Fix global privilege type in RoleDescriptor

### DIFF
--- a/specification/security/_types/RoleDescriptor.ts
+++ b/specification/security/_types/RoleDescriptor.ts
@@ -55,7 +55,7 @@ export class RoleDescriptor {
    * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware.
    * @availability stack
    */
-  global?: GlobalPrivilege[] | GlobalPrivilege
+  global?: GlobalPrivilege
   /**
    * A list of application privilege entries
    */


### PR DESCRIPTION
The server parser ([ConfigurableClusterPrivileges.parse](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java#L133)) unconditionally expects a `START_OBJECT` token, so passing an array throws an `XContentParseException`. Remove the erroneous array variant.