### PR TITLE
fix: make GlobalPrivilege.application optional

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -258411,7 +258411,7 @@
       "properties": [
         {
           "name": "application",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -21438,7 +21438,7 @@ export interface SecurityFieldSecurity {
 }
 
 export interface SecurityGlobalPrivilege {
-  application: SecurityApplicationGlobalUserPrivileges
+  application?: SecurityApplicationGlobalUserPrivileges
   data_source?: SecurityDataSourcePrivileges[]
 }
 

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -416,7 +416,7 @@ export enum IndexPrivilege {
 }
 
 export class GlobalPrivilege {
-  application: ApplicationGlobalUserPrivileges
+  application?: ApplicationGlobalUserPrivileges
   /**
    * A list of data source privilege entries, used to grant access to ES|QL data sources.
    * @availability stack since=9.5.0


### PR DESCRIPTION
@mattkime made [the same change](https://github.com/elastic/elasticsearch-js/pull/3434) directly to the JS client. Backporting it here to ensure it's permanent.
