### PR TITLE
Fix clone API key required privilege

### DIFF
--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -682,7 +682,7 @@ export function hoistRequestAnnotations (
       endpoint.privileges.index = values
     } else if (tag === 'cluster_privileges') {
       const privileges = [
-        'all', 'cancel_task', 'create_snapshot', 'grant_api_key', 'manage', 'manage_api_key', 'manage_ccr',
+        'all', 'cancel_task', 'clone_api_key', 'create_snapshot', 'grant_api_key', 'manage', 'manage_api_key', 'manage_ccr',
         'manage_enrich', 'manage_ilm', 'manage_index_templates', 'manage_inference', 'manage_ingest_pipelines', 'manage_logstash_pipelines',
         'manage_ml', 'manage_oidc', 'manage_own_api_key', 'manage_pipeline', 'manage_project_routing', 'manage_rollup', 'manage_saml', 'manage_search_application', 'manage_search_query_rules', 'manage_search_synonyms',
         'manage_security', 'manage_service_account', 'manage_slm', 'manage_token', 'manage_transform', 'manage_user_profile',

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -45,6 +45,10 @@ export enum ClusterPrivilege {
   all,
   cancel_task,
   /**
+   * @availability stack since=9.4.0
+   */
+  clone_api_key,
+  /**
    * @availability stack
    */
   create_snapshot,

--- a/specification/security/clone_api_key/SecurityCloneApiKeyRequest.ts
+++ b/specification/security/clone_api_key/SecurityCloneApiKeyRequest.ts
@@ -32,7 +32,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name security.clone_api_key
  * @availability stack since=9.4.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
- * @cluster_privileges manage_own_api_key
+ * @cluster_privileges clone_api_key
  * @doc_id security-api-clone-api-key
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
- Published clone API key docs listed `manage_own_api_key`, but Elasticsearch requires `clone_api_key` (also implied by `manage_api_key`, `manage_security`, and `all`).
- Update `@cluster_privileges` on the clone API key request, add `clone_api_key` to `ClusterPrivilege`, and allow it in the compiler validator.
- Closes elastic/elasticsearch#158954. API docs will pick this up on the next spec regeneration.