### PR TITLE
CI: publish OpenAPI docs specs with overlays

### DIFF
--- a/.github/actions/build-openapi-docs/action.yml
+++ b/.github/actions/build-openapi-docs/action.yml
@@ -1,8 +1,8 @@
 name: Build OpenAPI docs specs
 description: >
-  Install dependencies and build the docs-ready OpenAPI specs at
-  output/openapi/elasticsearch-openapi-docs.json and
-  output/openapi/elasticsearch-serverless-openapi-docs.json.
+  Install dependencies and build the overlayed docs-ready OpenAPI specs at
+  output/openapi/elasticsearch-openapi-docs-final.json and
+  output/openapi/elasticsearch-serverless-openapi-docs-final.json.
 
 runs:
   using: composite
@@ -21,3 +21,7 @@ runs:
     - name: Build OpenAPI docs specs
       shell: bash
       run: make transform-to-openapi-for-docs
+
+    - name: Apply OpenAPI overlays
+      shell: bash
+      run: make overlay-docs

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Lint stateful spec
         uses: elastic/docs-actions/openapi/lint@v1
         with:
-          spec-path: output/openapi/elasticsearch-openapi-docs.json
+          spec-path: output/openapi/elasticsearch-openapi-docs-final.json
 
       - name: Lint serverless spec
         uses: elastic/docs-actions/openapi/lint@v1
         with:
-          spec-path: output/openapi/elasticsearch-serverless-openapi-docs.json
+          spec-path: output/openapi/elasticsearch-serverless-openapi-docs-final.json

--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -11,6 +11,7 @@ on:
       - 'output/openapi/elasticsearch-serverless-openapi.json'
       - 'specification/**/examples/request/*.yaml'
       - 'docs/examples/**'
+      - 'docs/overlays/**'
       - '.github/actions/build-openapi-docs/**'
       - '.github/workflows/openapi-publish.yml'
 
@@ -39,17 +40,17 @@ jobs:
       - name: Lint stateful spec
         uses: elastic/docs-actions/openapi/lint@v1
         with:
-          spec-path: output/openapi/elasticsearch-openapi-docs.json
+          spec-path: output/openapi/elasticsearch-openapi-docs-final.json
 
       - name: Lint serverless spec
         uses: elastic/docs-actions/openapi/lint@v1
         with:
-          spec-path: output/openapi/elasticsearch-serverless-openapi-docs.json
+          spec-path: output/openapi/elasticsearch-serverless-openapi-docs-final.json
 
       - name: Publish stateful spec
         uses: elastic/docs-actions/openapi/upload@v1
         with:
-          spec-path: output/openapi/elasticsearch-openapi-docs.json
+          spec-path: output/openapi/elasticsearch-openapi-docs-final.json
           spec-name: elasticsearch
 
       # Serverless is always-latest: only publish from main.
@@ -57,5 +58,5 @@ jobs:
         if: github.ref_name == 'main'
         uses: elastic/docs-actions/openapi/upload@v1
         with:
-          spec-path: output/openapi/elasticsearch-serverless-openapi-docs.json
+          spec-path: output/openapi/elasticsearch-serverless-openapi-docs-final.json
           spec-name: elasticsearch-serverless


### PR DESCRIPTION
## Why

- The OpenAPI publish workflow currently uploads docs specs without overlays, so published API docs miss overlay content such as titles, security schemes, and tag metadata.

## What

- Apply overlays during the docs OpenAPI build and lint and upload the final overlaid specs.
- Republish when overlay files change.

## Notes

- The hourly docs-internal-workflows mirror is unchanged and still uses pre-overlay specs.


Made with [Cursor](https://cursor.com)